### PR TITLE
feat(komorebi): Stack Widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ https://github.com/user-attachments/assets/aab8d8e8-248f-46a1-919c-9b0601236ac1
 - **[Windows-Desktops](https://github.com/amnweb/yasb/wiki/(Widget)-Windows-Desktops)**: Windows desktops switcher.
 - **[Komorebi Control](https://github.com/amnweb/yasb/wiki/(Widget)-Komorebi-Control)**: Komorebi control widget.
 - **[Komorebi Layout](https://github.com/amnweb/yasb/wiki/(Widget)-Komorebi-Layout)**: Shows the current layout of Komorebi.
+- **[Komorebi Stack](https://github.com/amnweb/yasb/wiki/(Widget)-Komorebi-Stack)**: Shows windows in the current Komorebi stack.
 - **[Komorebi Workspaces](https://github.com/amnweb/yasb/wiki/(Widget)-Komorebi-Workspaces)**: Komorebi workspaces widget.
 
 

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -43,5 +43,6 @@
     - [Windows-Desktops](./(Widget)-Windows-Desktops)
     - [Komorebi Control](./(Widget)-Komorebi-Control)
     - [Komorebi Layout](./(Widget)-Komorebi-Layout)
+    - [Komorebi Stack](./(Widget)-Komorebi-Layout)
     - [Komorebi Workspaces](./(Widget)-Komorebi-Workspaces)
 - [Writing Widget](./Writing-Widget)

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -43,6 +43,6 @@
     - [Windows-Desktops](./(Widget)-Windows-Desktops)
     - [Komorebi Control](./(Widget)-Komorebi-Control)
     - [Komorebi Layout](./(Widget)-Komorebi-Layout)
-    - [Komorebi Stack](./(Widget)-Komorebi-Layout)
+    - [Komorebi Stack](./(Widget)-Komorebi-Stack)
     - [Komorebi Workspaces](./(Widget)-Komorebi-Workspaces)
 - [Writing Widget](./Writing-Widget)

--- a/docs/widgets/(Widget)-Komorebi-Stack.md
+++ b/docs/widgets/(Widget)-Komorebi-Stack.md
@@ -6,7 +6,7 @@ This widget displays information about each window in the currently active Komor
 | `label_window`    | string  | `'{index}'`              | The format string for window buttons.                                    |
 | `label_window_active` | string | `'{index}'`              | The format string for the active window button.                          |
 | `label_no_window`       | string  | `''`                     | The label to display when no window is in focus.                                         |
-| `label_zero_index`        | boolean | `false`    | Whether to use zero-based indexing for workspace labels.                    |
+| `label_zero_index`        | boolean | `false`    | Whether to use zero-based indexing for window labels.                    |
 | `max_length`        | boolean | `None`    | 	The maximum length of the label text.              |
 | `max_length_active`        | boolean | `None`    | 	The maximum length of the label text for the active window.              |
 | `max_length_ellipsis`        | boolean | `None`    | 		The ellipsis to use when the label text exceeds the maximum length.              |

--- a/docs/widgets/(Widget)-Komorebi-Stack.md
+++ b/docs/widgets/(Widget)-Komorebi-Stack.md
@@ -60,8 +60,8 @@ This widget displays information about each window in the currently active Komor
 - **label_window_active:** The format string for the active window button, can be {title}, {index}, {process}, or {hwnd}.
 - **label_no_window:** The label to display when no window is in focus.  
 - **label_zero_index:** Whether to use zero-based indexing for workspace labels.
-- **max_length:** The maximum number of characters to display for the window title. If the title exceeds this length, it will be truncated.
-- **max_length_active:** The maximum number of characters to display for the active window title. If the title exceeds this length, it will be truncated.
+- **max_length:** The maximum number of characters to display for the label. If the title exceeds this length, it will be truncated.
+- **max_length_active:** The maximum number of characters to display for the active window label. If the title exceeds this length, it will be truncated.
 - **max_length_ellipsis:** The string to append to truncated window titles.  
 - **hide_if_offline:** Whether to hide the widget if Komorebi is offline.
 - **enable_scroll_switching:** Enable scroll switching between workspaces.

--- a/docs/widgets/(Widget)-Komorebi-Stack.md
+++ b/docs/widgets/(Widget)-Komorebi-Stack.md
@@ -11,6 +11,7 @@ This widget displays information about each window in the currently active Komor
 | `max_length_active`        | boolean | `None`    | 	The maximum length of the label text for the active window.              |
 | `max_length_ellipsis`        | boolean | `None`    | 		The ellipsis to use when the label text exceeds the maximum length.              |
 | `hide_if_offline`       | boolean | `false`         | Whether to hide the widget if Komorebi is offline.                          |
+| `show_only_stack`       | boolean | `false`         | Whether to show buttons only for stacked windows (other windows will display `label_no_window`).             |
 | `enable_scroll_switching` | boolean | `false`      | Enable scroll switching between windows.                                 |
 | `reverse_scroll_direction` | boolean | `false`      | Reverse scroll direction.                                                  |
 | `animation`  | boolean | `false`      | Buttons animation.                                           |
@@ -64,6 +65,7 @@ This widget displays information about each window in the currently active Komor
 - **max_length_active:** The maximum number of characters to display for the active window label. If the title exceeds this length, it will be truncated.
 - **max_length_ellipsis:** The string to append to truncated window titles.  
 - **hide_if_offline:** Whether to hide the widget if Komorebi is offline.
+- **show_only_stack:** Whether to show buttons only for stacked windows (other windows will display `label_no_window`).   
 - **enable_scroll_switching:** Enable scroll switching between workspaces.
 - **reverse_scroll_direction:** Reverse scroll direction.
 - **animation:** Buttons animation.

--- a/docs/widgets/(Widget)-Komorebi-Stack.md
+++ b/docs/widgets/(Widget)-Komorebi-Stack.md
@@ -1,4 +1,5 @@
-# Komorebi Workspaces Widget
+# Komorebi Stack Widget
+This widget displays information about each window in the currently active Komorebi stack.
 | Option                     | Type    | Default                  | Description                                                                 |
 |----------------------------|---------|--------------------------|-----------------------------------------------------------------------------|
 | `label_offline`          | string  | `'Komorebi Offline'`     | The label to display when Komorebi is offline.                              |
@@ -21,35 +22,36 @@
 ## Example Configuration
 
 ```yaml
-komorebi_stack:
-  type: "komorebi.stack.StackWidget"
-  options:
-    label_offline: "Offline"
-    label_window: "{process}"
-    label_window_active: "{title}"
-    label_no_window: "No Window"
-    label_zero_index: false
-    max_length: 10
-    max_length_active: 20
-    max_length_ellipsis: ".."
-    hide_if_offline: false
-    animation: true
-    enable_scroll_switching : true
-    container_shadow:
-      enabled: true
-      color: "#000000"
-      offset: [0, 1]
-      radius: 2
-    btn_shadow:
-      enabled: true
-      color: "#000000"
-      offset: [0, 1]
-      radius: 2
-    label_shadow:
-      enabled: true
-      color: "#000000"
-      offset: [0, 1]
-      radius: 2
+  komorebi_stack:
+    type: "komorebi.stack.StackWidget"
+    options:
+      label_offline: "Offline"
+      label_window: "{process}"
+      label_window_active: "{title}"
+      label_no_window: "No Window"
+      label_zero_index: false
+      max_length: 10
+      max_length_active: 20
+      max_length_ellipsis: ".."
+      hide_if_offline: false
+      show_only_stack: false
+      animation: true
+      enable_scroll_switching : true
+      container_shadow:
+        enabled: true
+        color: "#000000"
+        offset: [0, 1]
+        radius: 2
+      btn_shadow:
+        enabled: true
+        color: "#000000"
+        offset: [0, 1]
+        radius: 2
+      label_shadow:
+        enabled: true
+        color: "#000000"
+        offset: [0, 1]
+        radius: 2
 ```
 
 ## Description of Options
@@ -78,6 +80,8 @@ komorebi_stack:
 .komorebi-stack .window.active {} /*Style for the active window button.*/
 .komorebi-stack .window.button-1 {} /*Style for first button.*/
 .komorebi-stack .window.button-2 {} /*Style for second  button.*/
+.komorebi-stack .offline-status{} /*Style for offline status label.*/
+.komorebi-stack .no-window{} /*Style for no window label.*/
 ```
 
 ## Example Style

--- a/docs/widgets/(Widget)-Komorebi-Stack.md
+++ b/docs/widgets/(Widget)-Komorebi-Stack.md
@@ -16,6 +16,7 @@
 | `container_padding`  | dict | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}`      | Explicitly set padding inside widget container.
 | `container_shadow`      | dict    | `None`                  | Container shadow options.                                |
 | `label_shadow`            | dict    | `None`                  | Label shadow options.                       |
+| `btn_shadow`            | dict    | `None`                  | Window button shadow options.                         |
 
 ## Example Configuration
 
@@ -24,8 +25,8 @@ komorebi_stack:
   type: "komorebi.stack.StackWidget"
   options:
     label_offline: "Offline"
-    label_window: "{index} {process}"
-    label_window_active: "{index} {title}"
+    label_window: "{process}"
+    label_window_active: "{title}"
     label_no_window: "No Window"
     label_zero_index: false
     max_length: 10
@@ -35,6 +36,11 @@ komorebi_stack:
     animation: true
     enable_scroll_switching : true
     container_shadow:
+      enabled: true
+      color: "#000000"
+      offset: [0, 1]
+      radius: 2
+    btn_shadow:
       enabled: true
       color: "#000000"
       offset: [0, 1]
@@ -62,15 +68,37 @@ komorebi_stack:
 - **container_padding:** Explicitly set padding inside widget container.
 - **container_shadow:** Container shadow options.
 - **label_shadow:** Label shadow options for labels.
+- **btn_shadow:** Window button shadow options.
 
 ## Style
 ```css
-.komorebi-workspaces {} /*Style for widget.*/
-.komorebi-workspaces .widget-container {} /*Style for widget container.*/
-.komorebi-workspaces .window {} /*Style for buttons.*/
-.komorebi-workspaces .window.active {} /*Style for the active window button.*/
-.komorebi-workspaces .window.button-1 {} /*Style for first button.*/
-.komorebi-workspaces .window.button-2 {} /*Style for second  button.*/
+.komorebi-stack {} /*Style for widget.*/
+.komorebi-stack .widget-container {} /*Style for widget container.*/
+.komorebi-stack .window {} /*Style for buttons.*/
+.komorebi-stack .window.active {} /*Style for the active window button.*/
+.komorebi-stack .window.button-1 {} /*Style for first button.*/
+.komorebi-stack .window.button-2 {} /*Style for second  button.*/
+```
 
-> [!NOTE]  
-> You can use `button-x` to style each button separately. Where x is the index of the button.
+## Example Style
+```css
+.komorebi-stack {
+    margin: 4px 0;
+}
+.komorebi-stack .widget-container {
+    background-color: #282936; 
+    border-radius: 4px;
+}
+.komorebi-stack .window {
+    background-color: transparent;
+    border: none;
+    margin: 0px 8px;
+    padding: 0 4px;
+}
+.komorebi-stack .window.active {
+    background-color: #45475a;
+    border-radius: 4px;
+    height: auto;
+    margin: 0;
+}
+```

--- a/docs/widgets/(Widget)-Komorebi-Stack.md
+++ b/docs/widgets/(Widget)-Komorebi-Stack.md
@@ -1,0 +1,76 @@
+# Komorebi Workspaces Widget
+| Option                     | Type    | Default                  | Description                                                                 |
+|----------------------------|---------|--------------------------|-----------------------------------------------------------------------------|
+| `label_offline`          | string  | `'Komorebi Offline'`     | The label to display when Komorebi is offline.                              |
+| `label_window`    | string  | `'{index}'`              | The format string for window buttons.                                    |
+| `label_window_active` | string | `'{index}'`              | The format string for the active window button.                          |
+| `label_no_window`       | string  | `''`                     | The label to display when no window is in focus.                                         |
+| `label_zero_index`        | boolean | `false`    | Whether to use zero-based indexing for workspace labels.                    |
+| `max_length`        | boolean | `None`    | 	The maximum length of the label text.              |
+| `max_length_active`        | boolean | `None`    | 	The maximum length of the label text for the active window.              |
+| `max_length_ellipsis`        | boolean | `None`    | 		The ellipsis to use when the label text exceeds the maximum length.              |
+| `hide_if_offline`       | boolean | `false`         | Whether to hide the widget if Komorebi is offline.                          |
+| `enable_scroll_switching` | boolean | `false`      | Enable scroll switching between windows.                                 |
+| `reverse_scroll_direction` | boolean | `false`      | Reverse scroll direction.                                                  |
+| `animation`  | boolean | `false`      | Buttons animation.                                           |
+| `container_padding`  | dict | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}`      | Explicitly set padding inside widget container.
+| `container_shadow`      | dict    | `None`                  | Container shadow options.                                |
+| `label_shadow`            | dict    | `None`                  | Label shadow options.                       |
+
+## Example Configuration
+
+```yaml
+komorebi_stack:
+  type: "komorebi.stack.StackWidget"
+  options:
+    label_offline: "Offline"
+    label_window: "{index} {process}"
+    label_window_active: "{index} {title}"
+    label_no_window: "No Window"
+    label_zero_index: false
+    max_length: 10
+    max_length_active: 20
+    max_length_ellipsis: ".."
+    hide_if_offline: false
+    animation: true
+    enable_scroll_switching : true
+    container_shadow:
+      enabled: true
+      color: "#000000"
+      offset: [0, 1]
+      radius: 2
+    label_shadow:
+      enabled: true
+      color: "#000000"
+      offset: [0, 1]
+      radius: 2
+```
+
+## Description of Options
+- **label_offline:** The label to display when Komorebi is offline.
+- **label_window:** The format string for window buttons, can be {title}, {index}, {process}, or {hwnd}.
+- **label_window_active:** The format string for the active window button, can be {title}, {index}, {process}, or {hwnd}.
+- **label_no_window:** The label to display when no window is in focus.  
+- **label_zero_index:** Whether to use zero-based indexing for workspace labels.
+- **max_length:** The maximum number of characters to display for the window title. If the title exceeds this length, it will be truncated.
+- **max_length_active:** The maximum number of characters to display for the active window title. If the title exceeds this length, it will be truncated.
+- **max_length_ellipsis:** The string to append to truncated window titles.  
+- **hide_if_offline:** Whether to hide the widget if Komorebi is offline.
+- **enable_scroll_switching:** Enable scroll switching between workspaces.
+- **reverse_scroll_direction:** Reverse scroll direction.
+- **animation:** Buttons animation.
+- **container_padding:** Explicitly set padding inside widget container.
+- **container_shadow:** Container shadow options.
+- **label_shadow:** Label shadow options for labels.
+
+## Style
+```css
+.komorebi-workspaces {} /*Style for widget.*/
+.komorebi-workspaces .widget-container {} /*Style for widget container.*/
+.komorebi-workspaces .window {} /*Style for buttons.*/
+.komorebi-workspaces .window.active {} /*Style for the active window button.*/
+.komorebi-workspaces .window.button-1 {} /*Style for first button.*/
+.komorebi-workspaces .window.button-2 {} /*Style for second  button.*/
+
+> [!NOTE]  
+> You can use `button-x` to style each button separately. Where x is the index of the button.

--- a/src/build.py
+++ b/src/build.py
@@ -40,6 +40,7 @@ build_options = {
         'core.widgets.yasb.recycle_bin',
         'core.widgets.komorebi.control',
         'core.widgets.komorebi.active_layout',
+        'core.widgets.komorebi.stack',
         'core.widgets.komorebi.workspaces',
         'core.widgets.glazewm.tiling_direction',
         'core.widgets.glazewm.workspaces'

--- a/src/core/event_enums.py
+++ b/src/core/event_enums.py
@@ -44,3 +44,8 @@ class KomorebiEvent(Event):
     SendContainerToMonitorNumber = "SendContainerToMonitorNumber"
     SendContainerToWorkspaceNumber = "SendContainerToWorkspaceNumber"
     WorkspaceName = "WorkspaceName"
+    StackWindow = "StackWindow"
+    UnstackWindow = "UnstackWindow"
+    CycleStack = "CycleStack"
+    FocusStackWindow = "FocusStackWindow"
+    TitleUpdate = "TitleUpdate"

--- a/src/core/utils/komorebi/client.py
+++ b/src/core/utils/komorebi/client.py
@@ -174,3 +174,57 @@ class KomorebiClient:
         _stdout, stderr = proc.communicate()
 
         return stderr, proc
+
+    def get_containers(self, workspace: dict) -> list:
+        return [add_index(container, i) for i, container in enumerate(workspace['containers']['elements'])]
+
+    def get_container_by_index(self, workspace: dict, container_index: int) -> Optional[dict]:
+        try:
+            return self.get_containers(workspace)[container_index]
+        except IndexError:
+            return None             
+
+    def get_focused_container(self, workspace: dict) -> Optional[dict]:
+        try:
+            focused_container_index = workspace['containers']['focused']
+            focused_container = self.get_container_by_index(workspace, focused_container_index)
+            focused_container['index'] = focused_container_index
+            return focused_container
+        except (KeyError, TypeError):
+            return None
+
+    def get_windows(self, container: dict) -> list:
+        return [add_index(window, i) for i, window in enumerate(container['windows']['elements'])]
+
+    def get_window_by_index(self, container: dict, window_index: int) -> Optional[dict]:
+        try:
+            return self.get_windows(container)[window_index]
+        except IndexError:
+            return None             
+
+    def get_focused_window(self, container: dict) -> Optional[dict]:
+        try:
+            focused_window_index = container['windows']['focused']
+            focused_window = self.get_window_by_index(container, focused_window_index)
+            focused_window['index'] = focused_window_index
+            return focused_window
+        except (KeyError, TypeError):
+            return None
+
+    def focus_stack_window(self, w_idx: int) -> None:
+        try:
+            subprocess.Popen([self._komorebic_path, "focus-stack-window", str(w_idx)], shell=True)
+        except subprocess.SubprocessError:
+            logging.exception("Failed to focus stack window")
+
+    def next_stack_window(self) -> None:
+        try:
+            subprocess.Popen([self._komorebic_path, "cycle-stack", "next"], shell=True)
+        except subprocess.SubprocessError:
+            logging.exception("Failed to cycle komorebi stack")
+
+    def prev_stack_window(self) -> None:
+        try:
+            subprocess.Popen([self._komorebic_path, "cycle-stack", "prev"], shell=True)
+        except subprocess.SubprocessError:
+            logging.exception("Failed to cycle komorebi stack")

--- a/src/core/validation/widgets/komorebi/stack.py
+++ b/src/core/validation/widgets/komorebi/stack.py
@@ -1,0 +1,96 @@
+DEFAULTS = {
+    'label_offline': 'Komorebi Offline',
+    'label_window': '{tile}',
+    'label_window_active': '{title}',
+    'label_no_window': '',
+    'label_zero_index': False,
+    'max_length': None,
+    'max_length_ellipsis': '...',
+    'hide_if_offline': False,
+    'animation': False,
+    'enable_scroll_switching': False,
+    'reverse_scroll_direction': False,
+    'container_padding': {'top': 0, 'left': 0, 'bottom': 0, 'right': 0},
+}
+
+VALIDATION_SCHEMA = {
+    'label_offline': {
+        'type': 'string',
+        'default': DEFAULTS['label_offline']
+    },
+    'label_window': {
+        'type': 'string',
+        'default': DEFAULTS['label_window']
+    },
+    'label_window_active': {
+        'type': 'string',
+        'default': DEFAULTS['label_window_active']
+    },
+    'label_no_window': {
+        'type': 'string',
+        'default': DEFAULTS['label_no_window']
+    },
+    'label_zero_index': {
+        'type': 'boolean',
+        'default': DEFAULTS['label_zero_index']
+    },
+    'hide_if_offline': {
+        'type': 'boolean',
+        'default': DEFAULTS['hide_if_offline']
+    },
+    'max_length': {
+        'type': 'integer',
+        'min': 1,
+        'nullable': True,
+        'default': DEFAULTS['max_length']
+    },
+    'max_length_active': {
+        'type': 'integer',
+        'min': 1,
+        'nullable': True,
+        'default': DEFAULTS['max_length']
+    },
+    'max_length_ellipsis': {
+        'type': 'string',
+        'default': DEFAULTS['max_length_ellipsis']
+    },
+    'animation': {
+        'type': 'boolean',
+        'default': DEFAULTS['animation']
+    },
+    'enable_scroll_switching': {
+        'type': 'boolean',
+        'default': DEFAULTS['enable_scroll_switching']
+    },
+    'reverse_scroll_direction': {
+        'type': 'boolean',
+        'default': DEFAULTS['reverse_scroll_direction']
+    },
+    'container_padding': {
+        'type': 'dict',
+        'default': DEFAULTS['container_padding'],
+        'required': False
+    },
+    'label_shadow': {
+        'type': 'dict',
+        'required': False,
+        'schema': {
+            'enabled': {'type': 'boolean', 'default': False},
+            'color': {'type': 'string', 'default': 'black'},
+            'offset': {'type': 'list', 'default': [1, 1]},
+            'radius': {'type': 'integer', 'default': 3},
+        },
+        'default': {'enabled': False, 'color': 'black', 'offset': [1, 1], 'radius': 3}
+    },
+    'container_shadow': {
+        'type': 'dict',
+        'required': False,
+        'schema': {
+            'enabled': {'type': 'boolean', 'default': False},
+            'color': {'type': 'string', 'default': 'black'},
+            'offset': {'type': 'list', 'default': [1, 1]},
+            'radius': {'type': 'integer', 'default': 3},
+        },
+        'default': {'enabled': False, 'color': 'black', 'offset': [1, 1], 'radius': 3}
+    }
+}

--- a/src/core/validation/widgets/komorebi/stack.py
+++ b/src/core/validation/widgets/komorebi/stack.py
@@ -71,6 +71,17 @@ VALIDATION_SCHEMA = {
         'default': DEFAULTS['container_padding'],
         'required': False
     },
+    'btn_shadow': {
+        'type': 'dict',
+        'required': False,
+        'schema': {
+            'enabled': {'type': 'boolean', 'default': False},
+            'color': {'type': 'string', 'default': 'black'},
+            'offset': {'type': 'list', 'default': [1, 1]},
+            'radius': {'type': 'integer', 'default': 3},
+        },
+        'default': {'enabled': False, 'color': 'black', 'offset': [1, 1], 'radius': 3}
+    },
     'label_shadow': {
         'type': 'dict',
         'required': False,

--- a/src/core/validation/widgets/komorebi/stack.py
+++ b/src/core/validation/widgets/komorebi/stack.py
@@ -7,6 +7,7 @@ DEFAULTS = {
     'max_length': None,
     'max_length_ellipsis': '...',
     'hide_if_offline': False,
+    'show_only_stack': False,
     'animation': False,
     'enable_scroll_switching': False,
     'reverse_scroll_direction': False,
@@ -37,6 +38,10 @@ VALIDATION_SCHEMA = {
     'hide_if_offline': {
         'type': 'boolean',
         'default': DEFAULTS['hide_if_offline']
+    },
+    'show_only_stack': {
+        'type': 'boolean',
+        'default': DEFAULTS['show_only_stack']
     },
     'max_length': {
         'type': 'integer',

--- a/src/core/widgets/komorebi/stack.py
+++ b/src/core/widgets/komorebi/stack.py
@@ -122,6 +122,7 @@ class StackWidget(BaseWidget):
             animation: bool,
             enable_scroll_switching: bool,
             reverse_scroll_direction: bool,
+            btn_shadow: dict = None,
             label_shadow: dict = None,
             container_shadow: dict = None
     ):
@@ -137,6 +138,7 @@ class StackWidget(BaseWidget):
         self._hide_if_offline = hide_if_offline
         self._padding = container_padding
         self._animation = animation
+        self._btn_shadow = btn_shadow
         self._label_shadow = label_shadow
         self._container_shadow = container_shadow
         self._komorebi_screen = None
@@ -324,7 +326,7 @@ class StackWidget(BaseWidget):
             for window_index in self._window_buttons:
                 self._widget_container_layout.addWidget(window_index)
                 self._update_button_status(window_index)
-                add_shadow(window_index, self._label_shadow)
+                add_shadow(window_index, self._btn_shadow)
                 
     def _get_window_label(self, window_index):
         window = self._komorebic.get_window_by_index(self._komorebi_focus_container, window_index)

--- a/src/core/widgets/komorebi/stack.py
+++ b/src/core/widgets/komorebi/stack.py
@@ -1,0 +1,401 @@
+import logging
+from PyQt6.QtWidgets import QPushButton, QWidget, QHBoxLayout, QLabel
+from PyQt6.QtCore import Qt, pyqtSignal, QTimer
+from PyQt6.QtGui import QCursor
+from typing import Literal
+from contextlib import suppress
+from core.utils.win32.utilities import get_monitor_hwnd
+from core.utils.utilities import add_shadow
+from core.event_service import EventService
+from core.event_enums import KomorebiEvent
+from core.widgets.base import BaseWidget
+from core.utils.komorebi.client import KomorebiClient
+from core.validation.widgets.komorebi.stack import VALIDATION_SCHEMA
+from core.utils.win32.app_icons import get_window_icon
+
+try:
+    from core.utils.komorebi.event_listener import KomorebiEventListener
+except ImportError:
+    KomorebiEventListener = None
+    logging.warning("Failed to load Komorebi Event Listener")
+
+WorkspaceStatus = Literal["INACTIVE", "ACTIVE"]
+WORKSPACE_STATUS_INACTIVE: WorkspaceStatus = "INACTIVE"
+WORKSPACE_STATUS_ACTIVE: WorkspaceStatus = "ACTIVE"
+
+class WindowButton(QPushButton):
+
+    def __init__(self, window_index: int, parent_widget: 'StackWidget', label: str = None, active_label: str = None, animation: bool = False):
+        super().__init__()
+        self._animation_initialized = False
+        self.komorebic = KomorebiClient()
+        self.window_index = window_index
+        self.parent_widget = parent_widget
+        self.status = WORKSPACE_STATUS_INACTIVE
+        self.setProperty("class", f"window")
+        self.default_label = label if label else str(window_index + 1)
+        self.active_label = active_label if active_label else self.default_label
+        self.setText(self.default_label)
+        self.clicked.connect(self.focus_stack_window)
+        self._animation = animation
+        self.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
+        self.hide()
+        
+    def update_visible_buttons(self):
+        visible_buttons = [btn for btn in self.parent_widget._window_buttons if btn.isVisible()]
+        for index, button in enumerate(visible_buttons):
+            current_class = button.property("class")
+            new_class = ' '.join([cls for cls in current_class.split() if not cls.startswith('button-')])
+            new_class = f"{new_class} button-{index + 1}"
+            button.setProperty("class", new_class)
+            button.setStyleSheet('')
+ 
+    def update_and_redraw(self, status: WorkspaceStatus):
+        self.status = status
+        self.setProperty("class", f"window {status.lower()}")
+        if status == WORKSPACE_STATUS_ACTIVE:
+            self.setText(self.active_label)
+        else:
+            self.setText(self.default_label)
+        self.setStyleSheet('')
+
+    def focus_stack_window(self):
+        try:
+            self.komorebic.focus_stack_window(self.window_index)
+            if self._animation:
+                pass
+                #self.animate_buttons()
+        except Exception:
+            logging.exception(f"Failed to focus workspace at index {self.window_index}")
+
+    def animate_buttons(self, duration=200, step=30):
+        # Store the initial width if not already stored (to enable reverse animations)
+        if not hasattr(self, '_initial_width'):
+            self._initial_width = self.width()
+
+        self._current_width = self.width()
+        target_width = self.sizeHint().width()
+
+        step_duration = int(duration / step)
+        width_increment = (target_width - self._current_width) / step
+        self._current_step = 0
+
+        def update_width():
+            if self._current_step < step:
+                self._current_width += width_increment
+                self.setFixedWidth(int(self._current_width))
+                self._current_step += 1
+            else:
+                # Animation done: stop timer and set to target exactly
+                self._animation_timer.stop()
+                self.setFixedWidth(target_width)
+
+        # Stop any existing timer before starting a new one to prevent conflicts
+        if hasattr(self, '_animation_timer') and self._animation_timer.isActive():
+            self._animation_timer.stop()
+
+        # Parent the timer to the widget to avoid potential memory leaks
+        self._animation_timer = QTimer(self)
+        self._animation_timer.timeout.connect(update_width)
+        self._animation_timer.start(step_duration)
+        
+        
+class StackWidget(BaseWidget):
+    k_signal_connect = pyqtSignal(dict)
+    k_signal_update = pyqtSignal(dict, dict)
+    k_signal_disconnect = pyqtSignal()
+    validation_schema = VALIDATION_SCHEMA
+    event_listener = KomorebiEventListener
+
+    def __init__(
+            self,
+            label_offline: str,
+            label_window: str,
+            label_window_active: str,
+            label_no_window: str,
+            label_zero_index: bool,
+            max_length: int,
+            max_length_active: int,
+            max_length_ellipsis: str,
+            hide_if_offline: bool,
+            container_padding: dict,
+            animation: bool,
+            enable_scroll_switching: bool,
+            reverse_scroll_direction: bool,
+            label_shadow: dict = None,
+            container_shadow: dict = None
+    ):
+        super().__init__(class_name="komorebi-stack")
+        self._event_service = EventService()
+        self._komorebic = KomorebiClient()
+        self._label_window = label_window
+        self._label_window_active = label_window_active
+        self._label_zero_index = label_zero_index
+        self._max_length = max_length
+        self._max_length_active = max_length_active
+        self._max_length_ellipsis = max_length_ellipsis
+        self._hide_if_offline = hide_if_offline
+        self._padding = container_padding
+        self._animation = animation
+        self._label_shadow = label_shadow
+        self._container_shadow = container_shadow
+        self._komorebi_screen = None
+        self._komorebi_focus_container = None
+        self._komorebi_windows = []
+        self._prev_workspace_index = None
+        self._curr_workspace_index = None  
+        self._prev_container_index = None
+        self._curr_container_index = None
+        self._prev_window_index = None
+        self._curr_window_index = None
+        self._window_buttons: list[WindowButton] = []
+        self._window_focus_events = [
+            KomorebiEvent.CycleStack.value,
+            KomorebiEvent.FocusStackWindow.value,
+        ]
+        self._reset_buttons_events = [                                                                                                                      
+            KomorebiEvent.ReloadConfiguration.value,
+            KomorebiEvent.WatchConfiguration.value,
+            KomorebiEvent.StackWindow.value,
+            KomorebiEvent.UnstackWindow.value,
+            KomorebiEvent.TitleUpdate.value,
+        ]
+        # Disable default mouse event handling inherited from BaseWidget
+        self.mousePressEvent = None
+        if self._hide_if_offline:
+            self.hide()
+        # Status text shown when komorebi state can't be retrieved
+        self._offline_text = QLabel()
+        self._offline_text.setText(label_offline)
+        add_shadow(self._offline_text, self._label_shadow)
+        self._offline_text.setProperty("class", "offline-status")
+        # Status text shown when there is no active window
+        self._no_window_text = QLabel()
+        self._no_window_text.setText(label_no_window)
+        add_shadow(self._no_window_text, self._label_shadow)
+        self._no_window_text.setProperty("class", "no-window")
+        # Construct container which holds workspace buttons
+        self._widget_container_layout: QHBoxLayout = QHBoxLayout()
+        self._widget_container_layout.setSpacing(0)
+        self._widget_container_layout.setContentsMargins(self._padding['left'],self._padding['top'],self._padding['right'],self._padding['bottom'])
+        self._widget_container_layout.addWidget(self._offline_text)
+        self._widget_container_layout.addWidget(self._no_window_text)
+        self._widget_container: QWidget = QWidget()
+        self._widget_container.setLayout(self._widget_container_layout)
+        self._widget_container.setProperty("class", "widget-container")
+        add_shadow(self._widget_container, self._container_shadow)
+        self._widget_container.hide()
+        self.widget_layout.addWidget(self._offline_text)
+        self.widget_layout.addWidget(self._no_window_text)
+        self.widget_layout.addWidget(self._widget_container)
+        
+        self._enable_scroll_switching = enable_scroll_switching
+        self._reverse_scroll_direction = reverse_scroll_direction
+
+        self._hide_no_window_text()
+        self._register_signals_and_events()
+
+    def _register_signals_and_events(self):
+        self.k_signal_connect.connect(self._on_komorebi_connect_event)
+        self.k_signal_update.connect(self._on_komorebi_update_event)
+        self.k_signal_disconnect.connect(self._on_komorebi_disconnect_event)
+        self._event_service.register_event(KomorebiEvent.KomorebiConnect, self.k_signal_connect)
+        self._event_service.register_event(KomorebiEvent.KomorebiDisconnect, self.k_signal_disconnect)
+        self._event_service.register_event(KomorebiEvent.KomorebiUpdate, self.k_signal_update)
+
+    def _reset(self):
+        self._komorebi_state = None
+        self._komorebi_screen = None
+        self._komorebi_windows = []
+        self._prev_workspace_index = None
+        self._curr_workspace_index = None     
+        self._prev_container_index = None
+        self._curr_container_index = None
+        self._prev_window_index = None
+        self._curr_window_index = None
+        self._window_buttons = []
+        self._clear_container_layout()
+
+    def _on_komorebi_connect_event(self, state: dict) -> None:
+        self._reset()
+        self._hide_offline_status()
+        if self._update_komorebi_state(state):
+            self._add_or_update_buttons()
+        if self._hide_if_offline:
+            self.show()
+
+    def _on_komorebi_disconnect_event(self) -> None:
+        self._show_offline_status()
+        if self._hide_if_offline:
+            self.hide()
+
+    def _on_komorebi_update_event(self, event: dict, state: dict) -> None:
+        if self._update_komorebi_state(state):  
+            self._hide_no_window_text()    
+            if event['type'] in self._window_focus_events or self._has_active_window_index_changed():
+                try:
+                    prev_window_button = self._window_buttons[self._prev_window_index]
+                    self._update_button_status(prev_window_button)
+                    new_window_button = self._window_buttons[self._curr_window_index]
+                    self._update_button_status(new_window_button)
+                except (IndexError, TypeError):
+                    self._add_or_update_buttons()
+            elif event['type'] in self._reset_buttons_events or self._has_active_container_index_changed() or self._has_active_workspace_index_changed():
+                self._window_buttons = []
+                self._add_or_update_buttons()
+            if event['type'] in ['Minimize', 'Show', 'Hide', 'Destroy', 'Close']:
+                self._window_buttons = []
+                self._add_or_update_buttons()
+        else:
+            # Clear everything if state can't be updated
+            self._window_buttons = []
+            self._show_no_window_text()
+                
+    def _clear_container_layout(self):
+        for i in reversed(range(self._widget_container_layout.count())):
+            old_widget = self._widget_container_layout.itemAt(i).widget()
+            self._widget_container_layout.removeWidget(old_widget)
+            old_widget.setParent(None)
+
+    def _update_komorebi_state(self, komorebi_state: dict) -> bool:
+        try:
+            self._screen_hwnd = get_monitor_hwnd(int(QWidget.winId(self)))
+            self._komorebi_state = komorebi_state
+            if self._komorebi_state:
+                self._komorebi_screen = self._komorebic.get_screen_by_hwnd(self._komorebi_state, self._screen_hwnd)
+                focused_workspace = self._komorebic.get_focused_workspace(self._komorebi_screen)
+                focused_container = self._komorebic.get_focused_container(focused_workspace)
+                self._komorebi_focus_container = focused_container
+                self._komorebi_windows = self._komorebic.get_windows(focused_container)
+                focused_window = self._komorebic.get_focused_window(focused_container)
+
+                if focused_workspace:
+                    self._prev_workspace_index = self._curr_workspace_index
+                    self._curr_workspace_index = focused_workspace['index']                    
+                if focused_container:
+                    self._prev_container_index = self._curr_container_index
+                    self._curr_container_index = focused_container['index']
+                if focused_window:
+                    self._prev_window_index = self._curr_window_index
+                    self._curr_window_index = focused_window['index']
+                return True
+        except TypeError:
+            return False
+
+    def _has_active_window_index_changed(self):
+        return self._prev_window_index != self._curr_window_index and not self._has_active_container_index_changed()
+
+    def _has_active_container_index_changed(self):
+        return self._prev_container_index != self._curr_container_index and not self._has_active_workspace_index_changed()
+
+    def _has_active_workspace_index_changed(self):
+        return self._prev_workspace_index != self._curr_workspace_index
+
+    def _get_window_new_status(self, window) -> WorkspaceStatus:
+        if self._curr_window_index == window['index']:
+            return WORKSPACE_STATUS_ACTIVE
+        else:
+            return WORKSPACE_STATUS_INACTIVE
+
+    def _update_button_status(self, window_btn: WindowButton) -> None:
+        window_index = window_btn.window_index
+        window = self._komorebi_windows[window_index]
+        window_status = self._get_window_new_status(window)
+        window_btn.show()
+        if window_btn.status != window_status:
+            window_btn.update_and_redraw(window_status)
+            if self._animation and window_btn._animation_initialized:
+                window_btn.animate_buttons()
+        window_btn.update_visible_buttons()
+        window_btn._animation_initialized = True
+
+    def _add_or_update_buttons(self) -> None:
+        buttons_added = False
+        for window_index, _ in enumerate(self._komorebi_windows):             
+            try:
+                button = self._window_buttons[window_index]
+                self._update_button_status(button)
+            except IndexError:
+                button = self._try_add_window_button(window_index)
+                buttons_added = True    
+        if buttons_added:
+            self._window_buttons.sort(key=lambda btn: btn.window_index)
+            self._clear_container_layout()
+            for window_index in self._window_buttons:
+                self._widget_container_layout.addWidget(window_index)
+                self._update_button_status(window_index)
+                add_shadow(window_index, self._label_shadow)
+                
+    def _get_window_label(self, window_index):
+        window = self._komorebic.get_window_by_index(self._komorebi_focus_container, window_index)
+        w_index = window_index if self._label_zero_index else window_index + 1
+        process_name = window['exe'].removesuffix('.exe')
+        default_label = self._label_window.format(
+            index=w_index,
+            title=window['title'],
+            process=process_name,
+            hwnd=window['hwnd']
+        )
+        active_label = self._label_window_active.format(
+            index=w_index,
+            title=window['title'],
+            process=process_name,
+            hwnd=window['hwnd']
+        )
+        if self._max_length and len(default_label) > self._max_length:
+            default_label = default_label[:self._max_length] + self._max_length_ellipsis
+        if self._max_length_active and len(active_label) > self._max_length_active:
+            active_label = active_label[:self._max_length_active] + self._max_length_ellipsis
+        return default_label, active_label
+
+    def _try_add_window_button(self, window_index: int) -> WindowButton:
+        window_button_indexes = [ws_btn.window_index for ws_btn in self._window_buttons]
+        if window_index not in window_button_indexes:
+            default_label, active_label = self._get_window_label(window_index)
+            window_btn = WindowButton(window_index, self, default_label, active_label, self._animation)
+            self._window_buttons.append(window_btn)
+            return window_btn
+
+    def _try_remove_window_button(self, window_index: int) -> None:
+        with suppress(IndexError):
+            self._window_buttons.pop(window_index)
+
+    def _show_offline_status(self):
+        self._offline_text.show()
+        self._widget_container.hide()
+
+    def _hide_offline_status(self):
+        self._offline_text.hide()
+        self._widget_container.show()
+
+    def _show_no_window_text(self):
+        self._no_window_text.show()
+        self._widget_container.hide()
+
+    def _hide_no_window_text(self):
+        self._no_window_text.hide()
+        self._widget_container.show()
+
+    def wheelEvent(self, event):
+        """Handle mouse wheel events to switch workspaces."""
+        if not self._enable_scroll_switching or not self._komorebi_screen:
+            return
+
+        delta = event.angleDelta().y()
+        # Determine direction (consider reverse_scroll_direction setting)
+        direction = -1 if (delta > 0) != self._reverse_scroll_direction else 1
+
+        windows = self._komorebic.get_windows(self._komorebi_focus_container)
+        if not windows:
+            return
+
+        current_idx = self._curr_window_index
+        num_windows = len(windows)
+        next_idx = (current_idx + direction) % num_windows
+        try:
+            self._komorebic.focus_stack_window(next_idx)
+        except Exception:
+            logging.exception(
+                f"Failed to switch to workspace at index {next_idx}")
+
+    

--- a/src/core/widgets/komorebi/stack.py
+++ b/src/core/widgets/komorebi/stack.py
@@ -118,6 +118,7 @@ class StackWidget(BaseWidget):
             max_length_active: int,
             max_length_ellipsis: str,
             hide_if_offline: bool,
+            show_only_stack: bool,
             container_padding: dict,
             animation: bool,
             enable_scroll_switching: bool,
@@ -136,6 +137,7 @@ class StackWidget(BaseWidget):
         self._max_length_active = max_length_active
         self._max_length_ellipsis = max_length_ellipsis
         self._hide_if_offline = hide_if_offline
+        self._show_only_stack = show_only_stack
         self._padding = container_padding
         self._animation = animation
         self._btn_shadow = btn_shadow
@@ -248,6 +250,9 @@ class StackWidget(BaseWidget):
             if event['type'] in ['Minimize', 'Show', 'Hide', 'Destroy', 'Close']:
                 self._window_buttons = []
                 self._add_or_update_buttons()
+            if self._show_only_stack and len(self._window_buttons) == 1:
+                self._show_no_window_text()
+
         else:
             # Clear everything if state can't be updated
             self._window_buttons = []

--- a/src/core/widgets/komorebi/stack.py
+++ b/src/core/widgets/komorebi/stack.py
@@ -245,7 +245,6 @@ class StackWidget(BaseWidget):
                 except (IndexError, TypeError):
                     self._add_or_update_buttons()
             if event['type'] in self._reset_buttons_events or self._has_active_container_index_changed() or self._has_active_workspace_index_changed():
-                logging.debug(f"Resetting buttons due to event: {event['type']}")
                 self._window_buttons = []
                 self._add_or_update_buttons()
             if event['type'] in ['Minimize', 'Show', 'Hide', 'Destroy', 'Close']:

--- a/src/core/widgets/komorebi/stack.py
+++ b/src/core/widgets/komorebi/stack.py
@@ -244,7 +244,8 @@ class StackWidget(BaseWidget):
                     self._update_button_status(new_window_button)
                 except (IndexError, TypeError):
                     self._add_or_update_buttons()
-            elif event['type'] in self._reset_buttons_events or self._has_active_container_index_changed() or self._has_active_workspace_index_changed():
+            if event['type'] in self._reset_buttons_events or self._has_active_container_index_changed() or self._has_active_workspace_index_changed():
+                logging.debug(f"Resetting buttons due to event: {event['type']}")
                 self._window_buttons = []
                 self._add_or_update_buttons()
             if event['type'] in ['Minimize', 'Show', 'Hide', 'Destroy', 'Close']:


### PR DESCRIPTION
This widget allows users to see all windows in the currently active stack and click to focus on any individual window.

I have tested every action I know and can perform, including stacking, unstacking, and switching workspaces, and the buttons update correctly.
I haven't tested actions across monitors yet, but there shouldn't be any issues.

Known issue: 
When using the taskbar or a taskbar widget to open a window that is part of a stack but not currently focused, the widget may not detect the change and fail to update the buttons. This might occur because the taskbar only brings a single window to the front, rather than the entire stack.

https://github.com/user-attachments/assets/cbd4bf70-4353-4812-94ac-7beabdab08dd