### PR TITLE
fix(app): fix app instance init for debug mode

### DIFF
--- a/src/core/utils/css_processor.py
+++ b/src/core/utils/css_processor.py
@@ -102,10 +102,7 @@ class CSSProcessor:
         if not self._should_check_fonts():
             return set(), {}
 
-        # Ensure QApplication exists
-        app = QApplication.instance()
-        if app is None:
-            app = QApplication(sys.argv)
+        # Check for available fonts
         available_fonts = set(QFontDatabase.families())
 
         font_families = set()

--- a/src/main.py
+++ b/src/main.py
@@ -41,6 +41,10 @@ def single_instance_lock(name="yasb_reborn"):
    
 
 def main():
+    # Application instance should be created first
+    app = QApplication(argv)
+    app.setQuitOnLastWindowClosed(False)
+
     # Initialize configuration early after the single instance check
     config, stylesheet = get_config_and_stylesheet()
 
@@ -49,9 +53,6 @@ def main():
         logging.info("Debug mode enabled.")
         
     start_cli_server()
-    
-    app = QApplication(argv)
-    app.setQuitOnLastWindowClosed(False)
 
     env_file = config.get('env_file')
     if env_file:


### PR DESCRIPTION
The debug mode was not working because the app instance was initialized in the CSSProcessor first, instead of the main where it would. Moved the app init to be the first thing and removed the unnecessary CSSProcessor check (as app should exist there already in all cases).