### PR TITLE
feat(systray): systray expand/collapse right click menu

### DIFF
--- a/docs/widgets/(Widget)-Systray.md
+++ b/docs/widgets/(Widget)-Systray.md
@@ -50,6 +50,9 @@ There are some limitations with the systray widget:
 - **show_volume:** Whether to show volume icon (from the original systray).
 - **show_network:** Whether to show network icon (from the original systray).
 
+## Debug Options
+Show unpinned button has a right click menu that allows you to refresh the systray icons.
+
 ## Style
 ```css
 .systray {} /* The base widget style */


### PR DESCRIPTION
Systray expand/collapse button now has a right click menu to refresh the systray icons.
This allows to send a "TaskbarCreated" message to Windows without restarting YASB.
**Mostly a debug option**, but might be useful if for some reason some icons got stuck or not added.
Might be removed in the future when systray widget is more robust.

https://github.com/user-attachments/assets/5ccd840b-36e2-43ce-89b8-732e046863cf

