### PR TITLE
feat(media): add session switching functionality

### DIFF
--- a/src/core/utils/win32/media.py
+++ b/src/core/utils/win32/media.py
@@ -1,4 +1,3 @@
-import ctypes
 import logging
 from settings import DEBUG 
 from typing import Any, Callable
@@ -11,7 +10,6 @@ from PIL import Image, ImageFile
 import io
 
 from core.utils.utilities import Singleton
-from core.utils.win32.system_function import KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP
 
 from winsdk.windows.media.control import (GlobalSystemMediaTransportControlsSessionManager as SessionManager,
                                           GlobalSystemMediaTransportControlsSession as Session,

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -6,6 +6,7 @@ from PIL.ImageDraw import ImageDraw
 from PIL.ImageQt import QPixmap
 from PyQt6 import QtCore
 from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QWheelEvent
 from PIL.ImageQt import ImageQt
 from winsdk.windows.media.control import GlobalSystemMediaTransportControlsSessionPlaybackInfo
 
@@ -193,6 +194,11 @@ class MediaWidget(BaseWidget):
         if not self._show_thumbnail:
             return
 
+        # If no media in session, hide thumbnail and stop here
+        if media_info['thumbnail'] is None and not media_info['title']:
+            self._thumbnail_label.hide()
+            return
+
         # Only update the thumbnail if the title/artist changes or if we did a toggle (resize)
         try:
             if media_info['thumbnail'] is not None:
@@ -248,16 +254,21 @@ class MediaWidget(BaseWidget):
             return label
 
     def _create_media_buttons(self):
-        return (self._create_media_button(self._media_button_icons['prev_track'], WindowsMedia.prev),
-                self._create_media_button(
-            self._media_button_icons['play'], WindowsMedia.play_pause), self._create_media_button(
-            self._media_button_icons['next_track'], WindowsMedia.next))
+        return (self._create_media_button(self._media_button_icons['prev_track'], WindowsMedia().prev),
+                self._create_media_button(self._media_button_icons['play'], WindowsMedia().play_pause),
+                self._create_media_button( self._media_button_icons['next_track'], WindowsMedia().next))
 
     def execute_code(self, func):
         try:
             func()
         except Exception as e:
             logging.error(f"Error executing code: {e}")
+
+    def wheelEvent(self, event: QWheelEvent):
+        if event.angleDelta().y() > 0:
+            self.media.switch_session(+1) # Next
+        elif event.angleDelta().y() < 0:
+            self.media.switch_session(-1) # Prev
             
 class ClickableLabel(QLabel):
     def __init__(self, parent=None):


### PR DESCRIPTION
This pull request adds session switching functionality to the media widget, addressing #139.
Using scroll wheel on the media widget, sessions can be switched.
- Scroll down = Next session
- Scroll up = Previous session

#### Changes:
* Added `_current_session_only` decorator to ensure session update functions are called only if the session is the same as the current session.
* Added session switching logic with `switch_session` method and updated `play_pause`, `prev`, and `next` methods to use the current session.
* Added logic to hide the thumbnail if there is no media in the session in `_on_media_properties_changed`.
* Implemented `wheelEvent` to switch media sessions using the mouse wheel.

#### Demo:
Following is a demo of the media widget handling 3 sessions:
1. Apple Music
2. Spotify
3. YT Music (Browser)

https://github.com/user-attachments/assets/7e8a80ab-4bb7-4ff6-9539-10d1e6f0e73d

