### PR TITLE
fix(popup_widget): fixed padding not being ignored issue

### DIFF
--- a/src/core/utils/utilities.py
+++ b/src/core/utils/utilities.py
@@ -137,11 +137,11 @@ class PopupWidget(QWidget):
         # Determine screen where the parent is
         screen = QApplication.screenAt(parent.mapToGlobal(parent.rect().center()))
         if screen:
-            available_geometry = screen.availableGeometry()
+            screen_geometry = screen.geometry()
             # Ensure the popup fits horizontally
-            x = max(available_geometry.left(), min(global_position.x(), available_geometry.right() - self.width()))
+            x = max(screen_geometry.left(), min(global_position.x(), screen_geometry.right() - self.width()))
             # Ensure the popup fits vertically
-            y = max(available_geometry.top(), min(global_position.y(), available_geometry.bottom() - self.height()))
+            y = max(screen_geometry.top(), min(global_position.y(), screen_geometry.bottom() - self.height()))
             global_position = QPoint(x, y)
         self.move(global_position)
 


### PR DESCRIPTION
Fixed an issue where main bar padding affected the popup widget position when `windows_app_bar` was set to `true`.
Instead of using `screen.availableGeometry()` we just get the `screen.geometry()`