### PR TITLE
Add support for using keyboard layout in Language widget

### DIFF
--- a/docs/widgets/(Widget)-Language.md
+++ b/docs/widgets/(Widget)-Language.md
@@ -22,7 +22,7 @@ language:
 ```
 
 ## Description of Options
-- **label:** The format string for the label. You can use placeholders like `{lang[language_code]}`, `{lang[country_code]}`, `{lang[full_name]}`, `{lang[native_country_name]}`, `{lang[native_lang_name]}`, `{lang[layout_name]}`.
+- **label:** The format string for the label. You can use placeholders like `{lang[language_code]}`, `{lang[country_code]}`, `{lang[full_name]}`, `{lang[native_country_name]}`, `{lang[native_lang_name]}`, `{lang[layout_name]}`, `{lang[full_layout_name]}`.
 - **label_alt:** The alternative format string for the label. Useful for displaying the full language name.
 - **update_interval:** The interval in seconds to update the language information. Must be between 1 and 3600.
 - **callbacks:** A dictionary specifying the callbacks for mouse events. The keys are `on_left`, `on_middle`, and `on_right`, and the values are the names of the callback functions.

--- a/docs/widgets/(Widget)-Language.md
+++ b/docs/widgets/(Widget)-Language.md
@@ -22,7 +22,7 @@ language:
 ```
 
 ## Description of Options
-- **label:** The format string for the label. You can use placeholders like `{lang[language_code]}`, `{lang[country_code]}`, `{lang[full_name]}`, `{lang[native_country_name]}`, `{lang[native_lang_name]}`, 
+- **label:** The format string for the label. You can use placeholders like `{lang[language_code]}`, `{lang[country_code]}`, `{lang[full_name]}`, `{lang[native_country_name]}`, `{lang[native_lang_name]}`, `{lang[layout_name]}`.
 - **label_alt:** The alternative format string for the label. Useful for displaying the full language name.
 - **update_interval:** The interval in seconds to update the language information. Must be between 1 and 3600.
 - **callbacks:** A dictionary specifying the callbacks for mouse events. The keys are `on_left`, `on_middle`, and `on_right`, and the values are the names of the callback functions.

--- a/docs/widgets/(Widget)-Language.md
+++ b/docs/widgets/(Widget)-Language.md
@@ -22,7 +22,7 @@ language:
 ```
 
 ## Description of Options
-- **label:** The format string for the label. You can use placeholders like `{lang[language_code]}`, `{lang[country_code]}`, `{lang[full_name]}`, `{lang[native_country_name]}`, `{lang[native_lang_name]}`, `{lang[layout_name]}`, `{lang[full_layout_name]}`.
+- **label:** The format string for the label. You can use placeholders like `{lang[language_code]}`, `{lang[country_code]}`, `{lang[full_name]}`, `{lang[native_country_name]}`, `{lang[native_lang_name]}`, `{lang[layout_name]}`, `{lang[full_layout_name]}`, `{lang[layout_country_name]}`.
 - **label_alt:** The alternative format string for the label. Useful for displaying the full language name.
 - **update_interval:** The interval in seconds to update the language information. Must be between 1 and 3600.
 - **callbacks:** A dictionary specifying the callbacks for mouse events. The keys are `on_left`, `on_middle`, and `on_right`, and the values are the names of the callback functions.

--- a/src/core/widgets/yasb/language.py
+++ b/src/core/widgets/yasb/language.py
@@ -14,6 +14,7 @@ LOCALE_SCOUNTRY = 0x6
 LOCALE_SNAME = 0x5c
 LOCALE_SNATIVECTRYNAME = 0x07
 LOCALE_SNATIVELANGNAME = 0x04
+
 # Define necessary ctypes structures and functions
 user32 = ctypes.WinDLL('user32', use_last_error=True)
 kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
@@ -142,6 +143,7 @@ class LanguageWidget(BaseWidget):
         native_lang_name = ctypes.create_unicode_buffer(LOCALE_NAME_MAX_LENGTH)
         layout_locale_name = ctypes.create_unicode_buffer(LOCALE_NAME_MAX_LENGTH)
         full_layout_locale_name = ctypes.create_unicode_buffer(LOCALE_NAME_MAX_LENGTH)
+        layout_country_name = ctypes.create_unicode_buffer(LOCALE_NAME_MAX_LENGTH)
 
         # Get the ISO language name
         kernel32.GetLocaleInfoW(lang_id, LOCALE_SISO639LANGNAME, lang_name, LOCALE_NAME_MAX_LENGTH)
@@ -155,10 +157,12 @@ class LanguageWidget(BaseWidget):
         kernel32.GetLocaleInfoW(lang_id, LOCALE_SNATIVECTRYNAME, native_country_name, LOCALE_NAME_MAX_LENGTH)
         # Get the native language name
         kernel32.GetLocaleInfoW(lang_id, LOCALE_SNATIVELANGNAME, native_lang_name, LOCALE_NAME_MAX_LENGTH)
-        # Convert the keyboard layout name to a human-readable string
+        # Get the full name of the keyboard layout
         kernel32.GetLocaleInfoW(layout_id, LOCALE_SNAME, layout_locale_name, LOCALE_NAME_MAX_LENGTH)
-        # Convert the keyboard layout name to full language name
+        # Get the full language name of the keyboard layout
         kernel32.GetLocaleInfoW(layout_id, LOCALE_SLANGUAGE, full_layout_locale_name, LOCALE_NAME_MAX_LENGTH)
+        # Get the full country name of the keyboard layout
+        kernel32.GetLocaleInfoW(layout_id, LOCALE_SCOUNTRY, layout_country_name, LOCALE_NAME_MAX_LENGTH)
 
         language_code = lang_name.value
         country_code = country_name.value
@@ -170,5 +174,6 @@ class LanguageWidget(BaseWidget):
             'native_country_name': native_country_name.value,
             'native_lang_name': native_lang_name.value,
             'layout_name': layout_locale_name.value,
-            'full_layout_name': full_layout_locale_name.value
+            'full_layout_name': full_layout_locale_name.value,
+            'layout_country_name': layout_country_name.value
         }

--- a/src/core/widgets/yasb/language.py
+++ b/src/core/widgets/yasb/language.py
@@ -141,6 +141,7 @@ class LanguageWidget(BaseWidget):
         native_country_name = ctypes.create_unicode_buffer(LOCALE_NAME_MAX_LENGTH)
         native_lang_name = ctypes.create_unicode_buffer(LOCALE_NAME_MAX_LENGTH)
         layout_locale_name = ctypes.create_unicode_buffer(LOCALE_NAME_MAX_LENGTH)
+        full_layout_locale_name = ctypes.create_unicode_buffer(LOCALE_NAME_MAX_LENGTH)
 
         # Get the ISO language name
         kernel32.GetLocaleInfoW(lang_id, LOCALE_SISO639LANGNAME, lang_name, LOCALE_NAME_MAX_LENGTH)
@@ -156,6 +157,8 @@ class LanguageWidget(BaseWidget):
         kernel32.GetLocaleInfoW(lang_id, LOCALE_SNATIVELANGNAME, native_lang_name, LOCALE_NAME_MAX_LENGTH)
         # Convert the keyboard layout name to a human-readable string
         kernel32.GetLocaleInfoW(layout_id, LOCALE_SNAME, layout_locale_name, LOCALE_NAME_MAX_LENGTH)
+        # Convert the keyboard layout name to full language name
+        kernel32.GetLocaleInfoW(layout_id, LOCALE_SLANGUAGE, full_layout_locale_name, LOCALE_NAME_MAX_LENGTH)
 
         language_code = lang_name.value
         country_code = country_name.value
@@ -166,5 +169,6 @@ class LanguageWidget(BaseWidget):
             'full_name': full_name,
             'native_country_name': native_country_name.value,
             'native_lang_name': native_lang_name.value,
-            'layout_name': layout_locale_name.value
+            'layout_name': layout_locale_name.value,
+            'full_layout_name': full_layout_locale_name.value
         }


### PR DESCRIPTION
Implements a `layout_name` variable accessible via `{lang[layout_name]}` in the Language widget.

Closes #90. 

This config:
```yml
widgets:
  language:
    type: 'yasb.language.LanguageWidget'
    options:
      label: "<span>\uf11c</span>{lang[language_code]}-{lang[country_code]}  {lang[layout_name]}"
```
will give this:
![image](https://github.com/user-attachments/assets/3854fd7d-db7a-4e2c-8681-9b6a9eb25bda)
