### PR TITLE
fix(LHM): proper SensorID string encoding for request URL.

### DIFF
--- a/src/core/widgets/yasb/libre_monitor.py
+++ b/src/core/widgets/yasb/libre_monitor.py
@@ -8,6 +8,7 @@ from PyQt6.QtNetwork import QAuthenticator, QNetworkAccessManager, QNetworkReque
 
 from core.validation.widgets.yasb.libre_monitor import VALIDATION_SCHEMA
 from core.widgets.base import BaseWidget
+from urllib.parse import quote
 
 
 class LibreHardwareMonitorWidget(BaseWidget):
@@ -79,7 +80,7 @@ class LibreHardwareMonitorWidget(BaseWidget):
         self._network_manager.authenticationRequired.connect(self._handle_authentication)
 
         # Create a request
-        url = QUrl(f"http://{self._server_host}:{self._server_port}/Sensor?action=Get&id={self._sensor_id}")
+        url = QUrl(f"http://{self._server_host}:{self._server_port}/Sensor?action=Get&id={quote(self._sensor_id)}")
         self.request = QNetworkRequest(url)
         self.request.setHeader(
             QNetworkRequest.KnownHeaders.ContentTypeHeader,


### PR DESCRIPTION
SensorID string will now be properly URL encoded.
This should ensure that the request URL is correct even if SensorID string has special characters in it.