### PR TITLE
feat(github): added notification dot option

### DIFF
--- a/docs/widgets/(Widget)-Github.md
+++ b/docs/widgets/(Widget)-Github.md
@@ -1,21 +1,22 @@
 # Github Widget Options
 
-| Option           | Type     | Default                        | Description                                                                 |
-|------------------|----------|--------------------------------|-----------------------------------------------------------------------------|
-| `label`          | string   | `'{icon}'`                     | The format string for the label. You can use placeholders like `{icon}` to dynamically insert icon information. |
-| `label_alt`      | string   | `'{data} Notifications'`       | The alternative format string for the label. Useful for displaying additional notification details. |
-| `tooltip`  | boolean  | `True`        | Whether to show the tooltip on hover. |
-| `update_interval`| integer  | `600`                          | The interval in seconds to update the notifications. Must be between 60 and 3600. |
-| `token`          | string   | `""`                           | The GitHub personal access token. |
-| `max_notification`| integer | `20`                           | The maximum number of notifications to display in the menu. |
-| `only_unread`    | boolean  | `False`                        | Whether to show only unread notifications. |
-| `max_field_size` | integer  | `100`                          | The maximum number of characters in the title before truncation. |
-| `menu` | dict | `{'blur': True, 'round_corners': True, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Menu settings for the widget. |
-| `icons`          | dict     | `{'issue': '\uf41b', 'pull_request': '\uea64', 'release': '\uea84', 'discussion': '\uf442', 'default': '\uea84', 'github_logo': '\uea84'}` | Icons for different types of notifications in the menu. |
-| `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
-| `container_padding`  | dict | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}`      | Explicitly set padding inside widget container. |
-| `container_shadow`   | dict   | `None`                  | Container shadow options.                       |
-| `label_shadow`         | dict   | `None`                  | Label shadow options.                 |
+| Option              | Type    | Default                                                                                                                                                                         | Description                                                                                                     |
+|---------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `label`             | string  | `'{icon}'`                                                                                                                                                                      | The format string for the label. You can use placeholders like `{icon}` to dynamically insert icon information. |
+| `label_alt`         | string  | `'{data} Notifications'`                                                                                                                                                        | The alternative format string for the label. Useful for displaying additional notification details.             |
+| `tooltip`           | boolean | `True`                                                                                                                                                                          | Whether to show the tooltip on hover.                                                                           |
+| `update_interval`   | integer | `600`                                                                                                                                                                           | The interval in seconds to update the notifications. Must be between 60 and 3600.                               |
+| `token`             | string  | `""`                                                                                                                                                                            | The GitHub personal access token.                                                                               |
+| `max_notification`  | integer | `20`                                                                                                                                                                            | The maximum number of notifications to display in the menu.                                                     |
+| `notification_dot`  | dict    | `{'enabled': True, 'corner': 'bottom_left', 'color': 'red', 'margin': [1, 1]}`                                                                                                  | A dictionary specifying the notification dot settings for the widget.                                           |
+| `only_unread`       | boolean | `False`                                                                                                                                                                         | Whether to show only unread notifications.                                                                      |
+| `max_field_size`    | integer | `100`                                                                                                                                                                           | The maximum number of characters in the title before truncation.                                                |
+| `menu`              | dict    | `{'blur': True, 'round_corners': True, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Menu settings for the widget.                                                                                   |
+| `icons`             | dict    | `{'issue': '\uf41b', 'pull_request': '\uea64', 'release': '\uea84', 'discussion': '\uf442', 'default': '\uea84', 'github_logo': '\uea84'}`                                      | Icons for different types of notifications in the menu.                                                         |
+| `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`                                                                                                                       | Animation settings for the widget.                                                                              |
+| `container_padding` | dict    | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}`                                                                                                                                | Explicitly set padding inside widget container.                                                                 |
+| `container_shadow`  | dict    | `None`                                                                                                                                                                          | Container shadow options.                                                                                       |
+| `label_shadow`      | dict    | `None`                                                                                                                                                                          | Label shadow options.                                                                                           |
 
 ```yaml
 github:
@@ -25,6 +26,11 @@ github:
     label_alt: "Notifications {data}" # {data} return number of unread notification
     token: ghp_xxxxxxxxxxx # GitHub Personal access tokens (classic) https://github.com/settings/tokens
     max_notification: 20 # Max number of notification displaying in menu max: 50
+    notification_dot:
+      enabled: True
+      corner: "bottom_left" # Can be "top_left", "top_right", "bottom_left", "bottom_right"
+      color: "red" # Can be hex color or string
+      margin: [ 1, 1 ] # x and y margin for the dot
     only_unread: false # Show only unread or all notifications; 
     max_field_size: 54 # Max characters in title before truncation.
     update_interval: 300 # Check for new notification in seconds
@@ -36,7 +42,7 @@ github:
       alignment: "right"
       direction: "down"
     label_shadow:
-      enabled: true
+      enabled: True
       color: "black"
       radius: 3
       offset: [ 1, 1 ]
@@ -49,6 +55,11 @@ github:
 - **update_interval:** The interval in seconds to update the notifications. Must be between 60 and 3600.
 - **token:** The GitHub personal access token. GitHub Personal access tokens (classic) https://github.com/settings/tokens you can set `token: env`, this means you have to set YASB_GITHUB_TOKEN in environment variable.
 - **max_notification:** The maximum number of notifications to display in the menu, max 50.
+- **notification_dot:** A dictionary specifying the notification dot settings for the widget. This will show a dot on the icon (enclosed with the <span> tag).
+  - **enabled:** Enable notification dot.
+  - **corner:** Set the corner where the dot should appear.
+  - **color:** Set the color of the notification dot. Can be hex or string color.
+  - **margin:** Set the x, y margin for the notification dot.
 - **only_unread:** Whether to show only unread notifications.
 - **max_field_size:** The maximum number of characters in the title before truncation.
 - **menu:** A dictionary specifying the menu settings for the widget. It contains the following keys:

--- a/src/core/validation/widgets/yasb/github.py
+++ b/src/core/validation/widgets/yasb/github.py
@@ -7,6 +7,12 @@ DEFAULTS = {
     'max_notification':30,
     'only_unread': False,
     'max_field_size': 100,
+    'notification_dot': {
+        'enabled': True,
+        'corner': 'bottom_left',
+        'color': 'red',
+        'margin': [1, 1],
+    },
     'menu': {
         'blur': True,
         'round_corners': True,
@@ -61,6 +67,27 @@ VALIDATION_SCHEMA = {
     'max_notification': {
         'type': 'integer',
         'default': DEFAULTS['max_notification']
+    },
+    'notification_dot' : {
+        'type': 'dict',
+        'required': False,
+        'schema': {
+            'enabled': {
+                'type': 'boolean',
+                'default': DEFAULTS['notification_dot']['enabled'],
+            },
+            'corner': {
+                'type': 'string',
+                'default': DEFAULTS['notification_dot']['corner'],
+                'allowed': ['top_left', 'top_right', 'bottom_left', 'bottom_right'],
+            },
+            'color': {
+                'type': 'string',
+                'default': DEFAULTS['notification_dot']['color'],
+            },
+            'margin': {'type': 'list', 'default': [1, 1]},
+        },
+        'default': DEFAULTS['notification_dot'],
     },
     'only_unread': {
         'type': 'boolean',


### PR DESCRIPTION
This option will show a small dot in a specified corner with specified color when there are unread notifications available. 
Can also have customizable x and y margin. 
It is drawn on the QLabel itself, so changing margin/padding for the `.icon` style will affect the dot position.

![image](https://github.com/user-attachments/assets/27e0c83a-5447-4c83-90ee-e85ba09417e8)

```yaml
notification_dot:
  enabled: True
  corner: "bottom_left" # Can be "top_left", "top_right", "bottom_left", "bottom_right"
  color: "red" # Can be hex color or string
  margin: [ 1, 1 ] # x and y margin for the dot
```

