### PR TITLE
Add more RAM usage widget config

### DIFF
--- a/src/core/widgets/yasb/memory.py
+++ b/src/core/widgets/yasb/memory.py
@@ -103,6 +103,8 @@ class MemoryWidget(BaseWidget):
                 "{virtual_mem_percent}": virtual_mem.percent,
                 "{virtual_mem_total}": naturalsize(virtual_mem.total),
                 "{virtual_mem_avail}": naturalsize(virtual_mem.available),
+                "{virtual_mem_used}": naturalsize(virtual_mem.used),
+                "{virtual_mem_outof}": f"{naturalsize(virtual_mem.used)} / {naturalsize(virtual_mem.total)}",
                 "{swap_mem_free}": naturalsize(swap_mem.free),
                 "{swap_mem_percent}": swap_mem.percent,
                 "{swap_mem_total}": naturalsize(swap_mem.total),


### PR DESCRIPTION
This adds a "virtual_mem_used" to show the system ram usage and "virtual_mem_outof" to show a system ram usage / total system ram.

Would be nice to also change the default ram widget config (assuming this pr gets merged) to "virtual_mem_used" as I feel like the average user would like to see their ram usage instead of how much ram is free. (if you feel like this should be changed, lmk and I'll commit a change to config.yaml)