### PR TITLE
Add Media Widget

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pyquery
 pycaw
 winshell
 pillow
+qasync

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -32,11 +32,12 @@ bars:
         ] 
       center: [
          "komorebi_workspaces",
-         "komorebi_active_layout"
+         "komorebi_active_layout",
         ]
       right:
         [
           "fake_widget_left",
+          "media",
           "weather",
           "apps",
           "volume",
@@ -300,3 +301,23 @@ widgets:
         run_cmd: "powershell nvidia-smi --query-gpu=temperature.gpu --format=csv,noheader"
         run_interval: 10000 # run every 10 sec
         return_format: "string"
+
+  media:
+    type: "yasb.media.MediaWidget"
+    options:
+      label: "{title} - {artist}"
+      label_alt: "{title}"
+      update_interval: 1000
+      max_field_size:
+        label: 15
+        label_alt: 30
+      show_thumbnail: true
+      controls_only: false
+      controls_left: true
+      thumbnail_alpha: 255
+      thumbnail_padding: 4
+      icons:
+        prev_track: "\uf048"
+        next_track: "\uf051"
+        play: "\uf04b"
+        pause: "\uf04c"

--- a/src/core/utils/win32/media.py
+++ b/src/core/utils/win32/media.py
@@ -1,0 +1,99 @@
+# media.py
+import ctypes
+from typing import Dict, Union, Optional
+
+import winsdk.windows.media.control
+from winsdk.windows.storage.streams import Buffer, InputStreamOptions, IRandomAccessStreamReference
+from PIL import Image, ImageFile
+import io
+
+from core.utils.win32.system_function import KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP
+
+VK_MEDIA_PLAY_PAUSE = 0xB3
+VK_MEDIA_PREV_TRACK = 0xB1
+VK_MEDIA_NEXT_TRACK = 0xB0
+
+
+# Buffer is set to 5 MB, which is a bit overkill. Haven't found a way yet to find the size of the stream up front.
+BUFFER_SIZE = 5 * 1024 * 1024
+
+
+class MediaOperations:
+
+    @staticmethod
+    async def read_stream_into_buffer(stream_ref, buffer):
+        readable_stream = await stream_ref.open_read_async()
+        await readable_stream.read_async(buffer, buffer.capacity, InputStreamOptions.READ_AHEAD)
+
+    @staticmethod
+    async def get_thumbnail(thumbnail_stream_reference: IRandomAccessStreamReference) -> ImageFile:
+        """
+        Read the thumbnail for the IRandomAccessStreamReference and return it as PIL ImageFile
+        :param thumbnail_stream_reference: Thumbnail stream reference
+        :return: Loaded thumbnail
+        """
+        thumb_read_buffer = Buffer(5000000)
+
+        # copies data from data stream reference into buffer created above
+        await MediaOperations.read_stream_into_buffer(thumbnail_stream_reference, thumb_read_buffer)
+
+        # Convert bytearray to pillow image
+        pillow_image = Image.open(io.BytesIO(thumb_read_buffer))
+
+        del thumb_read_buffer
+
+        return pillow_image
+
+    @staticmethod
+    async def get_media_properties() -> Optional[Dict[str, Union[str, int, IRandomAccessStreamReference]]]:
+        """
+        Get media properties and the currently running media file
+        """
+        session_manager = await winsdk.windows.media.control.GlobalSystemMediaTransportControlsSessionManager.request_async()
+        current_session = session_manager.get_current_session()
+
+        # If no music is playing, return None
+        if current_session is None:
+            return None
+
+        media_properties = await current_session.try_get_media_properties_async()
+        playback_info = current_session.get_playback_info()
+        timeline_properties = current_session.get_timeline_properties()
+
+        media_info = {
+            "album_artist": media_properties.album_artist,
+            "album_title": media_properties.album_title,
+            "album_track_count": media_properties.album_track_count,
+            "artist": media_properties.artist,
+            "title": media_properties.title,
+            "playback_type": str(media_properties.playback_type),
+            "subtitle": media_properties.subtitle,
+            "album": media_properties.album_title,
+            "track_number": media_properties.track_number,
+            "thumbnail": media_properties.thumbnail,
+            "playing": playback_info.playback_status == 4,
+            "prev_available": playback_info.controls.is_previous_enabled,
+            "next_available": playback_info.controls.is_next_enabled,
+            "total_time": timeline_properties.end_time.total_seconds(),
+            "current_time": timeline_properties.position.total_seconds()
+            # genres
+        }
+        return media_info
+
+    @staticmethod
+    def play_pause():
+        user32 = ctypes.windll.user32
+        user32.keybd_event(VK_MEDIA_PLAY_PAUSE, 0, KEYEVENTF_EXTENDEDKEY, 0)
+        user32.keybd_event(VK_MEDIA_PLAY_PAUSE, 0, KEYEVENTF_KEYUP, 0)
+
+    @staticmethod
+    def prev():
+        user32 = ctypes.windll.user32
+        user32.keybd_event(VK_MEDIA_PREV_TRACK, 0, KEYEVENTF_EXTENDEDKEY, 0)
+        user32.keybd_event(VK_MEDIA_PREV_TRACK, 0, KEYEVENTF_KEYUP, 0)
+
+    @staticmethod
+    def next():
+        user32 = ctypes.windll.user32
+        user32.keybd_event(VK_MEDIA_NEXT_TRACK, 0, KEYEVENTF_EXTENDEDKEY, 0)
+        user32.keybd_event(VK_MEDIA_NEXT_TRACK, 0, KEYEVENTF_KEYUP, 0)

--- a/src/core/validation/widgets/yasb/media.py
+++ b/src/core/validation/widgets/yasb/media.py
@@ -1,0 +1,106 @@
+DEFAULTS = {
+    'label': '\uf017 {%H:%M:%S}',
+    'label_alt': '\uf017 {%d-%m-%y %H:%M:%S}',
+    'update_interval': 1000,
+    'callbacks': {
+        'on_left': 'toggle_label',
+        'on_middle': 'do_nothing',
+        'on_right': 'do_nothing'
+    }
+}
+
+VALIDATION_SCHEMA = {
+    'label': {
+        'type': 'string',
+        'default': DEFAULTS['label']
+    },
+    'label_alt': {
+        'type': 'string',
+        'default': DEFAULTS['label_alt']
+    },
+    'update_interval': {
+        'type': 'integer',
+        'default': 1000,
+        'min': 0,
+        'max': 60000
+    },
+    'callbacks': {
+        'type': 'dict',
+        'schema': {
+            'on_left': {
+                'type': 'string',
+                'default': DEFAULTS['callbacks']['on_left'],
+            },
+            'on_middle': {
+                'type': 'string',
+                'default': DEFAULTS['callbacks']['on_middle'],
+            },
+            'on_right': {
+                'type': 'string',
+                'default': DEFAULTS['callbacks']['on_right'],
+            }
+        },
+        'default': DEFAULTS['callbacks']
+    },
+    'max_field_size': {
+        'type': 'dict',
+        'schema': {
+            'label': {
+                'type': 'integer',
+                'default': 15,
+                'min': 0,
+                'max': 200
+            },
+            'label_alt': {
+                'type': 'integer',
+                'default': 30,
+                'min': 0,
+                'max': 200
+            }
+        }
+    },
+    'show_thumbnail': {
+        'type': 'boolean',
+        'default': True
+    },
+    'controls_only': {
+        'type': 'boolean',
+        'default': False
+    },
+    'controls_left': {
+        'type': 'boolean',
+        'default': True
+    },
+    'thumbnail_alpha': {
+        'type': 'integer',
+        'default': 50,
+        'min': 0,
+        'max': 255
+    },
+    'thumbnail_padding':
+        {'type': 'integer',
+         'default': 8,
+         'min': 0,
+         'max': 200},
+    'icons': {
+        'type': 'dict',
+        'schema': {
+            'prev_track': {
+                'type': 'string',
+                'default': '\uf048',
+            },
+            'next_track': {
+                'type': 'string',
+                'default': '\uf051',
+            },
+            'play': {
+                'type': 'string',
+                'default': '\uf04b',
+            },
+            'pause': {
+                'type': 'string',
+                'default': '\uf04c',
+            },
+        },
+    }
+}

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -185,7 +185,6 @@ class MediaWidget(BaseWidget):
         return label
 
     def _create_media_buttons(self):
-        self.widget_layout.addWidget(QLabel(' '))
         return self._create_media_button(self._media_button_icons['prev_track'],
                                          MediaOperations.prev), self._create_media_button(
             self._media_button_icons['play'], MediaOperations.play_pause), self._create_media_button(

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -78,7 +78,7 @@ class MediaWidget(BaseWidget):
     def start_timer(self):
         if self.timer_interval and self.timer_interval > 0:
             self.timer.timeout.connect(self._timer_callback)
-            self.timer.start(self.timer_interval)  # self._timer_callback()
+            self.timer.start(self.timer_interval)
 
     def _toggle_label(self):
         self._show_alt_label = not self._show_alt_label

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -58,7 +58,6 @@ class MediaWidget(BaseWidget):
         self.thumbnail_box.addWidget(self._label, 0, 0)
         self.thumbnail_box.addWidget(self._label_alt, 0, 0)
 
-        self.register_callback("toggle_label", self._toggle_label)
         self.register_callback("update_label", self._update_label)
 
         self.callback_left = callbacks['on_left']
@@ -66,7 +65,10 @@ class MediaWidget(BaseWidget):
         self.callback_middle = callbacks['on_middle']
         self.callback_timer = "update_label"
 
-        self._label.show()
+        if not self._controls_only:
+            self.register_callback("toggle_label", self._toggle_label)
+            self._label.show()
+
         self._label_alt.hide()
         self._show_alt_label = False
 
@@ -126,15 +128,15 @@ class MediaWidget(BaseWidget):
             active_label.setText('')
             return
 
-        # If we are playing, make sure the label field is showing
-        active_label.show()
-
         # Change icon based on if song is playing
         self._play_label.setText(self._media_button_icons['pause' if media_info['playing'] else 'play'])
 
         # If we only have controls, stop update here
         if self._controls_only:
             return
+
+        # If we are playing, make sure the label field is showing
+        active_label.show()
 
         # Shorten fields if necessary with ...
         media_info = {k: self._format_max_field_size(v) if isinstance(v, str) else v for k, v in

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -1,0 +1,197 @@
+import time
+
+from PIL.ImageQt import QPixmap
+from PyQt6.QtCore import Qt
+from qasync import asyncSlot
+from PIL.ImageQt import ImageQt
+from core.utils.win32.media import MediaOperations
+from core.widgets.base import BaseWidget
+from core.validation.widgets.yasb.media import VALIDATION_SCHEMA
+from PyQt6.QtWidgets import QLabel, QGridLayout
+
+from core.widgets.yasb.applications import ClickableLabel
+
+
+class MediaWidget(BaseWidget):
+    validation_schema = VALIDATION_SCHEMA
+
+    def __init__(self, label: str, label_alt: str, update_interval: int, callbacks: dict[str, str],
+                 max_field_size: dict[str, int], show_thumbnail: bool, controls_only: bool, controls_left: bool,
+                 thumbnail_alpha: int,
+                 thumbnail_padding: int,
+                 icons: dict[str, str]):
+        super().__init__(update_interval, class_name="media-widget")
+        self._label_content = label
+        self._label_alt_content = label_alt
+
+        self._max_field_size = max_field_size
+        self._show_thumbnail = show_thumbnail
+        self._thumbnail_alpha = thumbnail_alpha
+        self._media_button_icons = icons
+        self._controls_only = controls_only
+        self._thumbnail_padding = thumbnail_padding
+
+        # Make a grid box to overlay the text and thumbnail
+        self.thumbnail_box = QGridLayout()
+
+        if controls_left:
+            self._prev_label, self._play_label, self._next_label = self._create_media_buttons()
+            if not controls_only:
+                self.widget_layout.addLayout(self.thumbnail_box)
+        else:
+            if not controls_only:
+                self.widget_layout.addLayout(self.thumbnail_box)
+            self._prev_label, self._play_label, self._next_label = self._create_media_buttons()
+
+        self._label = QLabel()
+        self._label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._label_alt = QLabel()
+        self._label_alt.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self._thumbnail_label = QLabel()
+        self._thumbnail_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        self._label.setProperty("class", "label")
+        self._label_alt.setProperty("class", "label alt")
+
+        self.thumbnail_box.addWidget(self._thumbnail_label, 0, 0)
+        self.thumbnail_box.addWidget(self._label, 0, 0)
+        self.thumbnail_box.addWidget(self._label_alt, 0, 0)
+
+        self.register_callback("toggle_label", self._toggle_label)
+
+        self.register_callback("toggle_label", self._toggle_label)
+        self.register_callback("update_label", self._update_label)
+
+        self.callback_left = callbacks['on_left']
+        self.callback_right = callbacks['on_right']
+        self.callback_middle = callbacks['on_middle']
+        self.callback_timer = "update_label"
+
+        self._label.show()
+        self._label_alt.hide()
+        self._show_alt_label = False
+
+        self.start_timer()
+
+        self._last_title = None
+        self._last_artist = None
+
+    def start_timer(self):
+        if self.timer_interval and self.timer_interval > 0:
+            self.timer.timeout.connect(self._timer_callback)
+            self.timer.start(self.timer_interval)  # self._timer_callback()
+
+    def _toggle_label(self):
+        self._show_alt_label = not self._show_alt_label
+
+        if self._show_alt_label:
+            self._label.hide()
+            self._label_alt.show()
+        else:
+            self._label.show()
+            self._label_alt.hide()
+        self._update_label(is_toggle=True)
+
+    @staticmethod
+    def _refresh_css(label: QLabel):
+        label.style().unpolish(label)
+        label.style().polish(label)
+        label.update()
+
+    @asyncSlot()
+    async def _update_label(self, is_toggle=False):
+        active_label = self._label_alt if self._show_alt_label else self._label
+        active_label_content = self._label_alt_content if self._show_alt_label else self._label_content
+
+        # Get media info
+        media_info = await MediaOperations.get_media_properties()
+
+        # If no media is playing, set disable class on all buttons
+        property = "btn" + (" disabled" if media_info is None else "")
+        self._prev_label.setProperty("class", property)
+        self._play_label.setProperty("class", property)
+        self._next_label.setProperty("class", property)
+        self._refresh_css(self._prev_label)
+        self._refresh_css(self._play_label)
+        self._refresh_css(self._next_label)
+
+        # If nothing playing, hide thumbnail and empty text, stop here
+        if media_info is None:
+            # Hide thumbnail and label fields
+            self._thumbnail_label.hide()
+            active_label.hide()
+            active_label.setText('')
+            return
+
+        # If we are playing, make sure the label field is showing
+        active_label.show()
+
+        # Give next/previous buttons a different css class based on whether they are available
+        self._prev_label.setProperty("class", "btn" + (" disabled" if not media_info['prev_available'] else ""))
+        self._next_label.setProperty("class", "btn" + (" disabled" if not media_info['next_available'] else ""))
+        self._refresh_css(self._prev_label)
+        self._refresh_css(self._next_label)
+
+        # Change icon based on if song is playing
+        self._play_label.setText(self._media_button_icons['pause' if media_info['playing'] else 'play'])
+
+        # If we only have controls, stop update here
+        if self._controls_only:
+            return
+
+        # Shorten fields if necessary with ...
+        media_info = {k: self._format_max_field_size(v) if isinstance(v, str) else v for k, v in
+                      media_info.items()}
+
+        # Format the label
+        format_label_content = active_label_content.format(**media_info)
+        active_label.setText(format_label_content)
+
+        # If we don't want the thumbnail, stop here
+        if not self._show_thumbnail:
+            return
+
+        # Only update the thumbnail if the title/artist changes or if we did a toggle (resize)
+        if is_toggle or not (self._last_title == media_info['title'] and self._last_artist == media_info['artist']):
+            if media_info['thumbnail'] is not None:
+                self._thumbnail_label.show()
+                self._last_title = media_info['title']
+                self._last_artist = media_info['artist']
+
+                thumbnail = await MediaOperations.get_thumbnail(media_info['thumbnail'])
+                thumbnail.putalpha(self._thumbnail_alpha)
+
+                size = active_label.sizeHint().width() + self._thumbnail_padding
+
+                thumbnail = thumbnail.resize((size, size))
+                qim = ImageQt(thumbnail)
+                pixmap = QPixmap.fromImage(qim)
+                self._thumbnail_label.setPixmap(pixmap)
+
+    def _format_max_field_size(self, text: str):
+        max_field_size = self._max_field_size['label_alt' if self._show_alt_label else 'label']
+        if len(text) > max_field_size:
+            return text[:max_field_size - 3] + '...'
+        else:
+            return text
+
+    def _create_media_button(self, icon, action):
+        label = ClickableLabel(self)
+        label.setProperty("class", "btn")
+        label.setText(icon)
+        label.data = action
+        self.widget_layout.addWidget(label)
+        return label
+
+    def _create_media_buttons(self):
+        self.widget_layout.addWidget(QLabel(' '))
+        return self._create_media_button(self._media_button_icons['prev_track'],
+                                         MediaOperations.prev), self._create_media_button(
+            self._media_button_icons['play'], MediaOperations.play_pause), self._create_media_button(
+            self._media_button_icons['next_track'], MediaOperations.next)
+
+    def execute_code(self, func):
+        func()
+        time.sleep(0.1)
+        self._update_label()

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -106,10 +106,14 @@ class MediaWidget(BaseWidget):
         media_info = await MediaOperations.get_media_properties()
 
         # If no media is playing, set disable class on all buttons
-        property = "btn" + (" disabled" if media_info is None else "")
-        self._prev_label.setProperty("class", property)
-        self._play_label.setProperty("class", property)
-        self._next_label.setProperty("class", property)
+        # Give next/previous buttons a different css class based on whether they are available
+
+        disabled_if = lambda disabled: "disabled" if disabled else ""
+        self._prev_label.setProperty("class", f'btn prev {disabled_if(media_info is None or
+                                                                      not media_info['prev_available'])}')
+        self._play_label.setProperty("class", f'btn play {disabled_if(media_info is None)}')
+        self._next_label.setProperty("class", f'btn next {disabled_if(media_info is None or 
+                                                                      not media_info['next_available'])}')
         self._refresh_css(self._prev_label)
         self._refresh_css(self._play_label)
         self._refresh_css(self._next_label)
@@ -124,12 +128,6 @@ class MediaWidget(BaseWidget):
 
         # If we are playing, make sure the label field is showing
         active_label.show()
-
-        # Give next/previous buttons a different css class based on whether they are available
-        self._prev_label.setProperty("class", "btn" + (" disabled" if not media_info['prev_available'] else ""))
-        self._next_label.setProperty("class", "btn" + (" disabled" if not media_info['next_available'] else ""))
-        self._refresh_css(self._prev_label)
-        self._refresh_css(self._next_label)
 
         # Change icon based on if song is playing
         self._play_label.setText(self._media_button_icons['pause' if media_info['playing'] else 'play'])

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -59,8 +59,6 @@ class MediaWidget(BaseWidget):
         self.thumbnail_box.addWidget(self._label_alt, 0, 0)
 
         self.register_callback("toggle_label", self._toggle_label)
-
-        self.register_callback("toggle_label", self._toggle_label)
         self.register_callback("update_label", self._update_label)
 
         self.callback_left = callbacks['on_left']

--- a/src/styles.css
+++ b/src/styles.css
@@ -14,6 +14,7 @@
 .power-menu-popup > .button {} -> Styles for power buttons inside the popup 
 .power-menu-popup > .button > .icon,
 .power-menu-popup > .button > .label {} -> Styles for power buttons icons and labels inside the popup 
+.media-widget {} -> Styles specific to the media widget
 */
 * {
     font-size: 14px;
@@ -105,7 +106,7 @@
 
 .fake-widget-left,
 .fake-widget-right  {
-    padding: 0; 
+    padding: 0;
 }
 .fake-widget-left .label{
     color: rgb(41, 42, 58);
@@ -126,6 +127,7 @@
 .weather-widget .label {
     font-weight: 600;
 }
+.media-widget,
 .apps-widget,
 .weather-widget,
 .volume-widget,
@@ -134,7 +136,7 @@
     padding-right: 0;
     background-color: rgb(41, 42, 58)
 }
-
+.media-widget,
 .apps-widget .label,
 .weather-widget .label,
 .volume-widget .label,
@@ -143,6 +145,7 @@
     padding-right: 6px;
     
 }
+.media-widget .btn:hover,
 .apps-widget .label:hover,
 .weather-widget .label:hover,
 .volume-widget .label:hover,
@@ -199,4 +202,25 @@
 }
 .power-menu-popup .button.shutdown .label {
     color:rgba(137, 180, 250, 0.95);
+}
+
+.media-widget {
+    padding-left: 0;
+    background-color: rgb(41, 42, 58);
+}
+
+.media-widget .label {
+    color: #BAC2DB;
+    background-color: rgba(24, 24, 37, 0.7);
+}
+.media-widget .btn {
+    color: #8c91a7;
+    padding-left:6px;
+    padding-right:6px;
+}
+
+.media-widget .btn.disabled:hover,
+.media-widget .btn.disabled {
+    color: #474A54;
+    background-color: rgb(41, 42, 58);
 }


### PR DESCRIPTION
Adds a media widget that shows the currently playing media as pulled from the Windows API. In addition, it features media buttons (previous/next track and play/pause). Provides some options for shortening fields with ellipsis to prevent the bar from blowing up from the occasional large title/artist field. Media thumbnail is used as a semi-transparent background.

For those who want it to take up little space in the bar, you can also disable the text/thumbnail field in the config and just have the media control buttons instead.

Still needs some work on the styling. Depending on the thumbnail, text might not be as legible. You can mitigate this with the background transparency, but I'd rather have something like text shadow to help improve legibility across thumbnails. 

Known issue: Border highlight on hover is rectangular instead of circular, despite having `border-radius` set for the hover state in CSS.

Also good to note is that this introduces a new dependency, `qasync`, which is needed to make `async` calls work properly with `PyQt6`. These `async` calls are needed for the media retrieval. I also had to change the main loop code a bit to make this work. I tested many of the bar functions and they seem unaffected by the change, but it is good to keep it into account.
