### PR TITLE
Improved taskbar and active_window icon rendering

### DIFF
--- a/src/core/utils/win32/app_icons.py
+++ b/src/core/utils/win32/app_icons.py
@@ -7,6 +7,7 @@ import win32con
 import win32api
 import ctypes
 import ctypes.wintypes
+from core.utils.systray.utils import hicon_to_image
 from core.utils.win32.app_uwp import get_package
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -35,6 +36,10 @@ def get_window_icon(hwnd, smooth_level = 0):
                 hicon = win32gui.GetClassLong(hwnd, win32con.GCL_HICON)
 
         if hicon:
+            img = hicon_to_image(hicon)
+            if img is not None:
+                return img
+
             hdc_handle = win32gui.GetDC(0)
             if not hdc_handle:
                 raise Exception("Failed to get DC handle")


### PR DESCRIPTION
This PR attempts to draw taskbar and active window icons using the same method as systray. It vastly improves icons quality and solves problems rendering icons of some apps (e.g. 7-zip).

Probably needs testing with HiDPI / different scaling.

Before:
![image](https://github.com/user-attachments/assets/8437c186-6b54-4622-ad99-b6cdf04738a2)

After:
![image](https://github.com/user-attachments/assets/76327633-0ee9-4b2d-bc7c-0a215685eb01)
