### PR TITLE
feat(wifi): add ethernet_label and ethernet_label_alt

### DIFF
--- a/docs/widgets/(Widget)-Custom.md
+++ b/docs/widgets/(Widget)-Custom.md
@@ -6,7 +6,7 @@
 | `label_alt`     | string  | `"{data}"`    | Example of label alt. |
 | `label_max_length`          | int     | `None`                                                                     | The maximum length of the label. |
 | `class_name`    | string  | `"custom-widget"`                                                      | The CSS class name for the widget. |
-| `exec_options`  | dict    | `{'run_cmd': None, 'run_interval': 120000, 'return_format': 'json', 'hide_empty: False', use_shell: True, endoding: None}` | Execution options for custom widget. |
+| `exec_options`  | dict    | `{'run_cmd': None, 'run_interval': 120000, 'return_format': 'json', 'hide_empty: False', use_shell: True, encoding: None}` | Execution options for custom widget. |
 | `callbacks`     | dict    | `{'on_left': 'toggle_label', 'on_middle': 'do_nothing', 'on_right': 'do_nothing'}` | Callbacks for mouse events. |
 | `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
 | `container_padding`  | dict | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}`      | Explicitly set padding inside widget container. |

--- a/docs/widgets/(Widget)-WiFi.md
+++ b/docs/widgets/(Widget)-WiFi.md
@@ -41,8 +41,8 @@ wifi:
 ```
 
 ## Description of Options
-- **label:** The format string for the active window title. You can use placeholders like `{win[title]}` to dynamically insert window information. Default is `"{icon}"`.
-- **label_alt:** The format string for the active window title when the widget is in the alternative state. Default is `"{wifi_name} {wifi_strength}%"`.
+- **label:** The format string for the WiFi Widget. Default is `"{wifi_icon}"`.
+- **label_alt:** The format string for the WiFi Widget when the it's in the alternative state. Default is `"{wifi_icon} {wifi_name}"`.
 - **update_interval:** The interval in milliseconds at which the widget updates. Default is `1000`.
 - **ethernet_label:** The format string for the WiFi Widget during active Ethernet connection. Default is `"{wifi_icon}"`.
 - **ethernet_label_alt:** The format string for the WiFi Widget during active Ethernet connection when the widget is in the alternative state. Default is `"{wifi_icon} {ip_addr}"`.

--- a/docs/widgets/(Widget)-WiFi.md
+++ b/docs/widgets/(Widget)-WiFi.md
@@ -3,7 +3,7 @@
 | Option              | Type    | Default                                                                 | Description                                                                 |
 |---------------------|---------|-------------------------------------------------------------------------|-----------------------------------------------------------------------------|
 | `label`   | string  | `"{wifi_icon}"`    | The label format for the WiFi widget. |
-| `label_alt`   | string  | `"{wifi_name} {wifi_strength}%"`  | The alternative label format for the WiFi widget. |
+| `label_alt`   | string  | `"{wifi_icon} {wifi_name}"`  | The alternative label format for the WiFi widget. |
 | `update_interval` | integer  | `1000`   | Update interval in milliseconds.  |
 | `wifi_icons`  | list    | `[ "\udb82\udd2e", "\udb82\udd1f", "\udb82\udd22", "\udb82\udd25", "\udb82\udd28" ]`   | Icons for different WiFi signal strengths.    |
 | `ethernet_label`   | string  | `"{wifi_icon}"`    | The label format during active Ethernet connection. |

--- a/docs/widgets/(Widget)-WiFi.md
+++ b/docs/widgets/(Widget)-WiFi.md
@@ -6,6 +6,8 @@
 | `label_alt`   | string  | `"{wifi_name} {wifi_strength}%"`  | The alternative label format for the WiFi widget. |
 | `update_interval` | integer  | `1000`   | Update interval in milliseconds.  |
 | `wifi_icons`  | list    | `[ "\udb82\udd2e", "\udb82\udd1f", "\udb82\udd22", "\udb82\udd25", "\udb82\udd28" ]`   | Icons for different WiFi signal strengths.    |
+| `ethernet_label`   | string  | `"{wifi_icon}"`    | The label format during active Ethernet connection. |
+| `ethernet_label_alt`   | string  | `"{wifi_icon} {ip_addr}"`  | The alternative label format during active Ethernet connection. |
 | `ethernet_icon` | string | "\ueba9" | The icon to indicate Ethernet connection. |
 | `callbacks`   | dict    | `{ 'on_left': 'next_layout', 'on_middle': 'toggle_monocle', 'on_right': 'prev_layout' }` | Callbacks for mouse events on the widget.    |
 | `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
@@ -26,6 +28,8 @@ wifi:
       on_left: "exec cmd.exe /c start ms-settings:network"
       on_middle: "do_nothing"
       on_right: "toggle_label"
+    ethernet_label: "<span>{wifi_icon}</span>"
+    ethernet_label_alt: "<span>{wifi_icon}</span>{ip_addr}"
     ethernet_icon: "\ueba9"
     wifi_icons: [
       "\udb82\udd2e",  # Icon for 0% strength
@@ -40,6 +44,8 @@ wifi:
 - **label:** The format string for the active window title. You can use placeholders like `{win[title]}` to dynamically insert window information. Default is `"{icon}"`.
 - **label_alt:** The format string for the active window title when the widget is in the alternative state. Default is `"{wifi_name} {wifi_strength}%"`.
 - **update_interval:** The interval in milliseconds at which the widget updates. Default is `1000`.
+- **ethernet_label:** The format string for the WiFi Widget during active Ethernet connection. Default is `"{wifi_icon}"`.
+- **ethernet_label_alt:** The format string for the WiFi Widget during active Ethernet connection when the widget is in the alternative state. Default is `"{wifi_icon} {ip_addr}"`.
 - **ethernet_icon**: The icon that indicates an active Ethernet connection. It will be used as `{wifi_icon}` whenever there's no active WiFi connection. Default is "\ueba9".
 - **wifi_icons:** A list of icons to use for different WiFi signal strengths. Default is `["\udb82\udd2e","\udb82\udd1f","\udb82\udd22","\udb82\udd25","\udb82\udd28",]`.
 - **callbacks:** A dictionary of callbacks for mouse events on the widget. Default is `{'on_left': 'toggle_label', 'on_middle': 'do_nothing', 'on_right': 'do_nothing'}`.

--- a/src/core/validation/widgets/yasb/wifi.py
+++ b/src/core/validation/widgets/yasb/wifi.py
@@ -14,6 +14,8 @@ DEFAULTS = {
         "\udb82\udd25",  # Icon for 50-74% strength
         "\udb82\udd28"   # Icon for 75-100% strength
     ],
+    'ethernet_label': "{wifi_icon}",
+    'ethernet_label_alt': "{wifi_icon} {ip_addr}",
     'ethernet_icon': "\ueba9",
     'container_padding': {'top': 0, 'left': 0, 'bottom': 0, 'right': 0},
     'animation': {
@@ -45,6 +47,14 @@ VALIDATION_SCHEMA = {
             'type': 'string',
             'required': False
         }
+    },
+    'ethernet_label': {
+        'type': 'string',
+        'default': DEFAULTS['ethernet_label']
+    },
+    'ethernet_label_alt': {
+        'type': 'string',
+        'default': DEFAULTS['ethernet_label_alt']
     },
     'ethernet_icon': {
         'type': 'string',

--- a/src/core/widgets/yasb/wifi.py
+++ b/src/core/widgets/yasb/wifi.py
@@ -8,6 +8,7 @@ from PyQt6.QtWidgets import QLabel, QHBoxLayout, QWidget
 from PyQt6.QtCore import Qt
 from core.utils.widgets.animation_manager import AnimationManager
 
+
 class WifiWidget(BaseWidget):
     validation_schema = VALIDATION_SCHEMA
 
@@ -17,6 +18,8 @@ class WifiWidget(BaseWidget):
         label_alt: str,
         update_interval: int,
         wifi_icons: list[str],
+        ethernet_label: str,
+        ethernet_label_alt: str,
         ethernet_icon: str,
         animation: dict[str, str],
         container_padding: dict[str, int],
@@ -27,14 +30,17 @@ class WifiWidget(BaseWidget):
         self._ethernet_icon = ethernet_icon
 
         self._show_alt_label = False
+        self._ethernet_active = False
         self._label_content = label
         self._label_alt_content = label_alt
+        self._ethernet_label_content = ethernet_label
+        self._ethernet_label_alt_content = ethernet_label_alt
         self._animation = animation
         self._padding = container_padding
         # Construct container
         self._widget_container_layout: QHBoxLayout = QHBoxLayout()
         self._widget_container_layout.setSpacing(0)
-        self._widget_container_layout.setContentsMargins(self._padding['left'],self._padding['top'],self._padding['right'],self._padding['bottom'])
+        self._widget_container_layout.setContentsMargins(self._padding['left'], self._padding['top'], self._padding['right'], self._padding['bottom'])
         # Initialize container
         self._widget_container: QWidget = QWidget()
         self._widget_container.setLayout(self._widget_container_layout)
@@ -43,6 +49,7 @@ class WifiWidget(BaseWidget):
         self.widget_layout.addWidget(self._widget_container)
 
         self._create_dynamically_label(self._label_content, self._label_alt_content)
+        self._create_dynamically_label(self._ethernet_label_content, self._ethernet_label_alt_content, is_ethernet=True)
 
         self.register_callback("toggle_label", self._toggle_label)
         self.register_callback("update_label", self._update_label)
@@ -54,20 +61,33 @@ class WifiWidget(BaseWidget):
 
         self.start_timer()
 
+    def _display_correct_label(self):
+        active_widget_group = "ethernet" if self._ethernet_active else "wifi"
+        widget_groups = {
+            "wifi": (self._widgets, self._widgets_alt),
+            "ethernet": (self._widgets_ethernet, self._widgets_ethernet_alt),
+        }
+        for name, (widgets, widgets_alt) in widget_groups.items():
+            if name == active_widget_group:
+                for widget in widgets:
+                    widget.setVisible(not self._show_alt_label)
+                for widget in widgets_alt:
+                    widget.setVisible(self._show_alt_label)
+            else:
+                for widget in widgets:
+                    widget.setVisible(False)
+                for widget in widgets_alt:
+                    widget.setVisible(False)
+
     def _toggle_label(self):
         if self._animation['enabled']:
             AnimationManager.animate(self, self._animation['type'], self._animation['duration'])
         self._show_alt_label = not self._show_alt_label
-        for widget in self._widgets:
-            widget.setVisible(not self._show_alt_label)
-        for widget in self._widgets_alt:
-            widget.setVisible(self._show_alt_label)
         self._update_label()
 
-
-    def _create_dynamically_label(self, content: str, content_alt: str):
-        def process_content(content, is_alt=False):
-            label_parts = re.split('(<span.*?>.*?</span>)', content) #Filters out empty parts before entering the loop
+    def _create_dynamically_label(self, content: str, content_alt: str, is_ethernet=False):
+        def process_content(content, is_alt=False, is_ethernet=False):
+            label_parts = re.split('(<span.*?>.*?</span>)', content)  # Filters out empty parts before entering the loop
             label_parts = [part for part in label_parts if part]
             widgets = []
             for part in label_parts:
@@ -86,39 +106,48 @@ class WifiWidget(BaseWidget):
                 label.setAlignment(Qt.AlignmentFlag.AlignCenter)
                 self._widget_container_layout.addWidget(label)
                 widgets.append(label)
-                if is_alt:
+                if is_alt or is_ethernet:
                     label.hide()
                 else:
                     label.show()
             return widgets
-        self._widgets = process_content(content)
-        self._widgets_alt = process_content(content_alt, is_alt=True)
 
+        if is_ethernet:
+            self._widgets_ethernet = process_content(content, is_ethernet=True)
+            self._widgets_ethernet_alt = process_content(content_alt, is_alt=True, is_ethernet=True)
+        else:
+            self._widgets = process_content(content)
+            self._widgets_alt = process_content(content_alt, is_alt=True)
 
     def _update_label(self):
-        active_widgets = self._widgets_alt if self._show_alt_label else self._widgets
-        active_label_content = self._label_alt_content if self._show_alt_label else self._label_content
-        label_parts = re.split('(<span.*?>.*?</span>)', active_label_content)
-        label_parts = [part for part in label_parts if part]
-        widget_index = 0
         try:
             connection_info = NetworkInformation.get_internet_connection_profile()
             ip_addr = socket.gethostbyname(socket.gethostname())
-
-            # If no connection or WiFi connection, check WiFi connection
-            # (it will set the icon to the 0% icon (no connection) if no WiFi connection is found)
             if connection_info is None or connection_info.is_wlan_connection_profile:
-                # Retrieve WiFi information
+                self._ethernet_active = False
+                # sets the wifi_icon to the 0% icon if no WiFi connection is found
                 wifi_icon, wifi_strength = self._get_wifi_icon()
                 wifi_name = self._get_wifi_name()
             else:
-                # Otherwise, there is a connection that is Ethernet.
+                self._ethernet_active = True
                 wifi_icon = self._ethernet_icon
                 wifi_name = 'Ethernet'
                 wifi_strength = 'N/A'
         except Exception as e:
             logging.error(f'Error in wifi widget update: {e}')
             wifi_icon = wifi_name = wifi_strength = "N/A"
+
+        self._display_correct_label()
+        if self._ethernet_active:
+            active_widgets = self._widgets_ethernet_alt if self._show_alt_label else self._widgets_ethernet
+            active_label_content = self._ethernet_label_alt_content if self._show_alt_label else self._ethernet_label_content
+        else:
+            active_widgets = self._widgets_alt if self._show_alt_label else self._widgets
+            active_label_content = self._label_alt_content if self._show_alt_label else self._label_content
+
+        label_parts = re.split('(<span.*?>.*?</span>)', active_label_content)
+        label_parts = [part for part in label_parts if part]
+        widget_index = 0
         label_options = {
             "{wifi_icon}": wifi_icon,
             "{wifi_name}": wifi_name,
@@ -156,7 +185,7 @@ class WifiWidget(BaseWidget):
         for connection in connections:
             if connection.get_network_connectivity_level() == NetworkConnectivityLevel.INTERNET_ACCESS:
                 return connection.profile_name
-        return "No WiFi"
+        return "Disconnected"
 
     def _get_wifi_icon(self):
         strength = self._get_wifi_strength()


### PR DESCRIPTION
Added `ethernet_label` and `ethernet_label_alt` to be displayed during active Ethernet connection. The widget text switches between `label` and `ethernet_label` as soon as the change in internet connection is detected. The alternative widget state during the switch is maintained.