### PR TITLE
feat(komorebi): add app icons/more options to stack widget

### DIFF
--- a/docs/widgets/(Widget)-Komorebi-Stack.md
+++ b/docs/widgets/(Widget)-Komorebi-Stack.md
@@ -3,15 +3,18 @@ This widget displays information about each window in the currently active Komor
 | Option                     | Type    | Default                  | Description                                                                 |
 |----------------------------|---------|--------------------------|-----------------------------------------------------------------------------|
 | `label_offline`          | string  | `'Komorebi Offline'`     | The label to display when Komorebi is offline.                              |
-| `label_window`    | string  | `'{index}'`              | The format string for window buttons.                                    |
-| `label_window_active` | string | `'{index}'`              | The format string for the active window button.                          |
+| `label_window`    | string  | `'{title}'`              | The format string for window buttons.                                    |
+| `label_window_active` | string | `'{title}'`              | The format string for the active window button.                          |
 | `label_no_window`       | string  | `''`                     | The label to display when no window is in focus.                                         |
 | `label_zero_index`        | boolean | `false`    | Whether to use zero-based indexing for window labels.                    |
-| `max_length`        | boolean | `None`    | 	The maximum length of the label text.              |
-| `max_length_active`        | boolean | `None`    | 	The maximum length of the label text for the active window.              |
-| `max_length_ellipsis`        | boolean | `None`    | 		The ellipsis to use when the label text exceeds the maximum length.              |
+| `show_icons`        | string | `never`                                                                  | Whether to display app icons.                                  |
+| `icon_size`   | integer | `16`                                                                    | The size of the icon displayed.                              |
+| `max_length`        | integer | `None`    | 	The maximum length of the label text.              |
+| `max_length_active`        | integer | `None`    | 	The maximum length of the label text for the active window.              |
+| `max_length_overall`        | integer | `None`    | 	If specified, `max_length` will be calculated as `max_length_overall` divided by the number of inactive windows.       |
+| `max_length_ellipsis`        | string | `'...'`    | 		The ellipsis to use when the label text exceeds the maximum length.              |
 | `hide_if_offline`       | boolean | `false`         | Whether to hide the widget if Komorebi is offline.                          |
-| `show_only_stack`       | boolean | `false`         | Whether to show buttons only for stacked windows (other windows will display `label_no_window`).             |
+| `show_only_stack`       | boolean | `false`         | Whether to hide the widget if no stacked windows in focus.                |
 | `enable_scroll_switching` | boolean | `false`      | Enable scroll switching between windows.                                 |
 | `reverse_scroll_direction` | boolean | `false`      | Reverse scroll direction.                                                  |
 | `animation`  | boolean | `false`      | Buttons animation.                                           |
@@ -23,36 +26,38 @@ This widget displays information about each window in the currently active Komor
 ## Example Configuration
 
 ```yaml
-  komorebi_stack:
-    type: "komorebi.stack.StackWidget"
-    options:
-      label_offline: "Offline"
-      label_window: "{process}"
-      label_window_active: "{title}"
-      label_no_window: "No Window"
-      label_zero_index: false
-      max_length: 10
-      max_length_active: 20
-      max_length_ellipsis: ".."
-      hide_if_offline: false
-      show_only_stack: false
-      animation: true
-      enable_scroll_switching : true
-      container_shadow:
-        enabled: true
-        color: "#000000"
-        offset: [0, 1]
-        radius: 2
-      btn_shadow:
-        enabled: true
-        color: "#000000"
-        offset: [0, 1]
-        radius: 2
-      label_shadow:
-        enabled: true
-        color: "#000000"
-        offset: [0, 1]
-        radius: 2
+komorebi_stack:
+  type: "komorebi.stack.StackWidget"
+  options:
+    label_offline: "Offline"
+    label_window: "{process}"
+    label_window_active: "{title}"
+    label_no_window: "No Window"
+    label_zero_index: false
+    show_icons: "always"
+    icon_size: 14
+    max_length: 10
+    max_length_active: 20
+    max_length_ellipsis: ".."
+    hide_if_offline: false
+    show_only_stack: false
+    animation: true
+    enable_scroll_switching : true
+    container_shadow:
+      enabled: true
+      color: "#000000"
+      offset: [0, 1]
+      radius: 2
+    btn_shadow:
+      enabled: true
+      color: "#000000"
+      offset: [0, 1]
+      radius: 2
+    label_shadow:
+      enabled: true
+      color: "#000000"
+      offset: [0, 1]
+      radius: 2
 ```
 
 ## Description of Options
@@ -61,17 +66,18 @@ This widget displays information about each window in the currently active Komor
 - **label_window_active:** The format string for the active window button, can be {title}, {index}, {process}, or {hwnd}.
 - **label_no_window:** The label to display when no window is in focus.  
 - **label_zero_index:** Whether to use zero-based indexing for workspace labels.
+- **show_icons:** Whether to display app icons. Options are `always`, `never`, or `focused`.
 - **max_length:** The maximum number of characters to display for the label. If the title exceeds this length, it will be truncated.
 - **max_length_active:** The maximum number of characters to display for the active window label. If the title exceeds this length, it will be truncated.
 - **max_length_ellipsis:** The string to append to truncated window titles.  
 - **hide_if_offline:** Whether to hide the widget if Komorebi is offline.
-- **show_only_stack:** Whether to show buttons only for stacked windows (other windows will display `label_no_window`).   
+- **show_only_stack:** Whether to hide the widget if no stacked windows in focus.   
 - **enable_scroll_switching:** Enable scroll switching between workspaces.
 - **reverse_scroll_direction:** Reverse scroll direction.
 - **animation:** Buttons animation.
 - **container_padding:** Explicitly set padding inside widget container.
 - **container_shadow:** Container shadow options.
-- **label_shadow:** Label shadow options for labels.
+- **label_shadow:** Label shadow options for labels, including icons and labels within each window button.
 - **btn_shadow:** Window button shadow options.
 
 ## Style
@@ -79,7 +85,11 @@ This widget displays information about each window in the currently active Komor
 .komorebi-stack {} /*Style for widget.*/
 .komorebi-stack .widget-container {} /*Style for widget container.*/
 .komorebi-stack .window {} /*Style for buttons.*/
+.komorebi-stack .window .label {} /*Style for the window label.*/
+.komorebi-stack .window .icon {} /*Style for the window icon.*/
 .komorebi-stack .window.active {} /*Style for the active window button.*/
+.komorebi-stack .window.active .label {} /*Style for the active window label.*/
+.komorebi-stack .window.active .icon {} /*Style for the active window icon.*/
 .komorebi-stack .window.button-1 {} /*Style for first button.*/
 .komorebi-stack .window.button-2 {} /*Style for second  button.*/
 .komorebi-stack .offline-status{} /*Style for offline status label.*/

--- a/src/core/utils/komorebi/client.py
+++ b/src/core/utils/komorebi/client.py
@@ -177,17 +177,26 @@ class KomorebiClient:
 
     def get_containers(self, workspace: dict) -> list:
         return [add_index(container, i) for i, container in enumerate(workspace['containers']['elements'])]
+    
+    def get_monocle_container(self, workspace: dict) -> Optional[dict]:
+        return workspace['monocle_container']
 
-    def get_container_by_index(self, workspace: dict, container_index: int) -> Optional[dict]:
+    def get_container_by_index(self, workspace: dict, container_index: int, get_monocle: bool) -> Optional[dict]:
         try:
             return self.get_containers(workspace)[container_index]
         except IndexError:
-            return None             
+            if get_monocle:
+                try:
+                    return self.get_monocle_container(workspace)
+                except (KeyError, TypeError):
+                    return None   
+            else: 
+                return None          
 
-    def get_focused_container(self, workspace: dict) -> Optional[dict]:
+    def get_focused_container(self, workspace: dict, get_monocle: bool = True) -> Optional[dict]:
         try:
             focused_container_index = workspace['containers']['focused']
-            focused_container = self.get_container_by_index(workspace, focused_container_index)
+            focused_container = self.get_container_by_index(workspace, focused_container_index, get_monocle)
             focused_container['index'] = focused_container_index
             return focused_container
         except (KeyError, TypeError):

--- a/src/core/validation/widgets/komorebi/stack.py
+++ b/src/core/validation/widgets/komorebi/stack.py
@@ -1,9 +1,11 @@
 DEFAULTS = {
     'label_offline': 'Komorebi Offline',
-    'label_window': '{tile}',
+    'label_window': '{title}',
     'label_window_active': '{title}',
     'label_no_window': '',
     'label_zero_index': False,
+    'show_icons': "never",
+    'icon_size': 16,
     'max_length': None,
     'max_length_ellipsis': '...',
     'hide_if_offline': False,
@@ -39,6 +41,16 @@ VALIDATION_SCHEMA = {
         'type': 'boolean',
         'default': DEFAULTS['hide_if_offline']
     },
+    'show_icons': {
+        'type': 'string',
+        'allowed': ['focused', 'always', 'never'],
+        'default': DEFAULTS['show_icons']
+    },
+    'icon_size': {
+        'type': 'integer',
+        'min': 0,
+        'default': DEFAULTS['icon_size']
+    },
     'show_only_stack': {
         'type': 'boolean',
         'default': DEFAULTS['show_only_stack']
@@ -50,6 +62,12 @@ VALIDATION_SCHEMA = {
         'default': DEFAULTS['max_length']
     },
     'max_length_active': {
+        'type': 'integer',
+        'min': 1,
+        'nullable': True,
+        'default': DEFAULTS['max_length']
+    },
+    'max_length_overall': {
         'type': 'integer',
         'min': 1,
         'nullable': True,


### PR DESCRIPTION
What I did:
- Added app icons 
- Change button structures from `QPushButton` to `QFrame + QHBoxLayout` for better label/icon styling
- Introduced options: `max_length_overall`, `show_icon`, `icon_size`, `hide_if_no_stack` (from #250) 
- Removed `show_only_stack` to reduce redundancy
- Applied `label_shadow` with label and icon