### PR TITLE
feat(cli): add `--silent` option

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -20,6 +20,9 @@ The YASB CLI is a command line interface that allows you to interact with the YA
 - `--silent` - Disable print messages for `start`, `stop` and `reload`
 - `--version` - Show the YASB version.
 
+> **Note:**
+> You can use the `--silent` option with the `start`, `stop` and `reload` commands to prevent non-error messages from being displayed.
+
 ## Autostart
 
 To enable autostart for the status bar on system boot, use the following command:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -17,6 +17,7 @@ The YASB CLI is a command line interface that allows you to interact with the YA
 
 ## Options
 - `--help` - Show the help message for the command.
+- `--silent` - Disable print messages for `start`, `stop` and `reload`
 - `--version` - Show the YASB version.
 
 ## Autostart

--- a/src/core/utils/cli.py
+++ b/src/core/utils/cli.py
@@ -22,7 +22,7 @@ from colorama import just_fix_windows_console
 just_fix_windows_console()
 
 YASB_VERSION = BUILD_VERSION
-YASB_CLI_VERSION = "1.0.8"
+YASB_CLI_VERSION = "1.0.9"
 
 OS_STARTUP_FOLDER = os.path.join(os.environ['APPDATA'], r'Microsoft\Windows\Start Menu\Programs\Startup')
 INSTALLATION_PATH = os.path.abspath(os.path.join(__file__, "../../.."))

--- a/src/core/utils/cli.py
+++ b/src/core/utils/cli.py
@@ -136,9 +136,15 @@ class CLIHandler:
         parser = CustomArgumentParser(description="The command-line interface for YASB Reborn.", add_help=False)
         subparsers = parser.add_subparsers(dest='command', help='Commands')
 
-        subparsers.add_parser('start', help='Start the application')
-        subparsers.add_parser('stop', help='Stop the application')
-        subparsers.add_parser('reload', help='Reload the application')
+        start_parser = subparsers.add_parser('start', help='Start the application')
+        start_parser.add_argument('-s', '--silent', action='store_true', help='Silence print messages')
+
+        stop_parser = subparsers.add_parser('stop', help='Stop the application')
+        stop_parser.add_argument('-s', '--silent', action='store_true', help='Silence print messages')
+
+        reload_parser = subparsers.add_parser('reload', help='Reload the application')
+        reload_parser.add_argument('-s', '--silent', action='store_true', help='Silence print messages')
+
         subparsers.add_parser('update', help='Update the application')
 
         enable_autostart_parser = subparsers.add_parser('enable-autostart', help='Enable autostart on system boot')
@@ -150,7 +156,6 @@ class CLIHandler:
         subparsers.add_parser('help', help='Show help message')
         subparsers.add_parser('log', help='Tail yasb process logs (cancel with Ctrl-C)')
         parser.add_argument('-v', '--version', action='store_true', help="Show program's version number and exit.")
-        parser.add_argument('-s', '--silent', action='store_true', help='Silence print messages')
         parser.add_argument('-h', '--help', action='store_true', help='Show help message')
         args = parser.parse_args()
 
@@ -237,7 +242,6 @@ class CLIHandler:
             print("  help               Print this message")
             print('\n' + Format.underline + 'Options' + Format.end + ':')
             print("-v, --version  Print version")
-            print("-s, --silent   Silence print messages")
             print("-h, --help     Print this message")
             sys.exit(0)
 

--- a/src/core/utils/cli.py
+++ b/src/core/utils/cli.py
@@ -36,7 +36,7 @@ def is_process_running(process_name):
         if proc.info['name'] == process_name:
             return True
     return False
-    
+
 class Format:
     end = '\033[0m'
     underline = '\033[4m'
@@ -119,7 +119,7 @@ class CLIHandler:
         except Exception as e:
             logging.error(f"Failed to create startup shortcut: {e}")
             print(f"Failed to create startup shortcut: {e}")
-        
+
     def _disable_startup():
         shortcut_path = os.path.join(OS_STARTUP_FOLDER, SHORTCUT_FILENAME)
         if os.path.exists(shortcut_path):
@@ -130,8 +130,8 @@ class CLIHandler:
             except Exception as e:
                 logging.error(f"Failed to remove startup shortcut: {e}")
                 print(f"Failed to remove startup shortcut: {e}")
-        
-        
+
+
     def parse_arguments():
         parser = CustomArgumentParser(description="The command-line interface for YASB Reborn.", add_help=False)
         subparsers = parser.add_subparsers(dest='command', help='Commands')
@@ -140,37 +140,41 @@ class CLIHandler:
         subparsers.add_parser('stop', help='Stop the application')
         subparsers.add_parser('reload', help='Reload the application')
         subparsers.add_parser('update', help='Update the application')
-        
+
         enable_autostart_parser = subparsers.add_parser('enable-autostart', help='Enable autostart on system boot')
         enable_autostart_parser.add_argument('--task', action='store_true', help='Enable autostart as a scheduled task')
-        
+
         disable_autostart_parser = subparsers.add_parser('disable-autostart', help='Disable autostart on system boot')
         disable_autostart_parser.add_argument('--task', action='store_true', help='Disable autostart as a scheduled task')
-        
+
         subparsers.add_parser('help', help='Show help message')
         subparsers.add_parser('log', help='Tail yasb process logs (cancel with Ctrl-C)')
         parser.add_argument('-v', '--version', action='store_true', help="Show program's version number and exit.")
+        parser.add_argument('-s', '--silent', action='store_true', help='Silence print messages')
         parser.add_argument('-h', '--help', action='store_true', help='Show help message')
         args = parser.parse_args()
- 
+
         if args.command == 'start':
-            print(f"Start YASB Reborn v{YASB_VERSION} in background.")
-            print("\n# Community")
-            print("* Join the Discord https://discord.gg/qkeunvBFgX - Chat, ask questions, share your desktops and more...")
-            print("* GitHub discussions https://github.com/amnweb/yasb/discussions - Ask questions, share your ideas and more...")
-            print("\n# Documentation")
-            print("* Read the docs https://github.com/amnweb/yasb/wiki - how to configure and use YASB")
+            if not args.silent:
+                print(f"Start YASB Reborn v{YASB_VERSION} in background.")
+                print("\n# Community")
+                print("* Join the Discord https://discord.gg/qkeunvBFgX - Chat, ask questions, share your desktops and more...")
+                print("* GitHub discussions https://github.com/amnweb/yasb/discussions - Ask questions, share your ideas and more...")
+                print("\n# Documentation")
+                print("* Read the docs https://github.com/amnweb/yasb/wiki - how to configure and use YASB")
             subprocess.Popen(["yasb.exe"])
             sys.exit(0)
-            
+
         elif args.command == 'stop':
-            print("Stop YASB...")
+            if not args.silent:
+                print("Stop YASB...")
             CLIHandler.stop_or_reload_application()
             sys.exit(0)
-            
+
         elif args.command == 'reload':
             if is_process_running("yasb.exe"):
-                print("Reload YASB...")
+                if not args.silent:
+                    print("Reload YASB...")
                 CLIHandler.stop_or_reload_application(reload=True)
             else:
                 print("YASB is not running. Reload aborted.")
@@ -178,7 +182,7 @@ class CLIHandler:
         elif args.command == 'update':
             CLIUpdateHandler.update_yasb(YASB_VERSION)
             sys.exit(0)
-            
+
         elif args.command == 'enable-autostart':
             if args.task:
                 if not CLITaskHandler.is_admin():
@@ -188,7 +192,7 @@ class CLIHandler:
             else:
                 CLIHandler._enable_startup()
             sys.exit(0)
-        
+
         elif args.command == 'disable-autostart':
             if args.task:
                 if not CLITaskHandler.is_admin():
@@ -197,8 +201,8 @@ class CLIHandler:
                     CLITaskHandler.delete_task()
             else:
                 CLIHandler._disable_startup()
-            sys.exit(0)    
-            
+            sys.exit(0)
+
         elif args.command == 'log':
             config_home = os.getenv('YASB_CONFIG_HOME') if os.getenv('YASB_CONFIG_HOME') else os.path.join(os.path.expanduser("~"), ".config", "yasb")
             log_file = os.path.join(config_home, "yasb.log")
@@ -218,7 +222,7 @@ class CLIHandler:
             except KeyboardInterrupt:
                 pass
             sys.exit(0)
-            
+
         elif args.command == 'help' or args.help:
             print("The command-line interface for YASB Reborn.")
             print('\n' + Format.underline + 'Usage' + Format.end + ': yasbc <COMMAND>')
@@ -233,9 +237,10 @@ class CLIHandler:
             print("  help               Print this message")
             print('\n' + Format.underline + 'Options' + Format.end + ':')
             print("-v, --version  Print version")
+            print("-s, --silent   Silence print messages")
             print("-h, --help     Print this message")
             sys.exit(0)
-            
+
         elif args.version:
             version_message = f"YASB Reborn v{YASB_VERSION}\nYASB-CLI v{YASB_CLI_VERSION}"
             print(version_message)
@@ -246,7 +251,7 @@ class CLIHandler:
 
 
 class CLITaskHandler:
-    
+
     def is_admin():
         try:
             return ctypes.windll.shell32.IsUserAnAdmin()
@@ -259,7 +264,7 @@ class CLITaskHandler:
         user, domain, type = win32security.LookupAccountName(None, username)
         sid = win32security.ConvertSidToStringSid(user)
         return sid
-    
+
     def create_task():
         scheduler = win32com.client.Dispatch('Schedule.Service')
         scheduler.Connect()
@@ -308,7 +313,7 @@ class CLITaskHandler:
             print(f"Task YASB Reborn created successfully.")
         except Exception as e:
             print(f"Failed to create task YASB Reborn. Error: {e}")
-        
+
     def delete_task():
         scheduler = win32com.client.Dispatch('Schedule.Service')
         scheduler.Connect()
@@ -318,7 +323,7 @@ class CLITaskHandler:
             print(f"Task YASB Reborn deleted successfully.")
         except Exception:
             print(f"Failed to delete task YASB or task does not exist.")
-        
+
 class CLIUpdateHandler():
 
     def get_installed_product_code():
@@ -335,7 +340,7 @@ class CLIUpdateHandler():
                 return product_code.value
             index += 1
         return None
-    
+
     def update_yasb(YASB_VERSION):
         # Fetch the latest tag from the GitHub API
         api_url = f"https://api.github.com/repos/amnweb/yasb/releases/latest"
@@ -376,7 +381,7 @@ class CLIUpdateHandler():
         except KeyboardInterrupt:
             print("\nDownload interrupted by user.")
             sys.exit(0)
-            
+
         # Verify the downloaded file size
         downloaded_size = os.path.getsize(msi_path)
         if downloaded_size != total_length:
@@ -394,7 +399,7 @@ class CLIUpdateHandler():
         #     uninstall_command = f'msiexec /x {product_code} /passive'
         # else:
         #     uninstall_command = ""
-            
+
         # Construct the install command as a string
         install_command = f'msiexec /i "{os.path.abspath(msi_path)}" /passive /norestart'
         run_after_command = f'"{EXE_PATH}"'
@@ -403,7 +408,7 @@ class CLIUpdateHandler():
         # Finally run update and restart the application
         subprocess.Popen(combined_command, shell=True)
         sys.exit(0)
-    
+
 if __name__ == "__main__":
     CLIHandler.parse_arguments()
     sys.exit(0)


### PR DESCRIPTION
Hi,

First of all, huge thanks for creating the cli. I would never expect for a status bar on windows to have one and I'm amazed at how useful it is. I use `yasbc` mostly to `start`, `stop` and `reload` the bar in my glazewm config. Especially the `reload` command I find very useful, since chaining `taskkill /f /im yasb.exe` and `yasb.exe` on glazewm reload doesn't work as expected. Hovewer, since all commands have print messages, everytime they get called from glazewm, a terminal window spawns and dissappears. 

To remove that behavior I'd like to propose the `--silent` option. When passed, commands `start`, `stop` and `reload` will not print any messages, unless they come from the `stop_or_reload_application` method.

Usage:
```
yasbc start -s
```
```
yasbc reload --silent
```