### PR TITLE
bugfix(media): winsdk stream stability

### DIFF
--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -10,6 +10,7 @@ from core.validation.widgets.yasb.media import VALIDATION_SCHEMA
 from PyQt6.QtWidgets import QLabel, QGridLayout, QHBoxLayout, QWidget
 from core.widgets.yasb.applications import ClickableLabel
 
+
 class MediaWidget(BaseWidget):
     validation_schema = VALIDATION_SCHEMA
 
@@ -53,8 +54,6 @@ class MediaWidget(BaseWidget):
                 self._widget_container_layout.addLayout(self.thumbnail_box)
             self._prev_label, self._play_label, self._next_label = self._create_media_buttons()
 
-
-        
         self._label = QLabel()
         self._label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self._label_alt = QLabel()
@@ -141,6 +140,9 @@ class MediaWidget(BaseWidget):
             active_label.setText('')
             if self._hide_empty:
                 self._widget_container.hide()
+
+            self._last_title = None
+            self._last_artist = None
             return
         
         # Change icon based on if song is playing


### PR DESCRIPTION
Hopefully this solves weird behaviour where the media detection freezes until restart. The code with dynamic size introduced another stream open, but we never close them. Now we only use a single stream call, and always close it.

Also fixes a small thumbnail loading bug:

- Fixes small bug where if you close a media player playing a certain song, and reopen it and continue, the thumbnail does not load because the title and artist are the same. Now, if media info is ever None, it wipes the last title and artist used for thumbnail detect.