### PR TITLE
fix(media): Fix error on config change

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -68,7 +68,6 @@ widgets:
     options:
       label: "{title} - {artist}"
       label_alt: "{title}"
-      update_interval: 1000
       max_field_size:
         label: 20
         label_alt: 30

--- a/src/core/bar_manager.py
+++ b/src/core/bar_manager.py
@@ -96,7 +96,8 @@ class BarManager(QObject):
         for t in tasks:
             t.cancel()
 
-        WindowsMedia().stop()
+        if WindowsMedia.has_instance():
+            WindowsMedia().stop()
 
         for bar in self.bars:
             bar.close()

--- a/src/core/utils/utilities.py
+++ b/src/core/utils/utilities.py
@@ -24,3 +24,6 @@ class Singleton(type):
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
+
+    def has_instance(cls):
+        return cls in cls._instances

--- a/src/core/validation/widgets/yasb/media.py
+++ b/src/core/validation/widgets/yasb/media.py
@@ -1,7 +1,6 @@
 DEFAULTS = {
     'label': '\uf017 {%H:%M:%S}',
     'label_alt': '\uf017 {%d-%m-%y %H:%M:%S}',
-    'update_interval': 1000,
     'callbacks': {
         'on_left': 'toggle_label',
         'on_middle': 'do_nothing',
@@ -21,12 +20,6 @@ VALIDATION_SCHEMA = {
     'hide_empty': {
         'type': 'boolean',
         'default': False
-    },
-    'update_interval': {
-        'type': 'integer',
-        'default': 1000,
-        'min': 0,
-        'max': 60000
     },
     'callbacks': {
         'type': 'dict',

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -23,13 +23,13 @@ class MediaWidget(BaseWidget):
     _media_info_signal = QtCore.pyqtSignal(object)
     _session_status_signal = QtCore.pyqtSignal(bool)
 
-    def __init__(self, label: str, label_alt: str, hide_empty:bool, update_interval: int, callbacks: dict[str, str],
+    def __init__(self, label: str, label_alt: str, hide_empty: bool, callbacks: dict[str, str],
                  max_field_size: dict[str, int], show_thumbnail: bool, controls_only: bool, controls_left: bool,
                  thumbnail_alpha: int,
                  thumbnail_padding: int,
                  thumbnail_corner_radius: int,
                  icons: dict[str, str]):
-        super().__init__(update_interval, class_name="media-widget")
+        super().__init__(class_name="media-widget")
         self._label_content = label
         self._label_alt_content = label_alt
 


### PR DESCRIPTION
Fixes a bug where the bar crashes on config reload if the media widget is not enabled. This was caused by the bar initializing a new media manager in the shutdown loop because it was not made by any of the widgets. Fixed by only trying to stop it if an instance exists.

Also removes the now unused update_interval parameter from the config and schema, since we are now using event-based updates.
