### PR TITLE
feat(media): Rounded thumbnail corners

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -40,8 +40,8 @@ bars:
         ]
       right:
         [
-          "wifi",
           "media",
+          "wifi",
           #"battery",
           #"lang",
           #"ip_info",
@@ -66,8 +66,9 @@ widgets:
       controls_only: false
       controls_left: true
       hide_empty: true
-      thumbnail_alpha: 225
-      thumbnail_padding: 5
+      thumbnail_alpha: 80
+      thumbnail_padding: 8
+      thumbnail_corner_radius: 16 # Set to 0 for square corners
       icons:
         prev_track: "\ue892"
         next_track: "\ue893"

--- a/src/core/bar_manager.py
+++ b/src/core/bar_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import uuid
 from contextlib import suppress
@@ -84,6 +85,9 @@ class BarManager(QObject):
 
     def close_bars(self):
         self.stop_listener_threads()
+        tasks = asyncio.all_tasks()
+        for t in tasks:
+            t.cancel()
 
         for bar in self.bars:
             bar.close()

--- a/src/core/validation/widgets/yasb/media.py
+++ b/src/core/validation/widgets/yasb/media.py
@@ -81,11 +81,18 @@ VALIDATION_SCHEMA = {
         'min': 0,
         'max': 255
     },
-    'thumbnail_padding':
-        {'type': 'integer',
-         'default': 8,
-         'min': 0,
-         'max': 200},
+    'thumbnail_padding': {
+        'type': 'integer',
+        'default': 8,
+        'min': 0,
+        'max': 200
+    },
+    'thumbnail_corner_radius': {
+        'type': 'integer',
+        'default': 0,
+        'min': 0,
+        'max': 100
+    },
     'icons': {
         'type': 'dict',
         'schema': {

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -157,12 +157,14 @@ class MediaWidget(BaseWidget):
         # Change icon based on if song is playing
         self._play_label.setText(self._media_button_icons['pause' if media_info['playing'] else 'play'])
 
+        # If media is not None, we show the frame
+        self._widget_frame.show()
+
         # If we only have controls, stop update here
         if self._controls_only:
             return
 
         # If we are playing, make sure the label field is showing
-        self._widget_frame.show()
         active_label.show()
 
         # Shorten fields if necessary with ...

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -138,6 +138,8 @@ class MediaWidget(BaseWidget):
             self._thumbnail_label.hide()
             active_label.hide()
             active_label.setText('')
+            self._play_label.setText(self._media_button_icons['play'])
+
             if self._hide_empty:
                 self._widget_frame.hide()
 

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -102,11 +102,15 @@ class MediaWidget(BaseWidget):
         else:
             self._label.show()
             self._label_alt.hide()
-        self._update_label(is_toggle=True)
 
+        # Clearing last title/artist field to make thumbnail update
+        self._last_title = None
+        self._last_artist = None
+
+        self._update_label()
 
     @asyncSlot()
-    async def _update_label(self, is_toggle=False):
+    async def _update_label(self):
         active_label = self._label_alt if self._show_alt_label else self._label
         active_label_content = self._label_alt_content if self._show_alt_label else self._label_content
 
@@ -165,7 +169,7 @@ class MediaWidget(BaseWidget):
             return
 
         # Only update the thumbnail if the title/artist changes or if we did a toggle (resize)
-        if is_toggle or not (self._last_title == media_info['title'] and self._last_artist == media_info['artist']):
+        if not (self._last_title == media_info['title'] and self._last_artist == media_info['artist']):
             if media_info['thumbnail'] is not None:
                 self._thumbnail_label.show()
                 self._last_title = media_info['title']

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -1,5 +1,8 @@
 import logging
 import time
+
+from PIL import Image
+from PIL.ImageDraw import ImageDraw
 from PIL.ImageQt import QPixmap
 from PyQt6.QtCore import Qt
 from qasync import asyncSlot
@@ -123,7 +126,7 @@ class MediaWidget(BaseWidget):
         except Exception as e:
             logging.error(f"Error fetching media properties: {e}")
             return  # Exit early if there's an error
- 
+
         # If no media is playing, set disable class on all buttons
         # Give next/previous buttons a different css class based on whether they are available
         disabled_if = lambda disabled: "disabled" if disabled else ""
@@ -150,7 +153,7 @@ class MediaWidget(BaseWidget):
             self._last_title = None
             self._last_artist = None
             return
-        
+
         # Change icon based on if song is playing
         self._play_label.setText(self._media_button_icons['pause' if media_info['playing'] else 'play'])
 
@@ -227,7 +230,7 @@ class MediaWidget(BaseWidget):
         label.data = action
         self._widget_container_layout.addWidget(label)
         return label
-    
+
     def _create_media_buttons(self):
         return self._create_media_button(self._media_button_icons['prev_track'],
                                          MediaOperations.prev), self._create_media_button(

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -104,11 +104,6 @@ class MediaWidget(BaseWidget):
             self._label_alt.hide()
         self._update_label(is_toggle=True)
 
-    @staticmethod
-    def _refresh_css(label: QLabel):
-        label.style().unpolish(label)
-        label.style().polish(label)
-        label.update()
 
     @asyncSlot()
     async def _update_label(self, is_toggle=False):
@@ -127,10 +122,11 @@ class MediaWidget(BaseWidget):
         self._prev_label.setProperty("class", f"btn prev {disabled_if(media_info is None or not media_info['prev_available'])}")
         self._play_label.setProperty("class", f"btn play {disabled_if(media_info is None)}")
         self._next_label.setProperty("class", f"btn next {disabled_if(media_info is None or not media_info['next_available'])}")
-            
-        self._refresh_css(self._prev_label)
-        self._refresh_css(self._play_label)
-        self._refresh_css(self._next_label)
+
+        # Refresh style sheets
+        self._prev_label.setStyleSheet('')
+        self._play_label.setStyleSheet('')
+        self._next_label.setStyleSheet('')
 
         # If nothing playing, hide thumbnail and empty text, stop here
         if media_info is None:

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -41,7 +41,7 @@ class MediaWidget(BaseWidget):
         # Add the container to the main widget layout
         self.widget_layout.addWidget(self._widget_container)
         if self._hide_empty:
-            self._widget_container.hide()
+            self._widget_frame.hide()
         # Make a grid box to overlay the text and thumbnail
         self.thumbnail_box = QGridLayout()
 
@@ -135,7 +135,7 @@ class MediaWidget(BaseWidget):
             active_label.hide()
             active_label.setText('')
             if self._hide_empty:
-                self._widget_container.hide()
+                self._widget_frame.hide()
 
             self._last_title = None
             self._last_artist = None
@@ -149,8 +149,9 @@ class MediaWidget(BaseWidget):
             return
 
         # If we are playing, make sure the label field is showing
-        self._widget_container.show()
+        self._widget_frame.show()
         active_label.show()
+
         # Shorten fields if necessary with ...
         media_info = {k: self._format_max_field_size(v) if isinstance(v, str) else v for k, v in
                       media_info.items()}

--- a/src/styles.css
+++ b/src/styles.css
@@ -225,11 +225,13 @@
 /* NEW MEDIA WIDGET */
 .media-widget {
 	padding: 0;
+	padding-left: 2px;
 	margin: 0;
+	border-radius: 16px;
+	margin-right: 8px;
 }
 .media-widget .label {
-	color: #bac2db;
-	background-color: rgba(24, 24, 37, 0.7);
+	background-color: rgba(0, 0, 0, 0.0);
 }
 .media-widget .btn {
 	color: #acb2c9;
@@ -238,7 +240,7 @@
 	font-family: Segoe Fluent Icons;
 }
 .media-widget .btn:hover {
-	color: #babfd3;
+	color: #89b4fa;
 }
 .media-widget .btn.play {
 	background-color: #313244;


### PR DESCRIPTION
Implements a corner rounding procedure for the media thumbnail. This cannot be achieved by CSS, so we need to make the corners transparent to mimic round corners. Using `thumbnail_corner_radius` users can set the rounding to match their CSS settings, or set it to 0 for default square corners.

In addition, provides a few small refactors and cleanups.