### PR TITLE
feat(battery): Add `hide_unsupported` option

### DIFF
--- a/docs/widgets/(Widget)-Battery.md
+++ b/docs/widgets/(Widget)-Battery.md
@@ -6,6 +6,7 @@
 | `label_alt`             | string  | `{percent}%` | Battery percent           | The alternative label format.                                               |
 | `update_interval`       | integer | `5000`                                       | The interval in milliseconds to update the widget.                          |
 | `time_remaining_natural`| boolean | `False`                                      | Whether to display the remaining time in a natural format.                  |
+| `hide_unsupported`| boolean | `True`                                      | Whether to hide the widget if the current system does not have battery info.                  |
 | `charging_options`      | dict    | `{icon_format: '{charging_icon} {icon}', blink_charging_icon: True}` | Options for charging state display.                                         |
 | `status_thresholds`     | dict    | `{critical: 10, low: 25, medium: 75, high: 95, full: 100}` | Thresholds for different battery statuses.                                  |
 | `status_icons`          | dict    | `{icon_charging: '\uf0e7', icon_critical: '\uf244', icon_low: '\uf243', icon_medium: '\uf242', icon_high: '\uf241', icon_full: '\uf240'}` | Icons for different battery statuses.                                       |
@@ -38,6 +39,7 @@ battery:
 - `label_alt`: The alternative label format for the battery widget. Useful for displaying additional battery details such as `{percent}%` and `remaining: {time_remaining}`.
 - `update_interval`: The interval in milliseconds to update the widget.
 - `time_remaining_natural`: A boolean indicating whether to display the remaining time in a natural format.
+- `hide_unsupported`: A boolean indicating whether to hide the widget if the current system does not have battery information.
 - `charging_options`: A dictionary specifying options for displaying the charging state. It contains:
   - `icon_format`: The format string for the charging icon. You can use placeholders like `{charging_icon}` and `{icon}`.
 - `status_thresholds`: A dictionary specifying the thresholds for different battery statuses. It contains:

--- a/src/core/validation/widgets/yasb/battery.py
+++ b/src/core/validation/widgets/yasb/battery.py
@@ -3,6 +3,7 @@ DEFAULTS = {
     'label_alt': '{percent}% | remaining: {time_remaining}',
     'update_interval': 5000,
     'time_remaining_natural': False,
+    'hide_unsupported': True,
     'charging_options': {
         'icon_format': '{charging_icon} {icon}',
         'blink_charging_icon': True
@@ -53,6 +54,10 @@ VALIDATION_SCHEMA = {
     'time_remaining_natural': {
         'type': 'boolean',
         'default': DEFAULTS['time_remaining_natural']
+    },
+    'hide_unsupported': {
+        'type': 'boolean',
+        'default': DEFAULTS['hide_unsupported']
     },
     'charging_options': {
         'type': 'dict',

--- a/src/core/widgets/yasb/battery.py
+++ b/src/core/widgets/yasb/battery.py
@@ -18,6 +18,7 @@ class BatteryWidget(BaseWidget):
             label_alt: str,
             update_interval: int,
             time_remaining_natural: bool,
+            hide_unsupported: bool,
             charging_options: dict[str, Union[str, bool]],
             status_thresholds: dict[str, int],
             status_icons: dict[str, str],
@@ -38,6 +39,7 @@ class BatteryWidget(BaseWidget):
         self._animation = animation
         self._icon_charging_format = charging_options['icon_format']
         self._icon_charging_blink = charging_options['blink_charging_icon']
+        self._hide_unsupported = hide_unsupported
         self._padding = container_padding
         self._label_shadow = label_shadow
         self._container_shadow = container_shadow
@@ -160,6 +162,10 @@ class BatteryWidget(BaseWidget):
         self._battery_state = psutil.sensors_battery()  
         # Check battery state
         if self._battery_state is None:
+            if self._hide_unsupported:
+                self.hide()
+                return
+
             for part in label_parts:
                 part = part.strip()
                 if widget_index < len(active_widgets) and isinstance(active_widgets[widget_index], QLabel):

--- a/src/core/widgets/yasb/battery.py
+++ b/src/core/widgets/yasb/battery.py
@@ -164,6 +164,7 @@ class BatteryWidget(BaseWidget):
         if self._battery_state is None:
             if self._hide_unsupported:
                 self.hide()
+                self.timer.stop()
                 return
 
             for part in label_parts:


### PR DESCRIPTION
Feature requested in #239

Added new option to the Battery widget. The option `hide_unsupported` defaults to true. If the system cannot provide any battery info and the `hide_unsupported` option is set to true then it will hide the Battery widget.