### PR TITLE
feat(launch): Loading indication on startup

### DIFF
--- a/src/core/widgets/base.py
+++ b/src/core/widgets/base.py
@@ -61,7 +61,8 @@ class BaseWidget(QWidget):
         if self.timer_interval and self.timer_interval > 0:
             self.timer.timeout.connect(self._timer_callback)
             self.timer.start(self.timer_interval)
-        self._timer_callback()
+
+        self.timer.singleShot(0, self._timer_callback)
 
     def _handle_mouse_events(self, event: QMouseEvent):
         if event.button() == Qt.MouseButton.LeftButton:

--- a/src/core/widgets/base.py
+++ b/src/core/widgets/base.py
@@ -62,7 +62,7 @@ class BaseWidget(QWidget):
             self.timer.timeout.connect(self._timer_callback)
             self.timer.start(self.timer_interval)
 
-        self.timer.singleShot(5000, self._timer_callback)
+        self.timer.singleShot(0, self._timer_callback)
 
     def _handle_mouse_events(self, event: QMouseEvent):
         if event.button() == Qt.MouseButton.LeftButton:

--- a/src/core/widgets/yasb/battery.py
+++ b/src/core/widgets/yasb/battery.py
@@ -70,36 +70,6 @@ class BatteryWidget(BaseWidget):
         self._update_label()
 
 
-    def _create_dynamically_label(self, content: str, content_alt: str):
-        def process_content(content, is_alt=False):
-            label_parts = re.split('(<span.*?>.*?</span>)', content)
-            label_parts = [part for part in label_parts if part]
-            widgets = []
-            for part in label_parts:
-                part = part.strip()  # Remove any leading/trailing whitespace
-                if not part:
-                    continue
-                if '<span' in part and '</span>' in part:
-                    class_name = re.search(r'class=(["\'])([^"\']+?)\1', part)
-                    class_result = class_name.group(2) if class_name else 'icon'
-                    icon = re.sub(r'<span.*?>|</span>', '', part).strip()
-                    label = QLabel(icon)
-                    label.setProperty("class", class_result)
-                else:
-                    label = QLabel(part)
-                    label.setProperty("class", "label")
-                    label.setText("Loading")
-                label.setAlignment(Qt.AlignmentFlag.AlignCenter)    
-                self._widget_container_layout.addWidget(label)
-                widgets.append(label)
-                if is_alt:
-                    label.hide()
-                else:
-                    label.show()
-            return widgets
-        self._widgets = process_content(content)
-        self._widgets_alt = process_content(content_alt, is_alt=True)
-        
     def _get_time_remaining(self) -> str:
         secs_left = self._battery_state.secsleft
         if secs_left == psutil.POWER_TIME_UNLIMITED:

--- a/src/core/widgets/yasb/battery.py
+++ b/src/core/widgets/yasb/battery.py
@@ -88,6 +88,7 @@ class BatteryWidget(BaseWidget):
                 else:
                     label = QLabel(part)
                     label.setProperty("class", "label")
+                    label.setText("Loading")
                 label.setAlignment(Qt.AlignmentFlag.AlignCenter)    
                 self._widget_container_layout.addWidget(label)
                 widgets.append(label)

--- a/src/core/widgets/yasb/clock.py
+++ b/src/core/widgets/yasb/clock.py
@@ -88,7 +88,8 @@ class ClockWidget(BaseWidget):
                     label.setProperty("class", class_result)
                 else:
                     label = QLabel(part)
-                    label.setProperty("class", "label") 
+                    label.setProperty("class", "label")
+                    label.setText("Loading") 
                 label.setAlignment(Qt.AlignmentFlag.AlignCenter)    
                 self._widget_container_layout.addWidget(label)
                 widgets.append(label)

--- a/src/core/widgets/yasb/clock.py
+++ b/src/core/widgets/yasb/clock.py
@@ -70,36 +70,6 @@ class ClockWidget(BaseWidget):
         for widget in self._widgets_alt:
             widget.setVisible(self._show_alt_label)
         self._update_label()          
-            
-    def _create_dynamically_label(self, content: str, content_alt: str):
-        def process_content(content, is_alt=False):
-            label_parts = re.split('(<span.*?>.*?</span>)', content) #Filters out empty parts before entering the loop
-            label_parts = [part for part in label_parts if part]
-            widgets = []
-            for part in label_parts:
-                part = part.strip()  # Remove any leading/trailing whitespace
-                if not part:
-                    continue
-                if '<span' in part and '</span>' in part:
-                    class_name = re.search(r'class=(["\'])([^"\']+?)\1', part)
-                    class_result = class_name.group(2) if class_name else 'icon'
-                    icon = re.sub(r'<span.*?>|</span>', '', part).strip()
-                    label = QLabel(icon)
-                    label.setProperty("class", class_result)
-                else:
-                    label = QLabel(part)
-                    label.setProperty("class", "label")
-                    label.setText("Loading") 
-                label.setAlignment(Qt.AlignmentFlag.AlignCenter)    
-                self._widget_container_layout.addWidget(label)
-                widgets.append(label)
-                if is_alt:
-                    label.hide()
-                else:
-                    label.show()
-            return widgets
-        self._widgets = process_content(content)
-        self._widgets_alt = process_content(content_alt, is_alt=True)
 
     def _update_label(self):
         active_widgets = self._widgets_alt if self._show_alt_label else self._widgets

--- a/src/core/widgets/yasb/cpu.py
+++ b/src/core/widgets/yasb/cpu.py
@@ -73,6 +73,7 @@ class CpuWidget(BaseWidget):
                 else:
                     label = QLabel(part)
                     label.setProperty("class", "label")
+                    label.setText("Loading")
                 label.setAlignment(Qt.AlignmentFlag.AlignCenter)    
                 self._widget_container_layout.addWidget(label)
                 widgets.append(label)

--- a/src/core/widgets/yasb/cpu.py
+++ b/src/core/widgets/yasb/cpu.py
@@ -55,36 +55,6 @@ class CpuWidget(BaseWidget):
             widget.setVisible(self._show_alt_label)
         self._update_label()
 
-    def _create_dynamically_label(self, content: str, content_alt: str):
-        def process_content(content, is_alt=False):
-            label_parts = re.split('(<span.*?>.*?</span>)', content)
-            label_parts = [part for part in label_parts if part]
-            widgets = []
-            for part in label_parts:
-                part = part.strip()  # Remove any leading/trailing whitespace
-                if not part:
-                    continue
-                if '<span' in part and '</span>' in part:
-                    class_name = re.search(r'class=(["\'])([^"\']+?)\1', part)
-                    class_result = class_name.group(2) if class_name else 'icon'
-                    icon = re.sub(r'<span.*?>|</span>', '', part).strip()
-                    label = QLabel(icon)
-                    label.setProperty("class", class_result)
-                else:
-                    label = QLabel(part)
-                    label.setProperty("class", "label")
-                    label.setText("Loading")
-                label.setAlignment(Qt.AlignmentFlag.AlignCenter)    
-                self._widget_container_layout.addWidget(label)
-                widgets.append(label)
-                if is_alt:
-                    label.hide()
-                else:
-                    label.show()
-            return widgets
-        self._widgets = process_content(content)
-        self._widgets_alt = process_content(content_alt, is_alt=True)
-
     def _update_label(self):
         active_widgets = self._widgets_alt if self._show_alt_label else self._widgets
         active_label_content = self._label_alt_content if self._show_alt_label else self._label_content

--- a/src/core/widgets/yasb/custom.py
+++ b/src/core/widgets/yasb/custom.py
@@ -63,36 +63,6 @@ class CustomWidget(BaseWidget):
         self._update_label()
 
 
-    def _create_dynamically_label(self, content: str, content_alt: str):
-        def process_content(content, is_alt=False):
-            label_parts = re.split('(<span.*?>.*?</span>)', content)
-            #label_parts = [part for part in label_parts if part]
-            widgets = []
-            for part in label_parts:
-                part = part.strip()  # Remove any leading/trailing whitespace
-                if not part:
-                    continue
-                if '<span' in part and '</span>' in part:
-                    class_name = re.search(r'class=(["\'])([^"\']+?)\1', part)
-                    class_result = class_name.group(2) if class_name else 'icon'
-                    icon = re.sub(r'<span.*?>|</span>', '', part).strip()
-                    label = QLabel(icon)
-                    label.setProperty("class", class_result)
-                else:
-                    label = QLabel(part)
-                    label.setProperty("class", "label")
-                    label.setText("Loading")
-                label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-                self._widget_container_layout.addWidget(label)
-                widgets.append(label)
-                if is_alt:
-                    label.hide()
-                else:
-                    label.show()
-            return widgets
-        self._widgets = process_content(content)
-        self._widgets_alt = process_content(content_alt, is_alt=True)
-        
     def _truncate_label(self, label):
         if self._label_max_length and len(label) > self._label_max_length:
             return label[:self._label_max_length] + "..."

--- a/src/core/widgets/yasb/custom.py
+++ b/src/core/widgets/yasb/custom.py
@@ -81,6 +81,7 @@ class CustomWidget(BaseWidget):
                 else:
                     label = QLabel(part)
                     label.setProperty("class", "label")
+                    label.setText("Loading")
                 label.setAlignment(Qt.AlignmentFlag.AlignCenter)
                 self._widget_container_layout.addWidget(label)
                 widgets.append(label)

--- a/src/core/widgets/yasb/memory.py
+++ b/src/core/widgets/yasb/memory.py
@@ -75,6 +75,7 @@ class MemoryWidget(BaseWidget):
                 else:
                     label = QLabel(part)
                     label.setProperty("class", "label")
+                    label.setText("Loading")
                 label.setAlignment(Qt.AlignmentFlag.AlignCenter)    
                 self._widget_container_layout.addWidget(label)
                 widgets.append(label)

--- a/src/core/widgets/yasb/memory.py
+++ b/src/core/widgets/yasb/memory.py
@@ -57,38 +57,6 @@ class MemoryWidget(BaseWidget):
             widget.setVisible(self._show_alt_label)
         self._update_label()
 
-    def _create_dynamically_label(self, content: str, content_alt: str):
-        def process_content(content, is_alt=False):
-            label_parts = re.split('(<span.*?>.*?</span>)', content)
-            label_parts = [part for part in label_parts if part]
-            widgets = []
-            for part in label_parts:
-                part = part.strip()  # Remove any leading/trailing whitespace
-                if not part:
-                    continue
-                if '<span' in part and '</span>' in part:
-                    class_name = re.search(r'class=(["\'])([^"\']+?)\1', part)
-                    class_result = class_name.group(2) if class_name else 'icon'
-                    icon = re.sub(r'<span.*?>|</span>', '', part).strip()
-                    label = QLabel(icon)
-                    label.setProperty("class", class_result)
-                else:
-                    label = QLabel(part)
-                    label.setProperty("class", "label")
-                    label.setText("Loading")
-                label.setAlignment(Qt.AlignmentFlag.AlignCenter)    
-                self._widget_container_layout.addWidget(label)
-                widgets.append(label)
-                if is_alt:
-                    label.hide()
-                else:
-                    label.show()
-            return widgets
-        self._widgets = process_content(content)
-        self._widgets_alt = process_content(content_alt, is_alt=True)
-            
-            
-            
     def _update_label(self):
         active_widgets = self._widgets_alt if self._show_alt_label else self._widgets
         active_label_content = self._label_alt_content if self._show_alt_label else self._label_content

--- a/src/core/widgets/yasb/traffic.py
+++ b/src/core/widgets/yasb/traffic.py
@@ -60,37 +60,6 @@ class TrafficWidget(BaseWidget):
             widget.setVisible(self._show_alt_label)
         self._update_label()
         
-    def _create_dynamically_label(self, content: str, content_alt: str):
-        def process_content(content, is_alt=False):
-            label_parts = re.split('(<span.*?>.*?</span>)', content)
-            label_parts = [part for part in label_parts if part]
-            widgets = []
-            for part in label_parts:
-                part = part.strip()  # Remove any leading/trailing whitespace
-                if not part:
-                    continue
-                if '<span' in part and '</span>' in part:
-                    class_name = re.search(r'class=(["\'])([^"\']+?)\1', part)
-                    class_result = class_name.group(2) if class_name else 'icon'
-                    icon = re.sub(r'<span.*?>|</span>', '', part).strip()
-                    label = QLabel(icon)
-                    label.setProperty("class", class_result)
-                else:
-                    label = QLabel(part)
-                    label.setProperty("class", "label")
-                    label.setText("Loading")
-                label.setAlignment(Qt.AlignmentFlag.AlignCenter)    
-                self._widget_container_layout.addWidget(label)
-                widgets.append(label)
-                if is_alt:
-                    label.hide()
-                else:
-                    label.show()
-            return widgets
-        self._widgets = process_content(content)
-        self._widgets_alt = process_content(content_alt, is_alt=True)
-               
-
     def _update_label(self):
         active_widgets = self._widgets_alt if self._show_alt_label else self._widgets
         active_label_content = self._label_alt_content if self._show_alt_label else self._label_content
@@ -119,11 +88,7 @@ class TrafficWidget(BaseWidget):
                     active_widgets[widget_index].setText(part)
                 widget_index += 1
         
-                            
 
-
-        
-        
     def _get_speed(self) -> list[str]:
         current_io = psutil.net_io_counters()
         upload_diff = current_io.bytes_sent - self.bytes_sent

--- a/src/core/widgets/yasb/traffic.py
+++ b/src/core/widgets/yasb/traffic.py
@@ -78,6 +78,7 @@ class TrafficWidget(BaseWidget):
                 else:
                     label = QLabel(part)
                     label.setProperty("class", "label")
+                    label.setText("Loading")
                 label.setAlignment(Qt.AlignmentFlag.AlignCenter)    
                 self._widget_container_layout.addWidget(label)
                 widgets.append(label)

--- a/src/core/widgets/yasb/volume.py
+++ b/src/core/widgets/yasb/volume.py
@@ -61,36 +61,6 @@ class VolumeWidget(BaseWidget):
             widget.setVisible(self._show_alt_label)
         self._update_label()
 
-    def _create_dynamically_label(self, content: str, content_alt: str):
-        def process_content(content, is_alt=False):
-            label_parts = re.split('(<span.*?>.*?</span>)', content)
-            label_parts = [part for part in label_parts if part]
-            widgets = []
-            for part in label_parts:
-                part = part.strip()
-                if not part:
-                    continue
-                if '<span' in part and '</span>' in part:
-                    class_name = re.search(r'class=(["\'])([^"\']+?)\1', part)
-                    class_result = class_name.group(2) if class_name else 'icon'
-                    icon = re.sub(r'<span.*?>|</span>', '', part).strip()
-                    label = QLabel(icon)
-                    label.setProperty("class", class_result)
-                else:
-                    label = QLabel(part)
-                    label.setProperty("class", "label")
-                    label.setText("Loading")
-                label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-                self._widget_container_layout.addWidget(label)
-                widgets.append(label)
-                if is_alt:
-                    label.hide()
-                else:
-                    label.show()
-            return widgets
-        self._widgets = process_content(content)
-        self._widgets_alt = process_content(content_alt, is_alt=True)
-
     def _update_label(self):
         active_widgets = self._widgets_alt if self._show_alt_label else self._widgets
         active_label_content = self._label_alt_content if self._show_alt_label else self._label_content

--- a/src/core/widgets/yasb/volume.py
+++ b/src/core/widgets/yasb/volume.py
@@ -79,6 +79,7 @@ class VolumeWidget(BaseWidget):
                 else:
                     label = QLabel(part)
                     label.setProperty("class", "label")
+                    label.setText("Loading")
                 label.setAlignment(Qt.AlignmentFlag.AlignCenter)
                 self._widget_container_layout.addWidget(label)
                 widgets.append(label)

--- a/src/core/widgets/yasb/weather.py
+++ b/src/core/widgets/yasb/weather.py
@@ -90,7 +90,7 @@ class WeatherWidget(BaseWidget):
                 else:
                     label = QLabel(part)
                     label.setProperty("class", "label")
-                    label.setText("weather update...")
+                    label.setText("Loading")
                 label.setAlignment(Qt.AlignmentFlag.AlignCenter)    
                 self._widget_container_layout.addWidget(label)
                 widgets.append(label)

--- a/src/core/widgets/yasb/wifi.py
+++ b/src/core/widgets/yasb/wifi.py
@@ -73,7 +73,8 @@ class WifiWidget(BaseWidget):
                     label.setProperty("class", class_result)
                 else:
                     label = QLabel(part)
-                    label.setProperty("class", "label") 
+                    label.setProperty("class", "label")
+                    label.setText("Loading") 
                 label.setAlignment(Qt.AlignmentFlag.AlignCenter)    
                 self._widget_container_layout.addWidget(label)
                 widgets.append(label)

--- a/src/core/widgets/yasb/wifi.py
+++ b/src/core/widgets/yasb/wifi.py
@@ -56,38 +56,6 @@ class WifiWidget(BaseWidget):
         self._update_label()
 
 
-    def _create_dynamically_label(self, content: str, content_alt: str):
-        def process_content(content, is_alt=False):
-            label_parts = re.split('(<span.*?>.*?</span>)', content) #Filters out empty parts before entering the loop
-            label_parts = [part for part in label_parts if part]
-            widgets = []
-            for part in label_parts:
-                part = part.strip()  # Remove any leading/trailing whitespace
-                if not part:
-                    continue
-                if '<span' in part and '</span>' in part:
-                    class_name = re.search(r'class=(["\'])([^"\']+?)\1', part)
-                    class_result = class_name.group(2) if class_name else 'icon'
-                    icon = re.sub(r'<span.*?>|</span>', '', part).strip()
-                    label = QLabel(icon)
-                    label.setProperty("class", class_result)
-                else:
-                    label = QLabel(part)
-                    label.setProperty("class", "label")
-                    label.setText("Loading") 
-                label.setAlignment(Qt.AlignmentFlag.AlignCenter)    
-                self._widget_container_layout.addWidget(label)
-                widgets.append(label)
-                if is_alt:
-                    label.setProperty("class", "label alt") 
-                    label.hide()
-                else:
-                    label.show()
-            return widgets
-        self._widgets = process_content(content)
-        self._widgets_alt = process_content(content_alt, is_alt=True)
-
-        
     def _update_label(self):
         active_widgets = self._widgets_alt if self._show_alt_label else self._widgets
         active_label_content = self._label_alt_content if self._show_alt_label else self._label_content


### PR DESCRIPTION
Previously, the bar would force update each widget before showing the UI. On slower systems (or heavier widgets), this could cause the bar to be invisible for some time, making it unclear for the user that yasb is running. Deferring the initial update to an instantaneous background call should help make the bar visible sooner.

Default text for many widgets is set to 'Loading', further indicating to the user that the widgets are loading.