### PR TITLE
docs: update wifi widget wiki

### DIFF
--- a/docs/widgets/(Widget)-WiFi.md
+++ b/docs/widgets/(Widget)-WiFi.md
@@ -6,6 +6,7 @@
 | `label_alt`   | string  | `"{wifi_name} {wifi_strength}%"`  | The alternative label format for the WiFi widget. |
 | `update_interval` | integer  | `1000`   | Update interval in milliseconds.  |
 | `wifi_icons`  | list    | `[ "\udb82\udd2e", "\udb82\udd1f", "\udb82\udd22", "\udb82\udd25", "\udb82\udd28" ]`   | Icons for different WiFi signal strengths.    |
+| `ethernet_icon` | string | "\ueba9" | The icon to indicate Ethernet connection. |
 | `callbacks`   | dict    | `{ 'on_left': 'next_layout', 'on_middle': 'toggle_monocle', 'on_right': 'prev_layout' }` | Callbacks for mouse events on the widget.    |
 | `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
 | `container_padding`  | dict | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}`      | Explicitly set padding inside widget container.      |
@@ -23,6 +24,7 @@ wifi:
       on_left: "exec cmd.exe /c start ms-settings:network"
       on_middle: "do_nothing"
       on_right: "toggle_label"
+    ethernet_icon: "\ueba9"
     wifi_icons: [
       "\udb82\udd2e",  # Icon for 0% strength
       "\udb82\udd1f",  # Icon for 1-20% strength
@@ -36,6 +38,7 @@ wifi:
 - **label:** The format string for the active window title. You can use placeholders like `{win[title]}` to dynamically insert window information. Default is `"{icon}"`.
 - **label_alt:** The format string for the active window title when the widget is in the alternative state. Default is `"{wifi_name} {wifi_strength}%"`.
 - **update_interval:** The interval in milliseconds at which the widget updates. Default is `1000`.
+- ethernet_icon: The icon that indicates an active Ethernet connection. Default is "\ueba9".
 - **wifi_icons:** A list of icons to use for different WiFi signal strengths. Default is `["\udb82\udd2e","\udb82\udd1f","\udb82\udd22","\udb82\udd25","\udb82\udd28",]`.
 - **callbacks:** A dictionary of callbacks for mouse events on the widget. Default is `{'on_left': 'toggle_label', 'on_middle': 'do_nothing', 'on_right': 'do_nothing'}`.
 - **animation:** A dictionary specifying the animation settings for the widget. It contains three keys: `enabled`, `type`, and `duration`. The `type` can be `fadeInOut` and the `duration` is the animation duration in milliseconds.

--- a/docs/widgets/(Widget)-WiFi.md
+++ b/docs/widgets/(Widget)-WiFi.md
@@ -27,10 +27,10 @@ wifi:
     ethernet_icon: "\ueba9"
     wifi_icons: [
       "\udb82\udd2e",  # Icon for 0% strength
-      "\udb82\udd1f",  # Icon for 1-20% strength
-      "\udb82\udd22",  # Icon for 21-40% strength
-      "\udb82\udd25",  # Icon for 41-80% strength
-      "\udb82\udd28"   # Icon for 81-100% strength
+      "\udb82\udd1f",  # Icon for 1-24% strength
+      "\udb82\udd22",  # Icon for 25-49% strength
+      "\udb82\udd25",  # Icon for 50-74% strength
+      "\udb82\udd28"   # Icon for 75-100% strength
     ]
 ```
 

--- a/docs/widgets/(Widget)-WiFi.md
+++ b/docs/widgets/(Widget)-WiFi.md
@@ -38,7 +38,7 @@ wifi:
 - **label:** The format string for the active window title. You can use placeholders like `{win[title]}` to dynamically insert window information. Default is `"{icon}"`.
 - **label_alt:** The format string for the active window title when the widget is in the alternative state. Default is `"{wifi_name} {wifi_strength}%"`.
 - **update_interval:** The interval in milliseconds at which the widget updates. Default is `1000`.
-- ethernet_icon: The icon that indicates an active Ethernet connection. Default is "\ueba9".
+- **ethernet_icon**: The icon that indicates an active Ethernet connection. It will be used as `{wifi_icon}` whenever there's no active WiFi connection. Default is "\ueba9".
 - **wifi_icons:** A list of icons to use for different WiFi signal strengths. Default is `["\udb82\udd2e","\udb82\udd1f","\udb82\udd22","\udb82\udd25","\udb82\udd28",]`.
 - **callbacks:** A dictionary of callbacks for mouse events on the widget. Default is `{'on_left': 'toggle_label', 'on_middle': 'do_nothing', 'on_right': 'do_nothing'}`.
 - **animation:** A dictionary specifying the animation settings for the widget. It contains three keys: `enabled`, `type`, and `duration`. The `type` can be `fadeInOut` and the `duration` is the animation duration in milliseconds.


### PR DESCRIPTION
Add missing info about the `ethernet_icon`.

Source: https://github.com/amnweb/yasb/blob/393054dc1db199c516e10800076e92eb98a58f09/src/core/validation/widgets/yasb/wifi.py#L17

While at it, also update the signal strength info.

Source:
https://github.com/amnweb/yasb/blob/393054dc1db199c516e10800076e92eb98a58f09/src/core/validation/widgets/yasb/wifi.py#L12