### PR TITLE
feat(systray): added systray widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ https://github.com/user-attachments/assets/aab8d8e8-248f-46a1-919c-9b0601236ac1
 - **[Notifications](https://github.com/amnweb/yasb/wiki/(Widget)-Notifications)**: Shows the number of notifications from Windows.
 - **[OBS](https://github.com/amnweb/yasb/wiki/(Widget)-Obs)**: Integrates with OBS Studio to show recording status.
 - **[Server Monitor](https://github.com/amnweb/yasb/wiki/(Widget)-Server-Monitor)**: Monitors server status.
+- **[Systray](https://github.com/amnweb/yasb/wiki/(Widget)-Systray)**: Displays system tray icons.
 - **[Traffic](https://github.com/amnweb/yasb/wiki/(Widget)-Traffic)**: Displays network traffic information.
 - **[Taskbar](https://github.com/amnweb/yasb/wiki/(Widget)-Taskbar)**: A customizable taskbar for launching applications.
 - **[Power Menu](https://github.com/amnweb/yasb/wiki/(Widget)-Power-Menu)**: A menu for power options.

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -27,6 +27,7 @@
     - [Notifications](./(Widget)-Notifications)
     - [OBS](./(Widget)-Obs)
     - [Server Monitor](./(Widget)-Server-Monitor)
+    - [Systray](./(Widget)-Systray)
     - [Traffic](./(Widget)-Traffic)
     - [Taskbar](./(Widget)-Taskbar)
     - [Power Menu](./(Widget)-Power-Menu)

--- a/docs/widgets/(Widget)-Systray.md
+++ b/docs/widgets/(Widget)-Systray.md
@@ -1,0 +1,108 @@
+# Systray Widget
+| Option               | Type    | Default     | Description                                                                             |
+|----------------------|---------|-------------|-----------------------------------------------------------------------------------------|
+| `class_name`         | string  | `'systray'` | The class name for the base widget.                                                     |
+| `label_collapsed`    | string  | `'▼'`       | Label used for the collapse button when unpinned container is hidden.                   |
+| `label_expanded`     | string  | `'▶'`       | Label used for the collapse button when unpinned container is shown.                    |
+| `label_position`     | string  | `'left'`    | The position of the button that collapses unpinned container. Can be "left" or "right". |
+| `icon_size`          | integer | `16`        | The size of the icons in the systray. Can be any integer between 8 and 64.              |
+| `pin_click_modifier` | string  | `'alt'`     | The modifier key used to pin/unpin icons. Can be "ctrl", "alt" or "shift".              |
+| `show_unpinned`      | boolean | `true`      | Whether to show unpinned container on startup.                                          |
+| `show_battery`       | boolean | `false`     | Whether to show battery icon (from the original systray).                               |
+| `show_volume`        | boolean | `false`     | Whether to show volume icon (from the original systray).                                |
+
+
+## Example Configuration
+```yaml
+systray:
+  type: "yasb.systray.SystrayWidget"
+  options:
+    class_name: "systray"
+    label_collapsed: "▼"
+    label_expanded: "▶"
+    label_position: "left" # Can be "left" or "right"
+    icon_size: 16 # Can be any integer between 8 and 64
+    pin_click_modifier: "alt" # Can be "ctrl", "alt" or "shift"
+    show_unpinned: true
+    show_battery: false
+    show_volume: false
+```
+
+## Important Notes:
+There are some limitations with the systray widget:
+- Systray widget will not show icons for apps if they ignore "TaskbarCreated" message. Meaning that if the original developers decided to ignore this message - their systray icons will not be shown. It's rare, but there are such cases (NVIDIA App for example). This is NOT a YASB bug.
+- In rare cases systray icon might ignore click events if the original application was already running before YASB was started. Example: Epic Games Launcher. No solution for this so far.
+
+## Description of Options
+- **class_name:** The class name for the base widget. Can be changed if multiple systray widgets need to have different styling.
+- **label_collapsed:** Label used for the collapse button when unpinned container is hidden.
+- **label_expanded:** Label used for the collapse button when unpinned container is shown.
+- **label_position:** The position of the button that collapses unpinned container.
+- **icon_size:** The size of the icons in the systray. Can be any integer between 8 and 64.
+- **pin_click_modifier:** The modifier key used to pin/unpin icons. Can be "ctrl", "alt" or "shift".
+- **show_unpinned:** Whether to show unpinned container on startup.
+- **show_battery:** Whether to show battery icon (from the original systray).
+- **show_volume:** Whether to show volume icon (from the original systray).
+
+## Style
+```css
+.systray {} /* The base widget style */
+.systray .unpinned-container {} /* Style for unpinned container */
+.systray .pinned-container {} /* Style for pinned container */
+.systray .pinned-container[forceshow=true] {} /* Style for pinned container when it is forced to show during dragging operation */
+.systray .button {} /* Style for the individual systray buttons/icons */
+.systray .button[dragging=true] {} /* Style for systray buttons/icons when dragging operation is in progress */
+.systray .unpinned-visibility-btn {} /* Style for the 'collapse unpinned icons' button */
+```
+
+## Example CSS
+```css
+.systray {
+    background: transparent;
+    border: None;
+    margin: 0;
+}
+
+.systray .unpinned-container {
+    background: darkblue;
+    border-radius: 8px;
+}
+
+.systray .pinned-container {
+    background: transparent;
+}
+
+.systray .pinned-container[forceshow=true] {
+    background: red;
+}
+
+.systray .button {
+    border-radius: 4px;
+    padding: 2px 2px;
+}
+
+.systray .button:hover {
+    background: #727272;
+}
+
+.systray .button[dragging=true] {
+    background: orange;
+    border-color: #FF8800;
+}
+
+.systray .unpinned-visibility-btn {
+    border-radius: 4px;
+    height: 20px;
+    width: 16px;
+}
+
+.systray .unpinned-visibility-btn:checked {
+    background: darkblue;
+}
+
+.systray .unpinned-visibility-btn:hover {
+    border: 1px solid #AAAAAA;
+    border-radius: 4px;
+    border-color: #AAAAAA;
+}
+```

--- a/src/core/tray.py
+++ b/src/core/tray.py
@@ -167,7 +167,6 @@ class TrayIcon(QSystemTrayIcon):
         Remove the tray icon from the system tray.
         """
         try:
-            self.hide()
             self.deleteLater()
         except Exception as e:
             logging.error(f"Error removing tray icon: {e}")

--- a/src/core/utils/systray/systray_widget.py
+++ b/src/core/utils/systray/systray_widget.py
@@ -1,0 +1,398 @@
+"""Systray container widget and systray icon widget"""
+
+import ctypes as ct
+from ctypes import byref
+from dataclasses import dataclass
+from typing import override
+
+from PyQt6.QtCore import QMimeData, QPoint, QSize, Qt, pyqtSignal
+from PyQt6.QtGui import QDrag, QDragEnterEvent, QDragLeaveEvent, QDragMoveEvent, QDropEvent, QIcon, QMouseEvent
+from PyQt6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QPushButton,
+    QWidget,
+)
+from win32con import (
+    WM_LBUTTONDBLCLK,
+    WM_LBUTTONDOWN,
+    WM_LBUTTONUP,
+    WM_MBUTTONDOWN,
+    WM_MBUTTONUP,
+    WM_RBUTTONDOWN,
+    WM_RBUTTONUP,
+)
+
+import core.utils.systray.utils as utils
+from core.utils.systray.tray_monitor import IconData
+from core.utils.systray.utils import pack_i32
+from core.utils.systray.win_types import (
+    NIN_CONTEXTMENU,
+    NIN_SELECT,
+)
+from core.utils.systray.win_wrappers import (
+    AllowSetForegroundWindow,
+    GetWindowThreadProcessId,
+    IsWindow,
+    SendNotifyMessage,
+)
+
+
+@dataclass
+class IconState:
+    is_pinned: bool = False
+    index: int = 0
+
+    @staticmethod
+    def from_dict(d: dict[str, str | bool | None]):
+        state = IconState()
+        state.is_pinned = bool(d["is_pinned"])
+        state.index = int(str(d["index"]))
+        return state
+
+
+class IconWidget(QPushButton):
+    pinned_changed = pyqtSignal(object)
+    icon_moved = pyqtSignal(object)
+    pin_modifier_key = Qt.KeyboardModifier.AltModifier
+    icon_size = 16
+
+    def __init__(self):
+        super().__init__()
+        self.data: IconData | None = None
+        self.last_cursor_pos = QPoint()
+        self.setProperty("class", "button")
+        self.setProperty("dragging", False)
+        self.setIconSize(QSize(self.icon_size, self.icon_size))
+        self.scaled_pixmap = None
+        self.is_pinned = False
+        self.lmb_pressed = False
+
+    def update_scaled_pixmap(self):
+        """Pre-compute the scaled pixmap."""
+        if self.data is not None and self.data.icon_image is not None:
+            self.scaled_pixmap = self.data.icon_image.scaled(16, 16, Qt.AspectRatioMode.KeepAspectRatio)
+        else:
+            self.scaled_pixmap = None
+
+    @override
+    def mousePressEvent(self, e: QMouseEvent | None) -> None:
+        if e is None:
+            return
+        mouse_button = e.button()
+        if mouse_button == Qt.MouseButton.LeftButton:
+            self.last_cursor_pos = e.pos()
+            if e.modifiers() & self.pin_modifier_key:
+                self.pinned_changed.emit(self)
+            else:
+                self.lmb_pressed = True
+                self.update_scaled_pixmap()
+        return super().mousePressEvent(e)
+
+    @override
+    def mouseMoveEvent(self, a0: QMouseEvent | None) -> None:
+        if a0 is None:
+            return super().mouseMoveEvent(a0)
+
+        # Only start drag if left mouse button is pressed and moved more than 10 pixels
+        if self.lmb_pressed and (a0.pos() - self.last_cursor_pos).manhattanLength() > 10:
+            drag = QDrag(self)
+            if self.scaled_pixmap is not None:
+                drag.setPixmap(self.scaled_pixmap)
+            mime_data = QMimeData()
+            mime_data.setText(self.text())
+            drag.setMimeData(mime_data)
+            drag.exec(Qt.DropAction.MoveAction)
+
+        return super().mouseMoveEvent(a0)
+
+    @override
+    def mouseReleaseEvent(self, e: QMouseEvent | None) -> None:
+        self.lmb_pressed = False
+        if e is None:
+            return super().mouseReleaseEvent(e)
+        btn = e.button()
+        if btn == Qt.MouseButton.LeftButton and (self.last_cursor_pos - e.pos()).manhattanLength() > 8:
+            return super().mouseReleaseEvent(e)
+        if btn == Qt.MouseButton.LeftButton:
+            self.send_action(WM_LBUTTONDOWN)
+            self.send_action(WM_LBUTTONUP)
+        elif btn == Qt.MouseButton.RightButton:
+            self.send_action(WM_RBUTTONDOWN)
+            self.send_action(WM_RBUTTONUP)
+        elif btn == Qt.MouseButton.MiddleButton:
+            self.send_action(WM_MBUTTONDOWN)
+            self.send_action(WM_MBUTTONUP)
+        return super().mouseReleaseEvent(e)
+
+    @override
+    def mouseDoubleClickEvent(self, a0: QMouseEvent | None) -> None:
+        self.send_action(WM_LBUTTONDBLCLK)
+        return super().mouseDoubleClickEvent(a0)
+
+    def send_action(self, action: int):
+        """Send a mouse action to the tray icon process"""
+        if self.data is None or not IsWindow(self.data.hWnd):
+            return
+
+        is_mouse_click = action in {
+            WM_LBUTTONDOWN,
+            WM_RBUTTONDOWN,
+            WM_MBUTTONDOWN,
+            WM_LBUTTONUP,
+            WM_RBUTTONUP,
+            WM_MBUTTONUP,
+            WM_LBUTTONDBLCLK,
+        }
+        if is_mouse_click:
+            process_id = ct.c_ulong(0)
+            GetWindowThreadProcessId(self.data.hWnd, byref(process_id))
+            AllowSetForegroundWindow(process_id.value)
+        self.send_notify_message(action)
+
+        if self.data.uVersion >= 3:
+            if action == WM_LBUTTONUP:
+                self.send_notify_message(NIN_SELECT)
+            elif action == WM_RBUTTONUP:
+                self.send_notify_message(NIN_CONTEXTMENU)
+            else:
+                return
+
+    def send_notify_message(self, message: int):
+        """Send a notify message to the tray icon process"""
+        if self.data is None or self.data.uCallbackMessage == 0:
+            return
+        if self.data.uVersion > 3:
+            cursor_pos = utils.cursor_position()
+            wparam = pack_i32(cursor_pos[0], cursor_pos[1])
+            lparam = pack_i32(message, self.data.uID)
+        else:
+            wparam = self.data.uID
+            lparam = pack_i32(message, 0)
+        # NOTE: Some icons (Epic Games Store) fail to receive the message if the app was already
+        # present before the system tray widget was created. No idea why.
+        SendNotifyMessage(self.data.hWnd, self.data.uCallbackMessage, wparam, lparam)
+
+    def update_icon(self):
+        """Update the icon and tooltip of the icon widget"""
+        if not self.data or self.data.hIcon == 0:
+            return
+        self.setToolTip(self.data.szTip or self.data.exe)
+        icon = self.data.icon_image
+        if icon:
+            self.setIcon(QIcon(icon))
+
+
+class DropWidget(QFrame):
+    drag_started = pyqtSignal()
+    drag_ended = pyqtSignal()
+
+    def __init__(self, parent: QWidget | None = None):
+        super().__init__(parent)
+        self.setAcceptDrops(True)
+
+        # Use a horizontal layout
+        self.main_layout = QHBoxLayout(self)
+        self.main_layout.setSpacing(0)
+        self.main_layout.setContentsMargins(0, 0, 0, 0)
+        self.setMaximumHeight(32)
+        self.setLayout(self.main_layout)
+
+        # Create the drop indicator but don't add it to the layout
+        self.drop_indicator = QFrame(self)
+        self.drop_indicator.setFixedSize(4, 32)
+        self.drop_indicator.setStyleSheet("background: #FF5500; border-radius: 2px;")
+        self.drop_indicator.hide()
+
+        # Track the dragged button
+        self.dragged_button: IconWidget | None = None
+
+        # Keep track of the indicator's position to avoid unnecessary updates
+        self.current_indicator_index = -1
+
+    @override
+    def dragEnterEvent(self, a0: QDragEnterEvent | None):
+        if a0 is None:
+            return
+
+        source = a0.source()
+        if isinstance(source, IconWidget):
+            self.dragged_button = source
+            self.dragged_button.setProperty("dragging", True)
+            self.refresh_styles()
+            a0.acceptProposedAction()
+
+            self.drag_started.emit()
+
+    @override
+    def dragMoveEvent(self, a0: QDragMoveEvent | None):
+        if a0 is None or not isinstance(a0.source(), IconWidget):
+            return
+
+        drop_position = a0.position().toPoint()
+        insert_index = self.get_insert_index(drop_position)
+
+        # Only update indicator if position has changed
+        if insert_index != self.current_indicator_index:
+            self.update_drop_indicator(insert_index)
+            self.current_indicator_index = insert_index
+
+        a0.acceptProposedAction()
+
+        self.drag_started.emit()
+
+    @override
+    def dragLeaveEvent(self, a0: QDragLeaveEvent | None):
+        if a0 is None:
+            return
+
+        self.hide_drop_indicator()
+
+        if self.dragged_button:
+            self.dragged_button.setProperty("dragging", False)
+            self.refresh_styles()
+            self.dragged_button = None
+
+        self.current_indicator_index = -1
+
+    @override
+    def dropEvent(self, a0: QDropEvent | None):
+        if a0 is None:
+            return
+
+        source = a0.source()
+        if not isinstance(source, IconWidget):
+            return
+
+        source.setProperty("dragging", False)
+        self.refresh_styles()
+        drop_position = a0.position().toPoint()
+        insert_index = self.get_insert_index(drop_position)
+
+        # Only move the button if it's coming from another parent or the position is different
+        button_current_index = -1
+        for i in range(self.main_layout.count()):
+            if (w := self.main_layout.itemAt(i)) and w.widget() == source:
+                button_current_index = i
+                break
+
+        # If the button is already in this layout
+        if source.parent() == self:
+            # If it would be placed at the same index or right after itself, do nothing
+            if insert_index == button_current_index or insert_index == button_current_index + 1:
+                self.hide_drop_indicator()
+                a0.acceptProposedAction()
+                self.drag_ended.emit()
+                return
+
+            # Adjust index if moving within the same parent and to a later position
+            if button_current_index != -1 and insert_index > button_current_index:
+                insert_index -= 1
+
+            # Remove it from its current position
+            self.main_layout.removeWidget(source)
+        else:
+            # Set this as the new parent
+            source.setParent(self)
+
+        # Insert at the new position
+        self.main_layout.insertWidget(insert_index, source)
+
+        # Show the button and update styles
+        source.show()
+        self.refresh_styles()
+
+        # Hide the indicator and reset tracking
+        self.hide_drop_indicator()
+        self.dragged_button = None
+        self.current_indicator_index = -1
+
+        a0.acceptProposedAction()
+
+        self.drag_ended.emit()
+
+        source.icon_moved.emit(source)
+
+    def get_insert_index(self, drop_position: QPoint) -> int:
+        """
+        Find the position in the layout to insert the button
+        """
+        # If there are no items, insert at the beginning
+        if self.main_layout.count() == 0:
+            return 0
+
+        # Calculate insertion position based on mouse position relative to widgets
+        for i in range(self.main_layout.count()):
+            item = self.main_layout.itemAt(i)
+            if not item or not item.widget():
+                continue
+
+            widget = item.widget()
+            if not widget:
+                continue
+            widget_center = widget.geometry().center().x()
+
+            # If mouse is to the left of this widget's center, insert before it
+            if drop_position.x() < widget_center:
+                return i
+
+        # If we get here, insert at the end
+        return self.main_layout.count()
+
+    def update_drop_indicator(self, index: int):
+        """
+        Update the drop indicator's position without removing/re-adding it to the layout.
+        """
+        self.drop_indicator.show()
+
+        # Calculate the position for the indicator
+        if self.main_layout.count() == 0:
+            # If empty, position in the middle
+            x = self.rect().center().x()
+            self.drop_indicator.move(
+                x - self.drop_indicator.width() // 2,
+                (self.height() - self.drop_indicator.height()) // 2,
+            )
+        elif index >= self.main_layout.count():
+            # Position after the last widget
+            item = self.main_layout.itemAt(self.main_layout.count() - 1)
+            if not item:
+                return
+            last_widget = item.widget()
+            if last_widget:
+                x = last_widget.geometry().right() + self.main_layout.spacing() // 2
+                self.drop_indicator.move(
+                    x - self.drop_indicator.width() // 2,
+                    (self.height() - self.drop_indicator.height()) // 2,
+                )
+        else:
+            # Position before the widget at the current index
+            item = self.main_layout.itemAt(index)
+            if not item:
+                return
+            widget = item.widget()
+            if widget:
+                x = widget.geometry().left() - self.main_layout.spacing() // 2
+                self.drop_indicator.move(
+                    x - self.drop_indicator.width() // 2,
+                    (self.height() - self.drop_indicator.height()) // 2,
+                )
+
+    def hide_drop_indicator(self):
+        """
+        Hide the drop indicator without affecting the layout.
+        """
+        self.drop_indicator.hide()
+        self.current_indicator_index = -1
+
+    def refresh_styles(self):
+        """
+        Refresh styles for the widget and dragged button.
+        """
+        if style := self.style():
+            style.unpolish(self)
+            style.polish(self)
+
+        if self.dragged_button and (style := self.dragged_button.style()):
+            style.unpolish(self.dragged_button)
+            style.polish(self.dragged_button)

--- a/src/core/utils/systray/tray_monitor.py
+++ b/src/core/utils/systray/tray_monitor.py
@@ -1,0 +1,314 @@
+"""Systray tray monitor client that intercepts systray messages"""
+
+import atexit
+import logging
+from ctypes import (
+    POINTER,
+    byref,
+    cast,
+    windll,
+)
+from ctypes.wintypes import MSG
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import UUID
+
+from PIL import Image
+from PIL.ImageFilter import SHARPEN
+from PIL.ImageQt import ImageQt
+from PyQt6.QtCore import QObject, pyqtSignal
+from PyQt6.QtGui import QPixmap
+from win32con import (
+    CW_USEDEFAULT,
+    HWND_BROADCAST,
+    HWND_TOPMOST,
+    SWP_NOACTIVATE,
+    SWP_NOMOVE,
+    SWP_NOSIZE,
+    WM_ACTIVATEAPP,
+    WM_CLOSE,
+    WM_COMMAND,
+    WM_COPYDATA,
+    WM_DESTROY,
+    WM_TIMER,
+    WM_USER,
+    WS_EX_APPWINDOW,
+    WS_EX_TOOLWINDOW,
+    WS_EX_TOPMOST,
+    WS_OVERLAPPEDWINDOW,
+)
+
+import core.utils.systray.utils as utils
+from core.utils.systray.utils import (
+    array_to_str,
+    get_exe_path_from_hwnd,
+    hicon_to_image,
+    pack_i32,
+)
+from core.utils.systray.win_types import (
+    COPYDATASTRUCT,
+    NIF_GUID,
+    NIF_ICON,
+    NIF_INFO,
+    NIF_MESSAGE,
+    NIF_STATE,
+    NIF_TIP,
+    NIM_ADD,
+    NIM_DELETE,
+    NIM_MODIFY,
+    NIM_SETVERSION,
+    NOTIFYICONDATA,
+    SHELLTRAYDATA,
+    WINNOTIFYICONIDENTIFIER,
+    WNDCLASS,
+    WNDPROC,
+)
+from core.utils.systray.win_wrappers import (
+    CreateWindowEx,
+    DefWindowProc,
+    DestroyWindow,
+    FindWindow,
+    FindWindowEx,
+    PostMessage,
+    RegisterWindowMessage,
+    SendMessage,
+    SendNotifyMessage,
+    SetTimer,
+    SetWindowPos,
+)
+from settings import DEBUG
+
+logger = logging.getLogger("systray_widget")
+
+if DEBUG:
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.CRITICAL)
+
+# Load necessary Windows functions
+user32 = windll.user32
+gdi32 = windll.gdi32
+kernel32 = windll.kernel32
+
+
+@dataclass
+class IconData:
+    """Data class for validated systray icon data"""
+
+    message_type: int = 0
+    hWnd: int = 0
+    uID: int = 0
+    guid: UUID | None = None
+    uFlags: int = 0
+    dwState: int = 0
+    dwStateMask: int = 0
+    hIcon: int = 0
+    szTip: str = ""
+    szInfo: str = ""
+    szInfoTitle: str = ""
+    dwInfoFlags: int = 0
+    uTimeout: int = 0
+    uCallbackMessage: int = 0
+    uVersion: int = 0
+    icon_image: QPixmap | None = None
+    exe: str = ""
+    exe_path: str = ""
+
+
+class TrayMonitor(QObject):
+    """Main class to handle systray message interception and forwarding"""
+
+    icon_modified = pyqtSignal(object)
+    icon_deleted = pyqtSignal(object)
+
+    def __init__(self, parent: QObject | None = None):
+        super().__init__(parent)
+        self.hwnd: int = 0
+        self.wc: WNDCLASS | None = None
+        atexit.register(self.destroy)
+
+    def run(self):
+        # Register the window class
+        wnd_class_name = "Shell_TrayWnd"
+        self.wc = WNDCLASS()
+        self.wc.lpfnWndProc = WNDPROC(self._window_proc)
+        self.wc.hInstance = kernel32.GetModuleHandleW(None)
+        self.wc.lpszClassName = wnd_class_name
+
+        if not user32.RegisterClassW(byref(self.wc)):
+            logger.debug("Window registration failed")
+            return
+
+        # Create the window
+        self.hwnd = CreateWindowEx(
+            WS_EX_TOOLWINDOW | WS_EX_APPWINDOW | WS_EX_TOPMOST,
+            wnd_class_name,
+            wnd_class_name,
+            WS_OVERLAPPEDWINDOW,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            None,
+            None,
+            self.wc.hInstance,
+            None,
+        )
+
+        if not self.hwnd:
+            logger.critical("Window creation failed")
+            return
+
+        # Set the window as the foreground window
+        SetWindowPos(self.hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE)
+
+        # Set a timer to keep the window as a foreground window to keep receiving messages
+        SetTimer(self.hwnd, 1, 100, None)
+
+        # Run the message loop
+        msg = MSG()
+        while user32.GetMessageW(byref(msg), None, 0, 0) > 0:
+            user32.TranslateMessage(byref(msg))
+            user32.DispatchMessageW(byref(msg))
+
+    def __del__(self):
+        """Ensure proper cleanup"""
+        self.destroy()
+
+    def destroy(self):
+        """Clean up window and unregister class"""
+        if self.hwnd != 0:
+            logger.debug(f"Destroying window {self.hwnd}")
+            PostMessage(self.hwnd, WM_CLOSE, 0, 0)
+            self.hwnd = 0
+
+    def send_taskbar_created(self):
+        """Send the taskbar created message to the Windows"""
+        # Register the window to receive the TaskbarCreated message
+        taskbar_created_msg = RegisterWindowMessage("TaskbarCreated")
+        logger.debug(f"Registered for TaskbarCreated message: {taskbar_created_msg}")
+        # Send the "taskbar created" message to the window
+        SendNotifyMessage(HWND_BROADCAST, taskbar_created_msg, 0, 0)
+
+    def _window_proc(self, hwnd: int, uMsg: int, wParam: int, lParam: int) -> int:
+        """Main window procedure for handling window messages"""
+        if uMsg == WM_CLOSE:
+            logger.debug(f"WM_CLOSE received, destroying window {hwnd}")
+            DestroyWindow(hwnd)
+            return 0
+        elif uMsg == WM_DESTROY:
+            logger.debug(f"WM_DESTROY received for window {hwnd}")
+            user32.PostQuitMessage(0)
+            return 0
+        elif uMsg == WM_TIMER:
+            # We need to set our window topmost to have the priority over the native system tray
+            SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE)
+            return 0
+        elif uMsg == WM_COPYDATA:
+            return self.handle_copy_data(hwnd, uMsg, wParam, lParam)
+        else:
+            if uMsg in {WM_COPYDATA, WM_ACTIVATEAPP, WM_COMMAND} or uMsg >= WM_USER:
+                return self.forward_message(hwnd, uMsg, wParam, lParam)
+            else:
+                return DefWindowProc(hwnd, uMsg, wParam, lParam)
+
+    def handle_copy_data(self, hwnd: int, uMsg: int, wParam: int, lParam: int) -> int:
+        """Handles the WM_COPYDATA message"""
+        copy_data = cast(lParam, POINTER(COPYDATASTRUCT)).contents
+        if copy_data.cbData == 0:
+            return 0
+        if copy_data.dwData == 1:
+            tray_message = cast(copy_data.lpData, POINTER(SHELLTRAYDATA)).contents
+            icon_data: NOTIFYICONDATA = tray_message.icon_data
+            if tray_message.message_type in {NIM_ADD, NIM_MODIFY, NIM_SETVERSION}:
+                validated_data = self.validate_icon_data(icon_data)
+                validated_data.message_type = tray_message.message_type
+                self.icon_modified.emit(validated_data)
+            elif tray_message.message_type == NIM_DELETE:
+                self.icon_deleted.emit(
+                    IconData(
+                        hWnd=icon_data.hWnd,
+                        uID=icon_data.uID,
+                        guid=icon_data.guidItem.to_uuid() if icon_data.uFlags & NIF_GUID else None,
+                    )
+                )
+            return self.forward_message(hwnd, uMsg, wParam, lParam)
+        elif copy_data.dwData == 3 and copy_data.lpData:
+            icon_identifier = cast(copy_data.lpData, POINTER(WINNOTIFYICONIDENTIFIER)).contents
+            cursor_pos = utils.cursor_position()
+            left = cursor_pos[0]
+            top = cursor_pos[1] + 1
+            right = cursor_pos[0] + 1
+            bottom = cursor_pos[1] - 1
+            if icon_identifier.message == 1:
+                return pack_i32(left, top)
+            elif icon_identifier.message == 2:
+                return pack_i32(right, bottom)
+            else:
+                return 0
+        else:
+            return self.forward_message(hwnd, uMsg, wParam, lParam)
+
+    def forward_message(self, hwnd: int, uMsg: int, wParam: int, lParam: int):
+        """Forward messages to real tray window"""
+        real_tray = self.find_tray_window(hwnd)
+        if not real_tray:
+            logger.critical("Could not find the real systray window")
+            return DefWindowProc(hwnd, uMsg, wParam, lParam)
+        if uMsg > WM_USER:
+            PostMessage(real_tray, uMsg, wParam, lParam)
+            return DefWindowProc(hwnd, uMsg, wParam, lParam)
+        else:
+            return SendMessage(real_tray, uMsg, wParam, lParam)
+
+    def find_tray_window(self, hwnd_ignore: int) -> int:
+        """Find the real tray window to forward messages to"""
+        taskbar_hwnd = FindWindow("Shell_TrayWnd", None)
+        if taskbar_hwnd != 0:
+            while taskbar_hwnd == hwnd_ignore:
+                taskbar_hwnd = FindWindowEx(0, taskbar_hwnd, "Shell_TrayWnd", None)
+        return taskbar_hwnd
+
+    def validate_icon_data(self, data: NOTIFYICONDATA) -> IconData:
+        """Validates and processes raw icon data"""
+        icon_data = IconData()
+        icon_data.hWnd = data.hWnd
+        icon_data.uID = data.uID
+        icon_data.uFlags = data.uFlags
+
+        exe_path = get_exe_path_from_hwnd(icon_data.hWnd)
+        if exe_path is not None:
+            icon_data.exe_path = exe_path
+            icon_data.exe = Path(exe_path).name.split(".")[0] if exe_path else ""
+
+        if 0 < data.anonymous.uVersion <= 4:
+            icon_data.uVersion = data.anonymous.uVersion
+
+        if data.uFlags & NIF_MESSAGE:
+            icon_data.uCallbackMessage = data.uCallbackMessage
+
+        if data.uFlags & NIF_ICON:
+            icon_data.hIcon = data.hIcon
+            icon_image = hicon_to_image(icon_data.hIcon)
+            if icon_image is not None:
+                if icon_image.size != (32, 32):  # Ensure we have consistent icon sizes
+                    icon_image = icon_image.resize((32, 32), Image.Resampling.LANCZOS).filter(SHARPEN)  # pyright: ignore [reportUnknownMemberType]
+                icon_image = QPixmap.fromImage(ImageQt(icon_image))
+            icon_data.icon_image = icon_image
+
+        if data.uFlags & NIF_TIP:
+            icon_data.szTip = array_to_str(data.szTip)
+
+        if data.uFlags & NIF_STATE:
+            icon_data.dwState = data.dwState
+            icon_data.dwStateMask = data.dwStateMask
+
+        if data.uFlags & NIF_GUID:
+            icon_data.guid = data.guidItem.to_uuid()
+
+        if data.uFlags & NIF_INFO:
+            icon_data.dwInfoFlags = data.dwInfoFlags
+            icon_data.szInfoTitle = array_to_str(data.szInfoTitle)
+            icon_data.szInfo = array_to_str(data.szInfo)
+
+        return icon_data

--- a/src/core/utils/systray/utils.py
+++ b/src/core/utils/systray/utils.py
@@ -1,0 +1,201 @@
+"""Utils for systray widget"""
+
+from __future__ import annotations
+
+import ctypes as ct
+import logging
+import struct
+from ctypes import byref, create_string_buffer, sizeof, windll
+from ctypes.wintypes import (
+    BOOL,
+    DWORD,
+    HANDLE,
+    HBITMAP,
+    HDC,
+    HICON,
+    LPVOID,
+    POINT,
+)
+from enum import Enum
+
+from PIL import Image
+from win32con import DIB_RGB_COLORS
+
+from core.utils.systray.win_types import BITMAP, BITMAPINFO, BITMAPINFOHEADER, ICONINFO
+from core.utils.systray.win_wrappers import (
+    CloseHandle,
+    GetWindowThreadProcessId,
+    OpenProcess,
+    QueryFullProcessImageNameW,
+)
+
+user32 = windll.user32
+gdi32 = windll.gdi32
+
+
+class MESSAGE_TYPE(Enum):
+    NIM_ADD = 0x0
+    NIM_MODIFY = 0x1
+    NIM_DELETE = 0x2
+    NIM_SETFOCUS = 0x3
+    NIM_SETVERSION = 0x4
+
+
+def cursor_position():
+    point = POINT()
+    user32.GetCursorPos(byref(point))
+    return point.x, point.y
+
+
+def pack_i32(low: int, high: int) -> int:
+    """Pack two 16-bit signed integers into a 32-bit integer."""
+    high = ct.c_short(high).value  # Ensure sign extension
+    return ct.c_long((low & 0xFFFF) | (high << 16)).value
+
+
+def get_exe_path_from_hwnd(hwnd: int) -> str | None:
+    # Get process ID from window handle
+    process_id = ct.c_ulong(0)
+    GetWindowThreadProcessId(hwnd, ct.byref(process_id))
+
+    # Open process to get module handle
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    h_process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, process_id.value)
+    if not h_process:
+        logging.debug("Could not open process with PID %d", process_id.value)
+        return None
+
+    try:
+        # Get process image file name
+        buffer_size = ct.c_ulong(1024)
+        buffer = ct.create_unicode_buffer(buffer_size.value)
+        if QueryFullProcessImageNameW(h_process, 0, buffer, ct.byref(buffer_size)):
+            return buffer.value
+    finally:
+        CloseHandle(h_process)
+
+    return None
+
+
+def array_to_str(array: bytes) -> str:
+    null_pos = next((i for i, c in enumerate(array) if c == 0), len(array))
+    return "".join(chr(c) for c in array[:null_pos]).replace("\r", "")
+
+
+def hicon_to_image(hicon: int) -> Image.Image | None:
+    user32.GetIconInfo.argtypes = [HICON, ct.POINTER(ICONINFO)]
+    user32.GetIconInfo.restype = BOOL
+
+    gdi32.GetObjectW.argtypes = [HANDLE, ct.c_int, LPVOID]
+    gdi32.GetObjectW.restype = ct.c_int
+
+    user32.GetDC.argtypes = [HANDLE]
+    user32.GetDC.restype = HDC
+
+    gdi32.GetDIBits.argtypes = [HDC, HBITMAP, DWORD, DWORD, LPVOID, ct.POINTER(BITMAPINFO), DWORD]
+    gdi32.GetDIBits.restype = ct.c_int
+
+    user32.ReleaseDC.argtypes = [HANDLE, HDC]
+    user32.ReleaseDC.restype = ct.c_int
+
+    gdi32.DeleteObject.argtypes = [HANDLE]
+    gdi32.DeleteObject.restype = BOOL
+
+    # Get icon info
+    icon_info = ICONINFO()
+    if not user32.GetIconInfo(hicon, byref(icon_info)):
+        logging.error("GetIconInfo failed: %s", hicon)
+        return None
+
+    # Get bitmap info
+    bitmap = BITMAP()
+    result = gdi32.GetObjectW(icon_info.hbmColor, sizeof(BITMAP), byref(bitmap))
+
+    if result == 0:
+        gdi32.DeleteObject(icon_info.hbmMask)
+        gdi32.DeleteObject(icon_info.hbmColor)
+        logging.error("GetObjectW failed")
+        return None
+
+    width, height = bitmap.bmWidth, bitmap.bmHeight
+    buffer_size = width * height * 4
+
+    # Create buffers for the bitmap data
+    color_buffer = create_string_buffer(buffer_size)
+    mask_buffer = create_string_buffer(buffer_size)
+
+    # Get DC
+    hdc = user32.GetDC(None)
+    if hdc == 0:
+        gdi32.DeleteObject(icon_info.hbmMask)
+        gdi32.DeleteObject(icon_info.hbmColor)
+        logging.error("GetDC failed")
+        return None
+
+    # Create bitmap info
+    bi = BITMAPINFO()
+    bi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER)
+    bi.bmiHeader.biWidth = width
+    bi.bmiHeader.biHeight = -abs(height)
+    bi.bmiHeader.biPlanes = 1
+    bi.bmiHeader.biBitCount = 32
+
+    # Get color bitmap data
+    color_result = gdi32.GetDIBits(
+        hdc,
+        icon_info.hbmColor,
+        0,
+        height,
+        byref(color_buffer),
+        byref(bi),
+        DIB_RGB_COLORS,
+    )
+
+    # Get mask bitmap data
+    mask_result = gdi32.GetDIBits(
+        hdc,
+        icon_info.hbmMask,
+        0,
+        height,
+        byref(mask_buffer),
+        byref(bi),
+        DIB_RGB_COLORS,
+    )
+
+    # Release DC and delete objects
+    user32.ReleaseDC(None, hdc)
+    gdi32.DeleteObject(icon_info.hbmColor)
+    gdi32.DeleteObject(icon_info.hbmMask)
+
+    if color_result == 0 or mask_result == 0:
+        logging.error("GetDIBits failed")
+        return None
+
+    # Convert buffer to bytes
+    color_bytes = color_buffer.raw
+    mask_bytes = mask_buffer.raw
+
+    # Check if icon is mask-based
+    is_mask_based = all(b == 0 for _, _, _, b in struct.iter_unpack("BBBB", color_bytes))
+
+    # Process pixel data
+    img_data = bytearray(buffer_size)
+    color_view = memoryview(color_bytes)
+    mask_view = memoryview(mask_bytes)
+
+    for i in range(0, buffer_size, 4):
+        # Get mask alpha
+        mask_alpha = mask_view[i]
+
+        # Unpack pixel (BGR + A)
+        b, g, r, a = color_view[i : i + 4]
+
+        # Adjust alpha if mask-based
+        if is_mask_based:
+            a = 0 if mask_alpha == 255 else 255
+
+        # Store as RGBA (BGR to RGB)
+        img_data[i : i + 4] = bytes((r, g, b, a))
+
+    # Create PIL Image
+    return Image.frombuffer("RGBA", (width, height), bytes(img_data), "raw", "RGBA", 0, 1)

--- a/src/core/utils/systray/win_types.py
+++ b/src/core/utils/systray/win_types.py
@@ -1,0 +1,199 @@
+"""Winapi types, structs and constants"""
+
+import ctypes as ct
+import uuid
+from ctypes import WINFUNCTYPE
+from ctypes.wintypes import (
+    BOOL,
+    BYTE,
+    DWORD,
+    HANDLE,
+    HBITMAP,
+    HBRUSH,
+    HICON,
+    HINSTANCE,
+    HWND,
+    INT,
+    LONG,
+    LPARAM,
+    LPCWSTR,
+    LPVOID,
+    UINT,
+    ULONG,
+    USHORT,
+    WORD,
+    WPARAM,
+)
+
+NIM_ADD = 0x0
+NIM_MODIFY = 0x1
+NIM_DELETE = 0x2
+NIM_SETFOCUS = 0x3
+NIM_SETVERSION = 0x4
+
+NIF_MESSAGE = 0x1
+NIF_ICON = 0x2
+NIF_TIP = 0x4
+NIF_STATE = 0x8
+NIF_INFO = 0x10
+NIF_GUID = 0x20
+NIF_REALTIME = 0x40
+NIF_SHOWTIP = 0x80
+
+NIN_POPUPOPEN = 0x406
+NIN_POPUPCLOSE = 0x407
+NIN_SELECT = 0x400
+NIN_CONTEXTMENU = 0x7B
+
+# Define the WNDPROC type
+WNDPROC = WINFUNCTYPE(LPARAM, HWND, UINT, WPARAM, LPARAM)
+
+
+# Set up the WNDCLASSEX structure
+class WNDCLASS(ct.Structure):
+    _fields_ = [
+        ("style", UINT),
+        ("lpfnWndProc", WNDPROC),
+        ("cbClsExtra", INT),
+        ("cbWndExtra", INT),
+        ("hInstance", HINSTANCE),
+        ("hIcon", HICON),
+        ("hCursor", HANDLE),
+        ("hbrBackground", HBRUSH),
+        ("lpszMenuName", LPCWSTR),
+        ("lpszClassName", LPCWSTR),
+    ]
+
+
+class COPYDATASTRUCT(ct.Structure):
+    _fields_ = [
+        ("dwData", ct.c_uint64),
+        ("cbData", ct.c_uint64),
+        ("lpData", ct.c_void_p),
+    ]
+
+
+class GUID(ct.Structure):
+    _fields_ = [
+        ("Data1", ULONG),
+        ("Data2", USHORT),
+        ("Data3", USHORT),
+        ("Data4", ct.c_ubyte * 8),
+    ]
+
+    def to_uuid(self):
+        # fmt: off
+        return uuid.UUID(
+            bytes=(
+                self.Data1.to_bytes(4) +
+                self.Data2.to_bytes(2) +
+                self.Data3.to_bytes(2) +
+                bytes(self.Data4)
+            )
+        )
+        # fmt: on
+
+    def __str__(self):
+        return (
+            f"{self.Data1:08X}-{self.Data2:04X}-{self.Data3:04X}-"
+            + f"{''.join(f'{b:02X}' for b in self.Data4[:2])}-"
+            + f"{''.join(f'{b:02X}' for b in self.Data4[2:])}"
+        ).lower()
+
+
+class NOFITYICONDATA_0(ct.Union):
+    _fields_ = [
+        ("uTimeout", ct.c_uint32),
+        ("uVersion", ct.c_uint32),
+    ]
+
+
+class NOTIFYICONDATA(ct.Structure):
+    _fields_ = [
+        ("cbSize", ct.c_uint32),
+        ("hWnd", ct.c_uint32),
+        ("uID", ct.c_uint32),
+        ("uFlags", ct.c_uint32),
+        ("uCallbackMessage", ct.c_uint32),
+        ("hIcon", ct.c_uint32),
+        ("szTip", ct.c_uint16 * 128),
+        ("dwState", ct.c_uint32),
+        ("dwStateMask", ct.c_uint32),
+        ("szInfo", ct.c_uint16 * 256),
+        ("anonymous", NOFITYICONDATA_0),
+        ("szInfoTitle", ct.c_uint16 * 64),
+        ("dwInfoFlags", ct.c_uint32),
+        ("guidItem", GUID),
+        ("hBalloonIcon", ct.c_uint32),
+    ]
+
+
+class SHELLTRAYDATA(ct.Structure):
+    _fields_ = [
+        ("magic_number", ct.c_int32),
+        ("message_type", ct.c_uint32),
+        ("icon_data", NOTIFYICONDATA),
+    ]
+
+
+class WINNOTIFYICONIDENTIFIER(ct.Structure):
+    _fields_ = [
+        ("magic_number", ct.c_int32),
+        ("message", ct.c_int32),
+        ("callback_size", ct.c_int32),
+        ("padding", ct.c_int32),
+        ("window_handle", ct.c_uint32),
+        ("uid", ct.c_uint32),
+        ("guid_item", GUID),
+    ]
+
+
+class ICONINFO(ct.Structure):
+    _fields_ = [
+        ("fIcon", BOOL),
+        ("xHotspot", DWORD),
+        ("yHotspot", DWORD),
+        ("hbmMask", HBITMAP),
+        ("hbmColor", HBITMAP),
+    ]
+
+
+class BITMAP(ct.Structure):
+    _fields_ = [
+        ("bmType", LONG),
+        ("bmWidth", LONG),
+        ("bmHeight", LONG),
+        ("bmWidthBytes", LONG),
+        ("bmPlanes", WORD),
+        ("bmBitsPixel", WORD),
+        ("bmBits", LPVOID),
+    ]
+
+
+class BITMAPINFOHEADER(ct.Structure):
+    _fields_ = [
+        ("biSize", DWORD),
+        ("biWidth", LONG),
+        ("biHeight", LONG),
+        ("biPlanes", WORD),
+        ("biBitCount", WORD),
+        ("biCompression", DWORD),
+        ("biSizeImage", DWORD),
+        ("biXPelsPerMeter", LONG),
+        ("biYPelsPerMeter", LONG),
+        ("biClrUsed", DWORD),
+        ("biClrImportant", DWORD),
+    ]
+
+
+class RGBQUAD(ct.Structure):
+    _fields_ = [
+        ("rgbBlue", BYTE),
+        ("rgbGreen", BYTE),
+        ("rgbRed", BYTE),
+        ("rgbReserved", BYTE),
+    ]
+
+
+class BITMAPINFO(ct.Structure):
+    _fields_ = [("bmiHeader", BITMAPINFOHEADER), ("bmiColors", RGBQUAD * 1)]

--- a/src/core/utils/systray/win_wrappers.py
+++ b/src/core/utils/systray/win_wrappers.py
@@ -1,0 +1,202 @@
+"""Wrappers for windows API functions to make them easier to use and have proper types"""
+
+import ctypes as ct
+from ctypes import (
+    Array,
+    c_int,
+    c_long,
+    c_wchar,
+    windll,
+)
+from ctypes.wintypes import (
+    BOOL,
+    DWORD,
+    HANDLE,
+    HMENU,
+    HWND,
+    INT,
+    LPARAM,
+    LPCWSTR,
+    LPDWORD,
+    LPVOID,
+    LPWSTR,
+    UINT,
+    WPARAM,
+)
+
+# Load necessary Windows functions
+user32 = windll.user32
+gdi32 = windll.gdi32
+kernel32 = windll.kernel32
+
+
+def DefWindowProc(hwnd: int, uMsg: int, wParam: int, lParam: int) -> int:
+    user32.DefWindowProcW.argtypes = [HWND, UINT, WPARAM, LPARAM]
+    user32.DefWindowProcW.restype = c_long
+    return user32.DefWindowProcW(hwnd, uMsg, wParam, lParam)
+
+
+def CreateWindowEx(
+    dwExStyle: int,
+    lpClassName: str | None,
+    lpWindowName: str | None,
+    dwStyle: int,
+    x: int,
+    y: int,
+    nWidth: int,
+    nHeight: int,
+    hWndParent: int | None,
+    hMenu: int | None,
+    hInstance: int | None,
+    lpParam: int | None,
+):
+    user32.CreateWindowExW.argtypes = [
+        DWORD,
+        LPCWSTR,
+        LPCWSTR,
+        DWORD,
+        INT,
+        INT,
+        INT,
+        INT,
+        HWND,
+        HMENU,
+        WPARAM,
+        LPVOID,
+    ]
+    user32.CreateWindowExW.restype = HWND
+    return user32.CreateWindowExW(
+        dwExStyle,
+        lpClassName,
+        lpWindowName,
+        dwStyle,
+        x,
+        y,
+        nWidth,
+        nHeight,
+        hWndParent,
+        hMenu,
+        hInstance,
+        lpParam,
+    )
+
+
+def SetWindowPos(
+    hwnd: int,
+    hWndInsertAfter: int,
+    x: int,
+    y: int,
+    cx: int,
+    cy: int,
+    uFlags: int,
+):
+    user32.SetWindowPos.restype = c_int
+    user32.SetWindowPos.argtypes = [
+        HWND,
+        HWND,
+        INT,
+        INT,
+        INT,
+        INT,
+        UINT,
+    ]
+    return user32.SetWindowPos(hwnd, hWndInsertAfter, x, y, cx, cy, uFlags)
+
+
+def DestroyWindow(hwnd: int):
+    user32.DestroyWindow.restype = c_int
+    user32.DestroyWindow.argtypes = [HWND]
+    return user32.DestroyWindow(hwnd)
+
+
+def RegisterWindowMessage(lpString: str):
+    user32.RegisterWindowMessageW.restype = UINT
+    user32.RegisterWindowMessageW.argtypes = [LPCWSTR]
+    return user32.RegisterWindowMessageW(lpString)
+
+
+def SendNotifyMessage(hwnd: int, msg: int, wParam: int, lParam: int) -> int:
+    user32.SendNotifyMessageW.restype = c_int
+    user32.SendNotifyMessageW.argtypes = [HWND, UINT, WPARAM, LPARAM]
+    return user32.SendNotifyMessageW(hwnd, msg, wParam, lParam)
+
+
+def PostMessage(hwnd: int, msg: int, wParam: int, lParam: int) -> int:
+    user32.PostMessageW.restype = c_int
+    user32.PostMessageW.argtypes = [HWND, UINT, WPARAM, LPARAM]
+    return user32.PostMessageW(hwnd, msg, wParam, lParam)
+
+
+def SetTimer(hwnd: int, nIDEvent: int, uElapse: int, lpTimerFunc: LPVOID | None):
+    user32.SetTimer.restype = c_int
+    user32.SetTimer.argtypes = [HWND, UINT, UINT, LPVOID]
+    return user32.SetTimer(hwnd, nIDEvent, uElapse, lpTimerFunc)
+
+
+def FindWindow(lpClassName: str | None, lpWindowName: str | None):
+    user32.FindWindowW.restype = HWND
+    user32.FindWindowW.argtypes = [LPCWSTR, LPCWSTR]
+    return user32.FindWindowW(lpClassName, lpWindowName)
+
+
+def FindWindowEx(
+    hwndParent: int,
+    hwndChildAfter: int,
+    lpszClass: str | None,
+    lpszWindow: str | None,
+):
+    user32.FindWindowExW.restype = HWND
+    user32.FindWindowExW.argtypes = [HWND, HWND, LPCWSTR, LPCWSTR]
+    return user32.FindWindowExW(hwndParent, hwndChildAfter, lpszClass, lpszWindow)
+
+
+def SendMessage(
+    hwnd: int,
+    msg: int,
+    wParam: int,
+    lParam: int,
+) -> int:
+    user32.SendMessageW.restype = c_int
+    user32.SendMessageW.argtypes = [HWND, UINT, WPARAM, LPARAM]
+    return user32.SendMessageW(hwnd, msg, wParam, lParam)
+
+
+def IsWindow(hwnd: int) -> BOOL:
+    user32.IsWindow.restype = BOOL
+    user32.IsWindow.argtypes = [HWND]
+    return user32.IsWindow(hwnd)
+
+
+def GetWindowThreadProcessId(hwnd: int, lpdwProcessId: "ct._CArgObject") -> int:  # pyright: ignore [reportPrivateUsage]
+    user32.GetWindowThreadProcessId.restype = DWORD
+    user32.GetWindowThreadProcessId.argtypes = [HWND, LPDWORD]
+    return user32.GetWindowThreadProcessId(hwnd, lpdwProcessId)
+
+
+def AllowSetForegroundWindow(dwProcessId: int) -> int:
+    user32.AllowSetForegroundWindow.restype = BOOL
+    user32.AllowSetForegroundWindow.argtypes = [DWORD]
+    return user32.AllowSetForegroundWindow(dwProcessId)
+
+
+def OpenProcess(dwDesiredAccess: int, bInheritHandle: bool, dwProcessId: int) -> int:
+    kernel32.OpenProcess.restype = HANDLE
+    kernel32.OpenProcess.argtypes = [DWORD, BOOL, DWORD]
+    return kernel32.OpenProcess(dwDesiredAccess, bInheritHandle, dwProcessId)
+
+
+def QueryFullProcessImageNameW(
+    hProcess: int,
+    dwFlags: int,
+    lpExeName: Array[c_wchar],
+    lpdwSize: "ct._CArgObject",  # pyright: ignore [reportPrivateUsage]
+) -> int:
+    kernel32.QueryFullProcessImageNameW.restype = BOOL
+    kernel32.QueryFullProcessImageNameW.argtypes = [HANDLE, DWORD, LPWSTR, LPDWORD]
+    return kernel32.QueryFullProcessImageNameW(hProcess, dwFlags, lpExeName, lpdwSize)
+
+
+def CloseHandle(hObject: int):
+    kernel32.CloseHandle.restype = BOOL
+    kernel32.CloseHandle.argtypes = [HANDLE]
+    return kernel32.CloseHandle(hObject)

--- a/src/core/validation/widgets/yasb/systray.py
+++ b/src/core/validation/widgets/yasb/systray.py
@@ -1,0 +1,61 @@
+DEFAULTS = {
+    "class_name": "systray",
+    "label_collapsed": "▼",
+    "label_expanded": "▶",
+    "label_position": "left",
+    "icon_size": 16,
+    "pin_click_modifier": "alt",
+    "show_unpinned": True,
+    "show_battery": False,
+    "show_volume": False,
+}
+
+VALIDATION_SCHEMA = {
+    "class_name": {
+        "type": "string",
+        "required": False,
+        "default": DEFAULTS["class_name"],
+    },
+    "label_collapsed": {
+        "type": "string",
+        "required": False,
+        "default": DEFAULTS["label_collapsed"],
+    },
+    "label_expanded": {
+        "type": "string",
+        "required": False,
+        "default": DEFAULTS["label_expanded"],
+    },
+    "label_position": {
+        "type": "string",
+        "required": False,
+        "default": DEFAULTS["label_position"],
+    },
+    "icon_size": {
+        "type": "integer",
+        "required": False,
+        "default": DEFAULTS["icon_size"],
+        "min": 8,
+        "max": 64,
+    },
+    "pin_click_modifier": {
+        "type": "string",
+        "required": False,
+        "default": DEFAULTS["pin_click_modifier"],
+    },
+    "show_unpinned": {
+        "type": "boolean",
+        "required": False,
+        "default": DEFAULTS["show_unpinned"],
+    },
+    "show_battery": {
+        "type": "boolean",
+        "required": False,
+        "default": DEFAULTS["show_battery"],
+    },
+    "show_volume": {
+        "type": "boolean",
+        "required": False,
+        "default": DEFAULTS["show_volume"],
+    },
+}

--- a/src/core/widgets/yasb/systray.py
+++ b/src/core/widgets/yasb/systray.py
@@ -1,0 +1,463 @@
+import json
+import logging
+import os
+import re
+import threading
+from pathlib import Path
+from typing import Any, override
+from uuid import UUID
+
+from PyQt6.QtCore import Qt, QThread, QTimer, pyqtSlot  # pyright: ignore [reportUnknownVariableType]
+from PyQt6.QtGui import QGuiApplication, QShowEvent
+from PyQt6.QtWidgets import (
+    QApplication,
+    QHBoxLayout,
+    QLayout,
+    QPushButton,
+)
+
+from core.utils.systray.systray_widget import DropWidget, IconState, IconWidget
+from core.utils.systray.tray_monitor import IconData, TrayMonitor
+from core.utils.systray.win_types import (
+    NIF_GUID,
+    NIF_ICON,
+    NIF_INFO,
+    NIF_MESSAGE,
+    NIF_STATE,
+    NIF_TIP,
+)
+from core.utils.systray.win_wrappers import IsWindow
+from core.validation.widgets.yasb.systray import VALIDATION_SCHEMA
+from core.widgets.base import BaseWidget
+from settings import DEBUG
+
+logger = logging.getLogger("systray_widget")
+
+if DEBUG:
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.CRITICAL)
+
+LOCALDATA_FOLDER = Path(os.environ["LOCALAPPDATA"]) / "Yasb"
+
+BATTERY_ICON_GUID = UUID("7820ae75-23e3-4229-82c1-e41cb67d5b9c")
+VOLUME_ICON_GUID = UUID("7820ae73-23e3-4229-82c1-e41cb67d5b9c")
+
+
+class TrayMonitorThread(QThread):
+    """Separate thread to run TrayMonitorClient"""
+
+    def __init__(self, client: TrayMonitor):
+        super().__init__()
+        self.client = client
+
+    @override
+    def run(self):
+        threading.current_thread().name = "TrayMonitorThread"
+        logger.debug("TrayMonitorThread started")
+        self.client.run()
+
+
+class SystrayWidget(BaseWidget):
+    validation_schema: dict[str, dict[str, str | bool | int]] = VALIDATION_SCHEMA
+    _instance = None
+    _thread = None
+
+    @classmethod
+    def get_client_instance(cls):
+        """
+        Since we don't want multiple systray monitors,
+        as they will just bounce messages between each other and cause issues,
+        we create a single instance of the TrayMonitor and use it for all widgets.
+        """
+        if cls._instance is None:
+            cls._instance = TrayMonitor()
+            cls._thread = TrayMonitorThread(cls._instance)
+            cls._thread.start()
+
+        return cls._instance
+
+    def __init__(
+        self,
+        class_name: str,
+        label_collapsed: str,
+        label_expanded: str,
+        label_position: str,
+        icon_size: int,
+        pin_click_modifier: str,
+        show_unpinned: bool,
+        show_battery: bool,
+        show_volume: bool,
+    ):
+        super().__init__(class_name=class_name)  # pyright: ignore [reportArgumentType]
+        self.label_collapsed = label_collapsed
+        self.label_expanded = label_expanded
+        self.label_position = label_position if label_position in {"left", "right"} else "left"
+        self.icon_size = icon_size
+        self.show_volume = show_volume
+        self.show_battery = show_battery
+        self.show_unpinned = show_unpinned
+
+        self.filtered_guids: set[UUID] = set()
+        if not self.show_battery:
+            self.filtered_guids.add(BATTERY_ICON_GUID)
+        if not self.show_volume:
+            self.filtered_guids.add(VOLUME_ICON_GUID)
+
+        IconWidget.icon_size = icon_size
+        IconWidget.pin_modifier_key = {
+            "ctrl": Qt.KeyboardModifier.ControlModifier,
+            "alt": Qt.KeyboardModifier.AltModifier,
+            "shift": Qt.KeyboardModifier.ShiftModifier,
+        }.get(pin_click_modifier.lower(), Qt.KeyboardModifier.AltModifier)
+
+        self.icons: list[IconWidget] = []
+        self.current_state: dict[str, IconState] = {}
+        self.screen_id: str | None = None
+
+        # This timer will check if icons are still valid and have actual process attached
+        self.icon_check_timer = QTimer(self)
+        self.icon_check_timer.timeout.connect(self.check_icons)  # pyright: ignore [reportUnknownMemberType]
+        self.icon_check_timer.start(5000)
+
+        self.sort_timer = QTimer(self)
+        self.sort_timer.timeout.connect(self.sort_icons)  # pyright: ignore [reportUnknownMemberType]
+        self.sort_timer.setSingleShot(True)
+
+        self.unpinned_vis_btn = QPushButton()
+        self.unpinned_vis_btn.setCheckable(True)
+        self.unpinned_vis_btn.clicked.connect(self.toggle_unpinned_widget_visibility)  # pyright: ignore [reportUnknownMemberType]
+
+        self.unpinned_widget = DropWidget(self)
+        self.unpinned_layout = self.unpinned_widget.main_layout
+
+        self.pinned_widget = DropWidget(self)
+        self.pinned_widget.setMinimumWidth(16)
+        self.pinned_layout = self.pinned_widget.main_layout
+
+        self.pinned_widget.setProperty("class", "pinned-container")
+        self.pinned_widget.setProperty("forceshow", False)
+        self.unpinned_widget.setProperty("class", "unpinned-container")
+        self.unpinned_vis_btn.setProperty("class", "unpinned-visibility-btn")
+
+        self.unpinned_widget.drag_started.connect(self.on_drag_started)  # pyright: ignore [reportUnknownMemberType]
+        self.unpinned_widget.drag_ended.connect(self.on_drag_ended)  # pyright: ignore [reportUnknownMemberType]
+        self.pinned_widget.drag_started.connect(self.on_drag_started)  # pyright: ignore [reportUnknownMemberType]
+        self.pinned_widget.drag_ended.connect(self.on_drag_ended)  # pyright: ignore [reportUnknownMemberType]
+
+        self.widget_layout.addWidget(self.unpinned_widget)
+        self.widget_layout.addWidget(self.pinned_widget)
+
+        if self.label_position == "left":
+            self.widget_layout.insertWidget(0, self.unpinned_vis_btn)
+        else:
+            self.widget_layout.insertWidget(-1, self.unpinned_vis_btn)
+
+        # Delay the client setup for a bit just to give YASB tray icon some time to init
+        init_timer = QTimer(self)
+        init_timer.setSingleShot(True)
+        init_timer.timeout.connect(self.setup_client)  # pyright: ignore [reportUnknownMemberType]
+        init_timer.start(3000)
+
+    def setup_client(self):
+        """Setup the tray monitor client and connect signals"""
+        client = SystrayWidget.get_client_instance()
+        client.icon_modified.connect(self.on_icon_modified)  # pyright: ignore [reportUnknownMemberType]
+        client.icon_deleted.connect(self.on_icon_deleted)  # pyright: ignore [reportUnknownMemberType]
+
+        app_inst = QApplication.instance()
+        if app_inst is not None:
+            app_inst.aboutToQuit.connect(self.save_state)  # pyright: ignore [reportUnknownMemberType]
+
+        # We need to send this message for each instance of the taskbar widget on init
+        client.send_taskbar_created()
+
+    @override
+    def showEvent(self, a0: QShowEvent | None) -> None:
+        """Called when the widget is shown on the screen"""
+        super().showEvent(a0)
+        self.get_screen_id()
+        self.load_state()
+        self.unpinned_vis_btn.setChecked(self.show_unpinned)
+        self.unpinned_vis_btn.setText(self.label_expanded if self.show_unpinned else self.label_collapsed)
+        self.unpinned_widget.setVisible(self.show_unpinned)
+
+    @pyqtSlot()  # pyright: ignore [reportUntypedFunctionDecorator]
+    def on_drag_started(self):
+        """Handle drag started signal for drag-and-drop functionality"""
+        # Always show pinned widget during drag operations
+        self.update_pinned_widget_visibility(force_show=True)
+
+    @pyqtSlot()  # pyright: ignore [reportUntypedFunctionDecorator]
+    def on_drag_ended(self):
+        """Handle drag ended signal for drag-and-drop functionality"""
+        # Update visibility based on content
+        self.update_pinned_widget_visibility()
+
+    @pyqtSlot(IconData)  # pyright: ignore [reportUntypedFunctionDecorator]
+    def on_icon_modified(self, data: IconData):
+        """Handle icon modified signal sent by the tray monitor"""
+        if data.guid in self.filtered_guids:
+            return
+        icon = self.find_icon(data.guid, data.hWnd, data.uID)
+        if icon is None:
+            icon = IconWidget()
+            icon.data = IconData()
+            icon.pinned_changed.connect(self.on_icon_pinned_changed)  # pyright: ignore [reportUnknownMemberType]
+            icon.icon_moved.connect(self.on_icon_moved)  # pyright: ignore [reportUnknownMemberType]
+            self.icons.append(icon)
+
+            # Check if the saved data exists for the icon by uuid and exe path
+            id = str(data.guid) if data.guid is not None else data.exe_path
+            saved_data = self.current_state.get(
+                id,
+                self.current_state.get(
+                    data.exe_path,
+                    IconState(index=-1, is_pinned=False),
+                ),
+            )
+
+            # Place the new icon in the correct layout and index
+            icon.is_pinned = saved_data.is_pinned
+            if saved_data.is_pinned:
+                self.pinned_layout.addWidget(icon)
+            else:
+                self.unpinned_layout.addWidget(icon)
+
+            # After a short delay (if no new icons are added) - re-sort the icons once
+            self.sort_timer.start(1000)
+        self.update_icon_data(icon.data, data)
+        icon.update_icon()
+        icon.setHidden(data.uFlags & NIF_STATE != 0 and data.dwState == 1)
+        self.update_pinned_widget_visibility()
+
+    @pyqtSlot(IconData)  # pyright: ignore [reportUntypedFunctionDecorator]
+    def on_icon_deleted(self, data: IconData):
+        """Handles the icon deleted signal sent by the tray monitor"""
+        icon = self.find_icon(data.guid, data.hWnd, data.uID)
+        if icon is not None:
+            self.icons.remove(icon)
+            icon.deleteLater()
+            self.update_pinned_widget_visibility()
+
+    @pyqtSlot(object)  # pyright: ignore [reportUntypedFunctionDecorator]
+    def on_icon_pinned_changed(self, icon: IconWidget):
+        """Handles the icon pinned changed signal sent when user [Mod]+Clicks on the icon"""
+        if icon.parent() is self.unpinned_widget:
+            self.pinned_layout.addWidget(icon)
+            icon.is_pinned = True
+        else:
+            self.unpinned_layout.addWidget(icon)
+            icon.is_pinned = False
+        # NOTE: This is needed to force-update the layout for that widget
+        # otherwise, the widget will not show up in the layout immediately
+        # and update_current_state will fail
+        icon.show()
+        self.unpinned_widget.refresh_styles()
+        self.pinned_widget.refresh_styles()
+        self.save_state()
+        self.update_pinned_widget_visibility()
+
+    @pyqtSlot(object)  # pyright: ignore [reportUntypedFunctionDecorator]
+    def on_icon_moved(self, icon: IconWidget):
+        """Handle icon moved signal"""
+        if icon.parent() is self.unpinned_widget:
+            icon.is_pinned = False
+        else:
+            icon.is_pinned = True
+        self.unpinned_widget.refresh_styles()
+        self.pinned_widget.refresh_styles()
+        self.save_state()
+
+    def find_icon(self, uuid: UUID | None, hwnd: int, uID: int) -> IconWidget | None:
+        """Find an icon by its uuid or hwnd and uID"""
+        if uuid is not None:
+            for icon in self.icons:
+                if icon.data is None or icon.data.guid is None:
+                    continue
+                if icon.data.guid == uuid:
+                    return icon
+        for icon in self.icons:
+            if icon.data is None:
+                continue
+            if icon.data.hWnd == hwnd and icon.data.uID == uID:
+                return icon
+
+    def check_icons(self):
+        """Check if any icons are still valid and have actual process attached"""
+        icons_changed = False
+        for icon in self.icons[:]:
+            if icon.data is not None and not IsWindow(icon.data.hWnd):
+                self.icons.remove(icon)
+                icon.deleteLater()
+                icons_changed = True
+
+        if icons_changed:
+            self.update_pinned_widget_visibility()
+
+    def update_icon_data(self, old_data: IconData | None, new_data: IconData):
+        """Update the icon data with the new data received from the tray monitor"""
+        if old_data is None:
+            return
+
+        direct_attributes = [
+            "message_type",
+            "hWnd",
+            "uID",
+            "uFlags",
+            "icon_image",
+            "exe",
+            "exe_path",
+        ]
+        for attr in direct_attributes:
+            setattr(old_data, attr, getattr(new_data, attr))
+
+        if 0 < new_data.uVersion <= 4:
+            old_data.uVersion = new_data.uVersion
+
+        flag_dependent_attrs = {
+            NIF_MESSAGE: ["uCallbackMessage"],
+            NIF_ICON: ["hIcon"],
+            NIF_TIP: ["szTip"],
+            NIF_STATE: ["dwState", "dwStateMask"],
+            NIF_GUID: ["guid"],
+            NIF_INFO: ["dwInfoFlags", "szInfoTitle", "szInfo", "uTimeout"],
+        }
+
+        for flag, attrs in flag_dependent_attrs.items():
+            if new_data.uFlags & flag:
+                for attr in attrs:
+                    setattr(old_data, attr, getattr(new_data, attr))
+
+    def is_layout_empty(self, layout: QHBoxLayout):
+        """Check if a layout has any visible widgets."""
+        for i in range(layout.count()):
+            item = layout.itemAt(i)
+            if item and (w := item.widget()) and not w.isHidden():
+                return False
+        return True
+
+    def update_pinned_widget_visibility(self, force_show: bool = False):
+        """
+        Update the visibility of the pinned widget based on its content.
+        If force_show is True, the widget will be shown regardless of content.
+        """
+        is_empty = self.is_layout_empty(self.pinned_layout)
+        self.pinned_widget.setVisible(not is_empty or force_show)
+        if force_show and is_empty and (w := self.pinned_widget.style()):
+            logger.debug(f"Is empty: {is_empty}, force show: {force_show}")
+            self.pinned_widget.setProperty("forceshow", True)
+            w.unpolish(self.pinned_widget)
+            w.polish(self.pinned_widget)
+        elif self.pinned_widget.property("forceshow") and not is_empty and (w := self.pinned_widget.style()):
+            logger.debug(f"Is empty: {is_empty}, force show: {force_show}")
+            self.pinned_widget.setProperty("forceshow", False)
+            w.unpolish(self.pinned_widget)
+            w.polish(self.pinned_widget)
+
+    def toggle_unpinned_widget_visibility(self):
+        """On button click, toggle the visibility of the unpinned widget."""
+        if self.unpinned_vis_btn.isChecked():
+            self.unpinned_widget.setVisible(True)
+            self.unpinned_vis_btn.setText(self.label_expanded)
+        else:
+            self.unpinned_widget.setVisible(False)
+            self.unpinned_vis_btn.setText(self.label_collapsed)
+
+    def sort_icons(self):
+        """Sorts pinned and unpinned widgets based on their state index"""
+        logger.debug("Re-sorting widgets")
+        unpinned = self.get_widgets_from_layout(self.unpinned_layout)
+        pinned = self.get_widgets_from_layout(self.pinned_layout)
+
+        def get_sort_index(widget: IconWidget):
+            if widget.data is None:
+                return 9999
+            if widget.data.guid is not None:
+                index = self.current_state.get(str(widget.data.guid))
+            else:
+                index = self.current_state.get(widget.data.exe_path)
+            return index.index if index is not None else 9999
+
+        unpinned.sort(key=get_sort_index)
+        pinned.sort(key=get_sort_index)
+        for w in unpinned:
+            self.unpinned_layout.insertWidget(unpinned.index(w), w)
+        for w in pinned:
+            self.pinned_layout.insertWidget(pinned.index(w), w)
+        self.update_current_state()
+
+    def update_current_state(self):
+        logger.debug("Updating current state")
+        widgets_state: dict[str, Any] = {}
+        for w in self.icons:
+            if w.data is None or w.isHidden():
+                continue
+            index = self.unpinned_layout.indexOf(w)
+            if index == -1:
+                index = self.pinned_layout.indexOf(w)
+            uuid = None if w.data.guid is None else str(w.data.guid)
+            widgets_state[uuid or w.data.exe_path] = IconState(
+                is_pinned=w.is_pinned,
+                index=index,
+            )
+        self.current_state = widgets_state
+
+    def save_state(self):
+        """Save the current icon position and pinned state to disk."""
+        self.update_current_state()
+        logger.debug("Saving state to disk")
+        if not LOCALDATA_FOLDER.exists():
+            LOCALDATA_FOLDER.mkdir(parents=True, exist_ok=True)
+
+        file_path = LOCALDATA_FOLDER / Path(f"systray_state_{self.screen_id}.json")
+        logger.debug(f"Saving state to {file_path}")
+        saved_state: dict[str, Any] = {}
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                saved_state = json.load(f)
+        except json.JSONDecodeError:
+            logger.debug("State file decode error. Ignoring.")
+        except FileNotFoundError:
+            logger.debug("State file not found.")
+        # Merging the saved state with current state before saving it to disk
+        new_state = saved_state | {k: v.__dict__ for k, v in self.current_state.items()}
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(json.dumps(new_state, indent=2))
+
+    def load_state(self):
+        """Load the saved icon position and pinned state from disk."""
+        logger.debug("Loading state from disk")
+        file_path = LOCALDATA_FOLDER / Path(f"systray_state_{self.screen_id}.json")
+        logger.debug(f"Loading state from {file_path}")
+        self.current_state = {}
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                state = json.load(f)
+                for k, v in state.items():
+                    self.current_state[k] = IconState.from_dict(v)
+        except json.JSONDecodeError:
+            logger.debug("State file decode error. Ignoring.")
+        except FileNotFoundError:
+            logger.debug("State file not found.")
+
+    def get_screen_id(self):
+        """Get the screen id for the current systray widget instance"""
+        window_handle = self.windowHandle()
+        if window_handle is not None:
+            screen = window_handle.screen()
+        else:
+            screen = QGuiApplication.primaryScreen()
+        if screen is not None:
+            raw_id = f"{screen.manufacturer()}{screen.name()}{screen.serialNumber()}".upper()
+            self.screen_id = re.sub(r"\W+", "", raw_id)
+            return self.screen_id
+
+    def get_widgets_from_layout(self, layout: QLayout) -> list[IconWidget]:
+        """Get all the widgets from a layout."""
+        widgets: list[IconWidget] = []
+        for i in range(layout.count()):
+            item = layout.itemAt(i)
+            if item is not None and (w := item.widget()) and isinstance(w, IconWidget):
+                widgets.append(w)
+        return widgets


### PR DESCRIPTION
A system tray widget that works similar to the original Windows systray.

**Functionality:**
- Shows the system tray icons that can be pinned into a separate container and the unpinned icons can be hidden using the collapse toggle button (by default on the left of the widget).
- Pinning can be done in two ways:
  - by holding a modifier key (alt by default) + LMB click.
  - by dragging and dropping the icon to the pinned container.
- Icons can be repositioned by dragging and dropping.
- Icons positions and pinned/unpinned state will be saved automatically and restored on the next YASB launch.
- If system tray widget is added to multiple monitors - each monitor will have its separate icon position and pinned/unpinned saved state. It's NOT shared between systray widgets.

**Known limitations:**
- Systray widget will not show icons for apps if they ignore "TaskbarCreated" message. Meaning that if the original developers decided to ignore this message - their systray icons will not be shown. It's rare, but there are such cases (NVIDIA App for example). This is NOT a YASB bug.
- In rare cases systray icon might ignore click events if the original application was already running before YASB was started. Example: Epic Games Launcher. No solution for this so far.

**Some technical stuff:**
It works by creating a process that intercepts the messages meant for the real systray, extracting all the data it needs (icon, tooltip, callback, etc.) and forwarding those messages to the original system tray to not interrupt its functionality.
The main trick here is to create a window that has the exact same class name as the original system tray and set it as topmost to get the messages priority. It needs to reset its "topmost" state every 100ms so that Windows keeps sending messages to it.
When the window gets the WM_COPYDATA message, this message will contain all the necessary data for a fully functional systray icon: icon handle, original window handle, callback for clicks, etc.

**Example config:**
```yaml
systray:
  type: "yasb.systray.SystrayWidget"
  options:
    class_name: "systray"
    label_collapsed: "▼"
    label_expanded: "▶"
    label_position: "left"
    icon_size: 16
    pin_click_modifier: "alt"
    show_unpinned: false
    show_battery: false
    show_volume: true
```

**Example CSS:**
```css
.systray {
    background: transparent;
    border: None;
    margin: 0;
}

.systray .unpinned-container {
    background: darkblue;
    border-radius: 8px;
}

.systray .pinned-container {
    background: transparent;
}

.systray .pinned-container[forceshow=true] {
    background: red;
}

.systray .button {
    border-radius: 4px;
    padding: 2px 2px;
}

.systray .button:hover {
    background: #727272;
}

.systray .button[dragging=true] {
    background: orange;
    border-color: #FF8800;
}

.systray .unpinned-visibility-btn {
    border-radius: 4px;
    height: 20px;
    width: 16px;
}

.systray .unpinned-visibility-btn:checked {
    background: darkblue;
}

.systray .unpinned-visibility-btn:hover {
    border: 1px solid #AAAAAA;
    border-radius: 4px;
    border-color: #AAAAAA;
}
```

**Special thanks:**
Special thanks to [Zebar](https://github.com/glzr-io/zebar) team and especially @lars-berger and @HolbyFPV for their fantastic systray-util rust crate. It would have been much harder to implement the Python version without their work. And of course the [Managed Shell](https://github.com/cairoshell/ManagedShell) team for the original idea of intercepting systray messages.