### PR TITLE
feat(bar): Add flag `hide_on_desktop`

### DIFF
--- a/src/core/bar.py
+++ b/src/core/bar.py
@@ -231,9 +231,8 @@ class Bar(QWidget):
         hwnd = win32gui.GetForegroundWindow()
         if not hwnd:
             return
-
         class_name = win32gui.GetClassName(hwnd)
-        if class_name in ("Progman", "WorkerW", "XamlWindow"):
+        if class_name in ("Progman", "WorkerW", "XamlWindow") and not self._window_flags["hide_on_desktop"]:
             return
         left, top, right, bottom = win32gui.GetWindowRect(hwnd)
         window_rect = (left, top, right - left, bottom - top)

--- a/src/core/bar_manager.py
+++ b/src/core/bar_manager.py
@@ -84,7 +84,7 @@ class BarManager(QObject):
                 self._threads[listener].wait(500)
         self._threads.clear()
         self.widget_event_listeners.clear()
- 
+
     def initialize_bars(self, init=False) -> None:
         self._widget_builder = WidgetBuilder(self.config['widgets'])
         screens_in_config = {screen for bar_config in self.config['bars'].values() for screen in bar_config['screens']}
@@ -119,6 +119,7 @@ class BarManager(QObject):
 
         del bar_options['enabled']
         del bar_options['screens']
+        del bar_options['hide_on_desktop']
 
         self.widget_event_listeners = self.widget_event_listeners.union(widget_event_listeners)
         self.bars.append(Bar(**bar_options))

--- a/src/core/validation/bar.py
+++ b/src/core/validation/bar.py
@@ -5,12 +5,13 @@ BAR_DEFAULTS = {
     'alignment': {'position': 'top', 'center': False},
     'blur_effect': {'enabled': False, 'dark_mode': False, 'acrylic': False,'round_corners': False,'round_corners_type':'normal','border_color': "System"},
     'animation': {'enabled': True, 'duration': 500},
-    'window_flags': {'always_on_top': False, 'windows_app_bar': False, 'hide_on_fullscreen': False},
+    'window_flags': {'always_on_top': False, 'windows_app_bar': False, 'hide_on_fullscreen': False, 'hide_on_desktop': False},
     'dimensions': {'width': '100%', 'height': 30},
     'padding': {'top': 0, 'left': 0, 'bottom': 0, 'right': 0},
     'widgets': {'left': [], 'center': [], 'right': []},
     'layouts': {'left': {'alignment': 'left','stretch': True},'center': {'alignment': 'center','stretch': True},'right': {'alignment': 'right','stretch': True}
-    }
+    },
+    'hide_on_desktop': False,  # New option
 }
 
 BAR_SCHEMA = {
@@ -109,6 +110,10 @@ BAR_SCHEMA = {
                 'hide_on_fullscreen': {
                     'type': 'boolean',
                     'default': BAR_DEFAULTS['window_flags']['hide_on_fullscreen']
+                },
+                'hide_on_desktop': {
+                    'type': 'boolean',
+                    'default': BAR_DEFAULTS['window_flags']['hide_on_desktop']
                 }
             },
             'default': BAR_DEFAULTS['window_flags']
@@ -230,6 +235,10 @@ BAR_SCHEMA = {
                 }
             },
             'default': BAR_DEFAULTS['layouts']
+        },
+        'hide_on_desktop': {
+            'type': 'boolean',
+            'default': BAR_DEFAULTS['hide_on_desktop']
         }
     },
     'default': BAR_DEFAULTS


### PR DESCRIPTION
Hides the status bar wen there is no windows active.

<sub>Unintended Side Effect: Status Bar hides still even if you have an open window if you focus on the background, would need some help improving on it</sub>

https://github.com/user-attachments/assets/9851dd98-8f43-4f56-8d4c-6a0fc81e7f08

