### PR TITLE
feat(komorebi): display opened app icons per workspace

### DIFF
--- a/docs/widgets/(Widget)-Komorebi-Workspaces.md
+++ b/docs/widgets/(Widget)-Komorebi-Workspaces.md
@@ -8,6 +8,7 @@
 | `label_default_name`       | string  | `''`                     | The default name for workspaces.                                            |
 | `label_float_override`     | string  | `'Override Active'`                     | The label to display when Komorebi is Float Override Active. |
 | `toggle_workspace_layer`  | dict    | `{'enabled': false, 'tiling_label': 'Tiling', 'floating_label': 'Floating'}` | Controls toggling between tiling and floating layers.  |
+| `app_icons`    | dict    | `{'enabled_populated': False, 'enabled_active': False, 'size': 16, 'max_icons': 0, 'hide_label': False, 'hide_duplicates': False, 'hide_floating': False}` | Controls the display of opened app icons per workspace. |
 | `hide_if_offline`       | boolean | `false`         | Whether to hide the widget if Komorebi is offline.                          |
 | `label_zero_index`        | boolean | `false`    | Whether to use zero-based indexing for workspace labels.                    |
 | `hide_empty_workspaces`  | boolean | `false`      | Whether to hide empty workspaces.                                           |
@@ -37,6 +38,14 @@ komorebi_workspaces:
       enabled: false
       tiling_label: "Tiling"
       floating_label: "Floating"
+    app_icons: 
+      enabled_populated: false
+      enabled_active: false
+      size: 12
+      max_icons: 0
+      hide_label: false
+      hide_duplicates: false
+      hide_floating: false
     container_padding: 
       top: 0
       left: 8
@@ -60,6 +69,14 @@ komorebi_workspaces:
   - **enabled:** Whether to enable the workspace layer toggle functionality.
   - **tiling_label:** The label to display for the tiling layer.
   - **floating_label:** The label to display for the floating layer.
+- **app_icons:** Controls the display of opened app icons per workspace.
+  - **enabled_populated:** Whether to show app icons in populated workspaces.
+  - **enabled_active:** Whether to show app icons in the active workspace.
+  - **size:** The size of the app icons.
+  - **max_icons:** The maximum number of app icons to display (0 for no limit).
+  - **hide_label:** Whether to hide the label of the workspace buttons that app icons are displayed.
+  - **hide_duplicates:** Whether to hide duplicate app icons.
+  - **hide_floating:** Whether to hide floating window app icons.
 - **hide_if_offline:** Whether to hide the widget if Komorebi is offline.
 - **label_zero_index:** Whether to use zero-based indexing for workspace labels.
 - **hide_empty_workspaces:** Whether to hide empty workspaces.
@@ -85,6 +102,17 @@ komorebi_workspaces:
 .komorebi-workspaces .workspace-layer.tiling {} /*Style for workspace layer text and icon when in tiling mode.*/
 .komorebi-workspaces .workspace-layer.floating {} /*Style for workspace layer text and icon when in floating mode.*/
 ```
+If `app_icons` is enabled (either `enabled_populated` or `enabled_active`), you can't use `.ws-btn` to style label. Add the following styles:
+```css
+.komorebi-workspaces .ws-btn .label {} /*Style for label text in buttons.*/
+.komorebi-workspaces .ws-btn.populated .label {} /*Style for label text in populated buttons.*/
+.komorebi-workspaces .ws-btn.active .label {} /*Style for label text in active buttons.*/
+.komorebi-workspaces .ws-btn .icon {} /*Style for icon in buttons.*/
+.komorebi-workspaces .ws-btn .icon-1 {} /*Style for icon in first button.*/
+.komorebi-workspaces .ws-btn .icon-2 {} /*Style for icon in second button.*/
+.komorebi-workspaces .ws-btn.active .icon {} /*Style for icon in active buttons.*/
+```
 
 > [!NOTE]  
 > You can use `button-x` to style each button separately. Where x is the index of the button.
+> If `app_icons` is enabled, you can use `icon-x` to style each icon separately. Where x is the index of the icon.

--- a/src/core/validation/widgets/komorebi/workspaces.py
+++ b/src/core/validation/widgets/komorebi/workspaces.py
@@ -9,6 +9,7 @@ DEFAULTS = {
     'hide_if_offline': False,
     'label_zero_index': False,
     'hide_empty_workspaces': False,
+    'app_icons': {'enabled_populated': False, 'enabled_active': False, 'size': 16, 'max_icons': 0, 'hide_label': False, 'hide_duplicates': False, 'hide_floating': False},
     'animation': False,
     'enable_scroll_switching': False,
     'reverse_scroll_direction': False,
@@ -69,6 +70,40 @@ VALIDATION_SCHEMA = {
     'hide_empty_workspaces': {
         'type': 'boolean',
         'default': DEFAULTS['hide_empty_workspaces']
+    },
+    'app_icons': {
+        'type': 'dict',
+        'default': DEFAULTS['app_icons'],
+        'schema': {
+            'enabled_populated': {
+                'type': 'boolean',
+                'default': DEFAULTS['app_icons']['enabled_populated']
+            },
+            'enabled_active': {
+                'type': 'boolean',
+                'default': DEFAULTS['app_icons']['enabled_active']
+            },
+            'size': {
+                'type': 'integer',
+                'default': DEFAULTS['app_icons']['size']
+            },
+            'max_icons': {
+                'type': 'integer',
+                'default': DEFAULTS['app_icons']['max_icons']
+            },
+            'hide_label': {
+                'type': 'boolean',
+                'default': DEFAULTS['app_icons']['hide_label']
+            },
+            'hide_duplicates': {
+                'type': 'boolean',
+                'default': DEFAULTS['app_icons']['hide_duplicates']
+            },
+            'hide_floating': {
+                'type': 'boolean',
+                'default': DEFAULTS['app_icons']['hide_floating']
+            }
+        }
     },
     'animation': {
         'type': 'boolean',


### PR DESCRIPTION
### Summary:
Added a new button class `WorkspaceButtonWithIcons` to display opened app icons in each workspace, along with a new option:
```yaml
app_icons: 
  enabled: true
  enabled_active: true
  size: 12
  max_icons: 0
  hide_duplicates: false
  hide_floating: true
```

### Details:
- This new class uses `QFrame + QHBoxLayout` (similar to the stack widget button), applying styling via `.ws-btn .label` and `.ws-btn .icon`.
- The original button class is left completely untouched to preserve compatibility. The new class is only used when app icons are enabled, ensuring that existing themes won’t break after the update.
- Users who want to style the new icon-enabled buttons will need to update their custom CSS accordingly.

![image](https://github.com/user-attachments/assets/da2dd8d4-0a4f-463b-9880-311e04f55940)