### PR TITLE
docs: update installation instructions using python

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -19,6 +19,7 @@ winget install --id AmN.yasb
 
 ### Using Python
 - Install Python 3.12
+- Install Visual Studio with Individual Components `Windows SDK` and `MSVC build tools`
 - Install required Python Modules:
   - `pip install -r requirements.txt`
   - Create the directory `C:/Users/{username}/.config/yasb/` and copy [styles.css](https://github.com/amnweb/yasb/blob/main/src/styles.css) and [config.yaml](https://github.com/amnweb/yasb/blob/main/src/config.yaml) into folder. If you don't have the `.config/yasb/` directory, on first run the application will create it for you. To use a custom directory, set the `YASB_CONFIG_HOME` environment variable.


### PR DESCRIPTION
Hey there,
I was trying to set up my development environment to develop some features for YASB and was following the instructions in the [wiki](https://github.com/amnweb/yasb/wiki/Installation#using-python), however I was constantly failing to install the requirements. After some research I found out, that the `winsdk` module requires Visual Studio installed together with 2 Individual Components, in my case `Windows 11 SDK` and `MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)`. Only after that did the `pip install -r requirements.txt` work. So I decided it would be nice to include that info in the wiki.
What are your thoughts on this? Did I miss anything?