### PR TITLE
feat(wifi): Add Ethernet connection icon

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -174,12 +174,6 @@ widgets:
       label: "<span>{wifi_icon}</span>"
       label_alt: "{wifi_name} {wifi_strength}%"
       update_interval: 5000
-      wifi_icons:
-        - "\udb82\udd2e" # 0% strength (no wifi)
-        - "\udb82\udd1f" # 1-25% strength
-        - "\udb82\udd22" # 26-50% strength
-        - "\udb82\udd25" # 51-75% strength
-        - "\udb82\udd28" # 76-100% strength. Alternate theming: \uf1eb
       callbacks:
         on_left: "exec cmd.exe /c start ms-settings:network"
         on_middle: "do_nothing"

--- a/src/core/validation/widgets/yasb/wifi.py
+++ b/src/core/validation/widgets/yasb/wifi.py
@@ -8,12 +8,13 @@ DEFAULTS = {
         'on_right': 'do_nothing'
     },
     'wifi_icons': [
-        "\udb82\udd2e",  # Icon for 0% strength
-        "\udb82\udd1f",  # Icon for 1-25% strength
-        "\udb82\udd22",  # Icon for 26-50% strength
-        "\udb82\udd25",  # Icon for 51-75% strength
-        "\udb82\udd28"   # Icon for 76-100% strength
-    ]
+        "\ueb5e",  # Icon for 0% strength
+        "\ue872",  # Icon for 1-25% strength
+        "\ue873",  # Icon for 26-50% strength
+        "\ue874",  # Icon for 51-75% strength
+        "\ue701"   # Icon for 76-100% strength
+    ],
+    'ethernet_icon': "\ue839"
 }
 
 VALIDATION_SCHEMA = {
@@ -38,6 +39,10 @@ VALIDATION_SCHEMA = {
             'type': 'string',
             'required': False
         }
+    },
+    'ethernet_icon': {
+        'type': 'string',
+        'default': DEFAULTS['ethernet_icon']
     },
     'callbacks': {
         'type': 'dict',

--- a/src/core/validation/widgets/yasb/wifi.py
+++ b/src/core/validation/widgets/yasb/wifi.py
@@ -14,7 +14,7 @@ DEFAULTS = {
         "\udb82\udd25",  # Icon for 51-75% strength
         "\udb82\udd28"   # Icon for 76-100% strength
     ],
-    'ethernet_icon': "\uef44"
+    'ethernet_icon': "\ueba9"
 }
 
 VALIDATION_SCHEMA = {

--- a/src/core/validation/widgets/yasb/wifi.py
+++ b/src/core/validation/widgets/yasb/wifi.py
@@ -8,13 +8,13 @@ DEFAULTS = {
         'on_right': 'do_nothing'
     },
     'wifi_icons': [
-        "\ueb5e",  # Icon for 0% strength
-        "\ue872",  # Icon for 1-25% strength
-        "\ue873",  # Icon for 26-50% strength
-        "\ue874",  # Icon for 51-75% strength
-        "\ue701"   # Icon for 76-100% strength
+        "\udb82\udd2e",  # Icon for 0% strength
+        "\udb82\udd1f",  # Icon for 1-25% strength
+        "\udb82\udd22",  # Icon for 26-50% strength
+        "\udb82\udd25",  # Icon for 51-75% strength
+        "\udb82\udd28"   # Icon for 76-100% strength
     ],
-    'ethernet_icon': "\ue839"
+    'ethernet_icon': "\uef44"
 }
 
 VALIDATION_SCHEMA = {

--- a/src/styles.css
+++ b/src/styles.css
@@ -194,6 +194,7 @@
 	color: #43d8d8;
 	padding: 0 6px;
 	margin: 0;
+	font-family: Segoe Fluent Icons;
 }
 
 /* Memory widget usage colors. Uncomment if you want to color of the battery widget icon to change based on status */

--- a/src/styles.css
+++ b/src/styles.css
@@ -194,7 +194,6 @@
 	color: #43d8d8;
 	padding: 0 6px;
 	margin: 0;
-	font-family: Segoe Fluent Icons;
 }
 
 /* Memory widget usage colors. Uncomment if you want to color of the battery widget icon to change based on status */


### PR DESCRIPTION
Adds the ability to show an ethernet connection icon when connected to ethernet, instead of showing 'no wifi' icon. Since `netsh` seems to give problems for the lan interfaces, I use the winsdk to identify whether the current connection is WiFi or not. If it is WiFi or disconnected, it uses the `netsh` code, otherwise sets an Ethernet icon.

I did switch to Segoe Fluent Icons because I could not get the NerdFont icons to look nice for the ethernet one. If we want the icons to stay the same, we'd need to look a bit deeper into it.