### PR TITLE
feat(power/mem): Reintroduce value-dependent icon color

### DIFF
--- a/src/core/widgets/yasb/battery.py
+++ b/src/core/widgets/yasb/battery.py
@@ -10,6 +10,7 @@ from typing import Union
 
 class BatteryWidget(BaseWidget):
     validation_schema = VALIDATION_SCHEMA
+    CLASS_NAME = "battery-widget"
 
     def __init__(
             self,
@@ -22,7 +23,7 @@ class BatteryWidget(BaseWidget):
             status_icons: dict[str, str],
             callbacks: dict[str, str]
     ):
-        super().__init__(update_interval, class_name="battery-widget")
+        super().__init__(update_interval, class_name=self.CLASS_NAME)
         self._time_remaining_natural = time_remaining_natural
         self._status_thresholds = status_thresholds
         self._status_icons = status_icons
@@ -156,14 +157,15 @@ class BatteryWidget(BaseWidget):
                     active_widgets[widget_index].setText("Battery info not available")          
                     widget_index += 1
             return
-        
-        if self._battery_state.power_plugged:
-            threshold = "charging"       
 
         for part in label_parts:
             part = part.strip()
             if part and widget_index < len(active_widgets) and isinstance(active_widgets[widget_index], QLabel):
                 threshold = self._get_battery_threshold()
+
+                if self._battery_state.power_plugged:
+                    threshold = "charging"
+
                 time_remaining = self._get_time_remaining()
                 is_charging_str = "yes" if self._battery_state.power_plugged else "no"
                 charging_icon = self._get_charging_icon(threshold)
@@ -182,4 +184,8 @@ class BatteryWidget(BaseWidget):
                     active_widgets[widget_index].setText(formatted_text)
                     active_widgets[widget_index].setProperty("class", f"label {alt_class} status-{threshold}")
                     active_widgets[widget_index].setStyleSheet('')
+
+                # Set memory threshold as property
+                self._widget_frame.setProperty("class", f"widget {self.CLASS_NAME} status-{threshold}")
+                self._widget_frame.setStyleSheet('')
                 widget_index += 1

--- a/src/core/widgets/yasb/memory.py
+++ b/src/core/widgets/yasb/memory.py
@@ -10,6 +10,7 @@ from PyQt6.QtCore import Qt
 
 class MemoryWidget(BaseWidget):
     validation_schema = VALIDATION_SCHEMA
+    CLASS_NAME = "memory-widget"
 
     def __init__(
             self,
@@ -19,7 +20,7 @@ class MemoryWidget(BaseWidget):
             callbacks: dict[str, str],
             memory_thresholds: dict[str, int]
     ):
-        super().__init__(update_interval, class_name="memory-widget")
+        super().__init__(update_interval, class_name=self.CLASS_NAME)
         self._memory_thresholds = memory_thresholds
         self._show_alt_label = False
         self._label_content = label
@@ -118,6 +119,10 @@ class MemoryWidget(BaseWidget):
                     else:
                         active_widgets[widget_index].setText(part)
                     widget_index += 1
+
+            # Set memory threshold as property
+            self._widget_frame.setProperty("class", f"widget {self.CLASS_NAME} status-{self._get_virtual_memory_threshold(virtual_mem.percent)}")
+            self._widget_frame.setStyleSheet('')
 
         except Exception:
             logging.exception("Failed to retrieve updated memory info")

--- a/src/styles.css
+++ b/src/styles.css
@@ -212,7 +212,7 @@
 }
 */
 
-/* Battery widget usage colors. Uncomment if you want to color of the battery widget icon to change based on status */
+/* Battery widget value colors. Uncomment if you want to color of the battery widget icon to change based on status */
 
 /*
 .battery-widget.status-charging .icon {

--- a/src/styles.css
+++ b/src/styles.css
@@ -195,7 +195,45 @@
 	margin: 0;
 }
 
+/* Memory widget usage colors. Uncomment if you want to color of the battery widget icon to change based on status */
 
+/*
+.memory-widget.status-low .icon {
+  color: #a6e3a1;
+}
+.memory-widget.status-medium .icon {
+  color: #f9e2af;
+}
+.memory-widget.status-high .icon {
+  color: #fab387;
+}
+.memory-widget.status-critical .icon {
+  color: #f38ba8;
+}
+*/
+
+/* Battery widget usage colors. Uncomment if you want to color of the battery widget icon to change based on status */
+
+/*
+.battery-widget.status-charging .icon {
+  color: #74c7ec;
+}
+.battery-widget.status-full .icon {
+  color: #94e2d5;
+}
+.battery-widget.status-high .icon {
+  color: #a6e3a1;
+}
+.battery-widget.status-medium .icon {
+  color: #f9e2af;
+}
+.battery-widget.status-low .icon {
+  color: #fab387;
+}
+.battery-widget.status-critical .icon {
+  color: #f38ba8;
+}
+*/
 
 /* WEATHER WIDGET */
 .weather-widget .icon {


### PR DESCRIPTION
Small changes that allow you to set value-dependent colors for the icons of the power and memory widget. Most of the code to make this happen was still left (as well as all parameters in the schema), but the CSS properties were missing. Added the property setting in code and added disabled template CSS code for the colors. The template colors should be consistent with the rest of the bar (Catppuccin Mocha).