### PR TITLE
docs(whkd): fix typoo above preview image

### DIFF
--- a/docs/widgets/(Widget)-Whkd.md
+++ b/docs/widgets/(Widget)-Whkd.md
@@ -149,5 +149,5 @@ Whkd is a simple hotkey daemon for Windows that reacts to input events by execut
     border-radius: 8px;
 }
 ```
-## Preview of the weather card
+## Preview of the WHKD popup
 ![YASB WHKD Widget](assets/765432109-1a2b3c4d-5e6f-78ab-9012-3456789abcd.png)


### PR DESCRIPTION
Fixes a typoo in the WHKD widget docs above the preview image.