### PR TITLE
feat(glazewm)!: add css classes `active_populated` and `active_empty`

### DIFF
--- a/docs/widgets/(Widget)-GlazeWM-Workspaces.md
+++ b/docs/widgets/(Widget)-GlazeWM-Workspaces.md
@@ -1,17 +1,17 @@
 # GlazeWM Workspaces Widget
-| Option                  | Type    | Default                 | Description                                              |
-|-------------------------|---------|-------------------------|----------------------------------------------------------|
-| `offline_label`         | string  | `'GlazeWM Offline'`     | The label to display when GlazeWM is offline.            |
-| `populated_label`       | string  | `'{name}'`              | Optional label for populated workspaces.                 |
-| `empty_label`           | string  | `'{name}'`              | Optional label for empty workspaces.                     |
-| `active_populated_label`           | string  | `'{name}'`              | Optional label for the currently focused workspace (has opened windows).                     |
-| `active_empty_label`           | string  | `'{name}'`              | Optional label for the currently focused workspace (has no windows opened).                     |
-| `hide_empty_workspaces` | boolean | `true`                  | Whether to hide empty workspaces.                        |
-| `hide_if_offline`       | boolean | `false`                 | Whether to hide workspaces widget if GlazeWM is offline. |
-| `glazewm_server_uri`    | string  | `'ws://localhost:6123'` | Optional GlazeWM server uri.                             |
-| `container_padding`     | dict    | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}` | Explicitly set padding inside widget container.        |
-| `container_shadow`      | dict    | `None`                  | Container shadow options.                                |
-| `btn_shadow`            | dict    | `None`                  | Workspace button shadow options.                         |
+| Option                   | Type    | Default                                          | Description                                                                 |
+|--------------------------|---------|--------------------------------------------------|-----------------------------------------------------------------------------|
+| `offline_label`          | string  | `'GlazeWM Offline'`                              | The label to display when GlazeWM is offline.                               |
+| `populated_label`        | string  | `'{name}'`                                       | Optional label for populated workspaces.                                    |
+| `empty_label`            | string  | `'{name}'`                                       | Optional label for empty workspaces.                                        |
+| `active_populated_label` | string  | `'{name}'`                                       | Optional label for the currently focused workspace (has opened windows).    |
+| `active_empty_label`     | string  | `'{name}'`                                       | Optional label for the currently focused workspace (has no windows opened). |
+| `hide_empty_workspaces`  | boolean | `true`                                           | Whether to hide empty workspaces.                                           |
+| `hide_if_offline`        | boolean | `false`                                          | Whether to hide workspaces widget if GlazeWM is offline.                    |
+| `glazewm_server_uri`     | string  | `'ws://localhost:6123'`                          | Optional GlazeWM server uri.                                                |
+| `container_padding`      | dict    | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}` | Explicitly set padding inside widget container.                             |
+| `container_shadow`       | dict    | `None`                                           | Container shadow options.                                                   |
+| `btn_shadow`             | dict    | `None`                                           | Workspace button shadow options.                                            |
 
 ## Example Configuration
 
@@ -82,10 +82,11 @@ workspaces:
 ## Style
 ```css
 .glazewm-workspaces {} /*Style for widget.*/
-.glazewm-workspaces .btn {} /*Style for workspace buttons.*/
-.glazewm-workspaces .btn.active {} /*Style for active workspace button.*/
-.glazewm-workspaces .btn.populated {} /*Style for populated workspace button.*/
-.glazewm-workspaces .btn.empty {} /*Style for empty workspace button.*/
+.glazewm-workspaces .ws-btn {} /*Style for workspace buttons.*/
+.glazewm-workspaces .ws-btn.active_populated {} /*Style for active populated workspace button.*/
+.glazewm-workspaces .ws-btn.active_empty {} /*Style for active empty workspace button.*/
+.glazewm-workspaces .ws-btn.populated {} /*Style for populated workspace button.*/
+.glazewm-workspaces .ws-btn.empty {} /*Style for empty workspace button.*/
 .glazewm-workspaces .offline-status {} /*Style for offline status label.*/
 ```
 
@@ -104,7 +105,12 @@ workspaces:
     color: #CDD6F4;
 }
 
-.glazewm-workspaces .ws-btn.active {
+.glazewm-workspaces .ws-btn.active_populated {
+    color: #C2DAF7;
+    background-color: #727272;
+}
+.glazewm-workspaces .ws-btn.active_empty {
+    color: #7D8B9D;
     background-color: #727272;
 }
 

--- a/src/core/widgets/glazewm/workspaces.py
+++ b/src/core/widgets/glazewm/workspaces.py
@@ -28,7 +28,8 @@ else:
 class WorkspaceStatus(StrEnum):
     EMPTY = auto()
     POPULATED = auto()
-    ACTIVE = auto()
+    ACTIVE_EMPTY = auto()
+    ACTIVE_POPULATED = auto()
 
 
 def natural_sort_key(s: str, _nsre: re.Pattern[str] = re.compile(r"(\d+)")):
@@ -74,9 +75,11 @@ class GlazewmWorkspaceButton(QPushButton):
         self.glazewm_client.activate_workspace(self.workspace_name)
 
     def _update_status(self):
-        if self.is_displayed:
-            self.status = WorkspaceStatus.ACTIVE
-        elif self.workspace_window_count > 0 and not self.is_displayed:
+        if self.is_displayed and self.workspace_window_count > 0:
+            self.status = WorkspaceStatus.ACTIVE_POPULATED
+        elif self.is_displayed:
+            self.status = WorkspaceStatus.ACTIVE_EMPTY
+        elif self.workspace_window_count > 0:
             self.status = WorkspaceStatus.POPULATED
         else:
             self.status = WorkspaceStatus.EMPTY
@@ -96,11 +99,11 @@ class GlazewmWorkspaceButton(QPushButton):
         empty_label = empty_label.format_map(replacements)
         active_populated_label = active_populated_label.format_map(replacements)
         active_empty_label = active_empty_label.format_map(replacements)
-        if self.status == WorkspaceStatus.ACTIVE:
-            if self.workspace_window_count > 0:
-                self.setText(active_populated_label)
-            else:
-                self.setText(active_empty_label)
+        if self.status == WorkspaceStatus.ACTIVE_POPULATED:
+            self.setText(active_populated_label)
+            self.setHidden(False)
+        elif self.status == WorkspaceStatus.ACTIVE_EMPTY:
+            self.setText(active_empty_label)
             self.setHidden(False)
         elif self.status == WorkspaceStatus.POPULATED:
             self.setText(populated_label)


### PR DESCRIPTION
PR #249 added labels `active_populated` and `active_empty`, however the CSS classes for them for not implemented. This PR adds missing classes, removes obsolete ones and updates the docs.

BREAKING CHANGE: replace `.glazewm-workspaces .ws-btn.active` with `.glazewm-workspaces .ws-btn.active_populated` in styles.css