### PR TITLE
Update media popup buttons before the widget is shown

### DIFF
--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -354,8 +354,8 @@ class MediaWidget(BaseWidget):
             offset_left=self._menu_config['offset_left'],
             offset_top=self._menu_config['offset_top']
         )
-        self._dialog.show()
         self._update_popup_menu_buttons()
+        self._dialog.show()
 
         # Create and install the filter
         self._wheel_filter = WheelEventFilter(self)


### PR DESCRIPTION
This avoids buttons "snapping in place" after the widget is shown.

Before:
https://github.com/user-attachments/assets/9aa0584e-7a10-4ec3-b526-f816f78c3cbd

After:
https://github.com/user-attachments/assets/8728667f-2c93-46f7-a0c4-413083e5fd07

