### PR TITLE
feat(weather): add optional field 'lang'

### DIFF
--- a/docs/widgets/(Widget)-Weather.md
+++ b/docs/widgets/(Widget)-Weather.md
@@ -6,6 +6,7 @@
 | `update_interval` | integer | `3600`                                                                 | The interval in seconds to update the weather data. Must be between 60 and 36000000. |
 | `hide_decimal`  | boolean | `False`                                                                 | Whether to hide the decimal part of the temperature. |
 | `location`      | string  | `'London'`                                                              | The location for which to fetch the weather data. |
+| `lang` | string | `""` | The language for the weather data. |
 | `show_alerts`   | boolean | `False`                                                                 | Whether to show weather alerts. |
 | `units`         | string  | `'metric'`                                                              | The units for the weather data. Can be `'metric'` or `'imperial'`. |
 | `api_key`       | string  | `'0'`                                                                   | The API key for accessing the weather service. |
@@ -68,6 +69,7 @@ weather:
 - **update_interval:** The interval in seconds to update the weather data. Must be between 60 and 36000000.
 - **hide_decimal:** Whether to hide the decimal part of the temperature.
 - **location:** The location for which to fetch the weather data. You can use example "USA Los Angeles 90006" {COUNTRY CITY ZIP_CODE}, or just city. Location can be set to `env`, this means you have to set `YASB_WEATHER_LOCATION` in environment variable or you can set it directly in the configuration file.
+- **lang:** The language for the weather data. The value should be a language code, such as "fr" for French. Lang can be set to `env`, this means you have to set `YASB_WEATHER_LANG` in environment variable or you can set it directly in the configuration file.
 - **api_key:** The API key for accessing the weather service. You can get free API key `weatherapi.com`. API key can be set to `env`, this means you have to set `YASB_WEATHER_API_KEY` in environment variable or you can set it directly in the configuration file.
 - **show_alerts:** Whether to show weather alerts.
 - **units:** The units for the weather data. Can be `'metric'` or `'imperial'`.

--- a/src/core/validation/widgets/yasb/weather.py
+++ b/src/core/validation/widgets/yasb/weather.py
@@ -4,6 +4,7 @@ DEFAULTS = {
     'update_interval': 3600,
     'hide_decimal': False,
     'location': '',
+    'lang': '',
     'api_key': '0',
     'units': 'metric',
     'show_alerts': False,
@@ -66,6 +67,10 @@ VALIDATION_SCHEMA = {
     'location': {
         'type': 'string',
         'default': DEFAULTS['location']
+    },
+    'lang': {
+        'type': 'string',
+        'default': DEFAULTS['lang']
     },
     'api_key': {
         'type': 'string',

--- a/src/core/widgets/yasb/weather.py
+++ b/src/core/widgets/yasb/weather.py
@@ -24,6 +24,7 @@ class WeatherWidget(BaseWidget):
             update_interval: int,
             hide_decimal: bool,
             location: str,
+            lang: str,
             api_key: str,
             units: str,
             show_alerts: bool,
@@ -39,6 +40,7 @@ class WeatherWidget(BaseWidget):
         self._label_content = label
         self._label_alt_content = label_alt
         self._location = location if location != 'env' else os.getenv('YASB_WEATHER_LOCATION')
+        self._lang = lang if lang != 'env' else os.getenv('YASB_WEATHER_LANG')
         self._hide_decimal = hide_decimal
         self._icons = icons
         self._api_key = api_key if api_key != 'env' else os.getenv('YASB_WEATHER_API_KEY')
@@ -47,6 +49,8 @@ class WeatherWidget(BaseWidget):
             self.hide()
             return
         self.api_url = f"http://api.weatherapi.com/v1/forecast.json?key={self._api_key}&q={urllib.parse.quote(self._location)}&days=3&aqi=no&alerts=yes"
+        if self._lang:
+            self.api_url += f"&lang={self._lang}"
         self._units = units
         self._show_alerts = show_alerts
         self._padding = container_padding


### PR DESCRIPTION
add a new optional field 'lang' to widget weather, so we can get the weather data in a specific language.
see [docs](https://www.weatherapi.com/docs/)
![image](https://github.com/user-attachments/assets/0503e6d0-2d3a-4ffd-b02a-011005679489)
