### PR TITLE
feat(media): Main/subtext label, thumbnail update fix, lightness thumbnail

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -68,8 +68,8 @@ widgets:
       controls_only: false
       controls_left: false
       hide_empty: true
-      thumbnail_alpha_range: 0.75 # Range in which image lightness controls alpha. At 0, alpha fully controlled by multiplier
-      thumbnail_alpha_multiplier: 0.8 # Scales the thumbnail alpha as a whole (after lightness calculation)
+      thumbnail_alpha_range: 1.0 # How much of the alpha range depends on lightness. If 0, alpha fully determined by multiplier
+      thumbnail_alpha_multiplier: 0.6 # Scales the thumbnail alpha as a whole (after lightness calculation)
       thumbnail_padding: 8
       thumbnail_corner_radius: 16 # Set to 0 for square corners
       icons:

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -58,17 +58,18 @@ widgets:
   media:
     type: "yasb.media.MediaWidget"
     options:
-      label: "{title} - {artist}"
-      label_alt: "{title}"
+      label_main: "{title}"
+      label_sub: "{artist}"
       update_interval: 1000
       max_field_size:
-        label: 20
+        label: 30
         label_alt: 30
       show_thumbnail: true
       controls_only: false
-      controls_left: true
+      controls_left: false
       hide_empty: true
-      thumbnail_alpha: 80
+      thumbnail_alpha_range: 0.75 # Range in which image lightness controls alpha. At 0, alpha fully controlled by multiplier
+      thumbnail_alpha_multiplier: 0.8 # Scales the thumbnail alpha as a whole (after lightness calculation)
       thumbnail_padding: 8
       thumbnail_corner_radius: 16 # Set to 0 for square corners
       icons:

--- a/src/core/validation/widgets/yasb/media.py
+++ b/src/core/validation/widgets/yasb/media.py
@@ -70,13 +70,13 @@ VALIDATION_SCHEMA = {
     },
     'thumbnail_alpha_range': {
         'type': 'float',
-        'default': 0.75,
+        'default': 1.0,
         'min': 0.0,
         'max': 1.0
     },
     'thumbnail_alpha_multiplier': {
         'type': 'float',
-        'default': 0.8,
+        'default': 0.6,
         'min': 0.0,
         'max': 1.0},
     'thumbnail_padding': {

--- a/src/core/validation/widgets/yasb/media.py
+++ b/src/core/validation/widgets/yasb/media.py
@@ -1,22 +1,11 @@
-DEFAULTS = {
-    'label': '\uf017 {%H:%M:%S}',
-    'label_alt': '\uf017 {%d-%m-%y %H:%M:%S}',
-    'update_interval': 1000,
-    'callbacks': {
-        'on_left': 'toggle_label',
-        'on_middle': 'do_nothing',
-        'on_right': 'do_nothing'
-    }
-}
-
 VALIDATION_SCHEMA = {
-    'label': {
+    'label_main': {
         'type': 'string',
-        'default': DEFAULTS['label']
+        'default': '{title}'
     },
-    'label_alt': {
+    'label_sub': {
         'type': 'string',
-        'default': DEFAULTS['label_alt']
+        'default': '{artist}'
     },
     'hide_empty': {
         'type': 'boolean',
@@ -33,18 +22,22 @@ VALIDATION_SCHEMA = {
         'schema': {
             'on_left': {
                 'type': 'string',
-                'default': DEFAULTS['callbacks']['on_left'],
+                'default': 'do_nothing',
             },
             'on_middle': {
                 'type': 'string',
-                'default': DEFAULTS['callbacks']['on_middle'],
+                'default': 'do_nothing',
             },
             'on_right': {
                 'type': 'string',
-                'default': DEFAULTS['callbacks']['on_right'],
+                'default': 'do_nothing',
             }
         },
-        'default': DEFAULTS['callbacks']
+        'default': {
+            'on_left': 'do_nothing',
+            'on_middle': 'do_nothing',
+            'on_right': 'do_nothing'
+        }
     },
     'max_field_size': {
         'type': 'dict',
@@ -75,12 +68,17 @@ VALIDATION_SCHEMA = {
         'type': 'boolean',
         'default': True
     },
-    'thumbnail_alpha': {
-        'type': 'integer',
-        'default': 50,
-        'min': 0,
-        'max': 255
+    'thumbnail_alpha_range': {
+        'type': 'float',
+        'default': 0.75,
+        'min': 0.0,
+        'max': 1.0
     },
+    'thumbnail_alpha_multiplier': {
+        'type': 'float',
+        'default': 0.8,
+        'min': 0.0,
+        'max': 1.0},
     'thumbnail_padding': {
         'type': 'integer',
         'default': 8,

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -101,11 +101,6 @@ class MediaWidget(BaseWidget):
         self._last_artist = None
         self._last_thumbnail = None
 
-    def start_timer(self):
-        if self.timer_interval and self.timer_interval > 0:
-            self.timer.timeout.connect(self._timer_callback)
-            self.timer.start(self.timer_interval)
-
     @asyncSlot()
     async def _update_label(self):
         text_labels = [self._main_text_label, self._sub_text_label]

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -209,8 +209,8 @@ class MediaWidget(BaseWidget):
         thumbnail = thumbnail.crop((0, y1, thumbnail.width, y1 + new_h))
 
         # Calculate lightness to scale alpha
-        lightness_range = (1.0 - self._thumbnail_alpha_range) * 255 + self._thumbnail_alpha_range * self._avg_lightness(thumbnail)
-        thumbnail_alpha = round(self._thumbnail_alpha_multiplier * (255 - lightness_range))
+        thumbnail_alpha = (1.0 - self._thumbnail_alpha_range) * 255 + self._thumbnail_alpha_range * (255 - self._avg_lightness(thumbnail))
+        thumbnail_alpha = round(self._thumbnail_alpha_multiplier * thumbnail_alpha)
 
         # If we want a rounded thumbnail, draw a rounded-corner mask and use it to make the image transparent
         if self._thumbnail_corner_radius > 0:

--- a/src/styles.css
+++ b/src/styles.css
@@ -288,7 +288,7 @@
 	font-size: 12px;
 }
 .media-widget .label.maintext {
-    padding-top: 4px;
+    padding-top: 3px;
 }
 .media-widget .label.subtext {
     color: #bac2de;

--- a/src/styles.css
+++ b/src/styles.css
@@ -277,13 +277,23 @@
 /* MEDIA WIDGET */
 .media-widget {
 	padding: 0;
-	padding-left: 2px;
 	margin: 0;
 	border-radius: 16px;
 	margin-right: 8px;
 }
 .media-widget .label {
 	background-color: rgba(0, 0, 0, 0.0);
+	padding: 0px;
+	padding-right: 4px;
+	font-size: 12px;
+}
+.media-widget .label.maintext {
+    padding-top: 4px;
+}
+.media-widget .label.subtext {
+    color: #bac2de;
+    font-size: 10px;
+    margin-top: -1px;
 }
 .media-widget .btn {
 	color: #acb2c9;


### PR DESCRIPTION
Big update with a lot of neat features:
* Add two vertical text fields, allowing title and artist to be listed above each other, making the widget smaller with more info! The labels can be configured through the config.
* Fixed a bug where the thumbnail would sometimes not update correctly on song change, as the title and artist fields would change before the thumbnail, causing a thumbnail update to the same old thumbnail. Now, once artist and title change, it will update the thumbnail until it is different from the previous one, and then stops updating and waits for title/artist change.
* Thumbnail alpha is now calculated based on the lightness of the image, which should help equalize the 'darkness' of the images a bit. This means that bright thumbnails are darkened more than light thumbnails, hopefully helping with readability. Two parameters, `thumbnail_alpha_range` and `thumbnail_alpha_multiplier`, control this calculation.

Also removes the `start_timer()` overload, like we discussed :)