### PR TITLE
feat(glazewm_binding_mode): cycling through modes, `default_icon` option, `icons` option, improved css classes

### DIFF
--- a/docs/widgets/(Widget)-GlazeWM-Binding-Mode.md
+++ b/docs/widgets/(Widget)-GlazeWM-Binding-Mode.md
@@ -2,13 +2,16 @@
 
 | Option           | Type     | Default                        | Description                                                                 |
 |------------------|----------|--------------------------------|-----------------------------------------------------------------------------|
-| `label`             | string  | `'<span>\uf071</span> {binding_mode}'` | The format string for the binding mode. You can use a placeholder `{binding_mode}` to dynamically insert active binding_mode. |
-| `label_alt`         | string  | `'<span>\uf071</span> Current mode: {binding_mode}'` | The alternative format string for the binding mode. |
+| `label`             | string  | `'<span>{icon}</span> {binding_mode}'` | The format string for the binding mode. You can use a placeholder `{binding_mode}` to dynamically insert active binding_mode. |
+| `label_alt`         | string  | `'<span>{icon}</span> Current mode: {binding_mode}'` | The alternative format string for the binding mode. |
 | `glazewm_server_uri` | string | `'ws://localhost:6123'` | Optional GlazeWM server uri. |
 | `hide_if_no_active` | boolean  | `True` | Hide the widget when no binding mode is active. |
 | `label_if_no_active` | string | `"No binding mode active"` | Label to display when no binding mode is active. |
+| `default_icon` | string | `'\uf071'` | Default icon for the binding modes where no other icon is specified. |
+| `icons` | dict | `{'none': '', 'resize': '\uf071', 'pause': '\uf28c'}` | Specified icons for each Binding Mode, if a binding mode is not specified than the `default_icon` will be used. |
+| `binding_modes_to_cycle_through` | list | `['none', 'resize', 'pause']` | Binding Mode names to cycle through with callbacks `next_binding_mode` and `prev_binding_mode` |
 | `container_padding` | dict | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}` | Explicitly set padding inside widget container. |
-| `callbacks` | dict | `{'on_left': 'disable_binding_mode', 'on_middle': 'do_nothing', 'on_right': 'toggle_lable'}` | Callbacks for mouse events on the widget. |
+| `callbacks` | dict | `{'on_left': 'next_binding_mode', 'on_middle': 'toggle_label', 'on_right': 'disable_binding_mode'}` | Callbacks for mouse events on the widget. |
 | `animation` | dict | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}` | Animation settings for the widget. |
 | `container_shadow` | dict   | `None` | Container shadow options. |
 | `label_shadow` | dict | `None` | Label shadow options. |
@@ -21,15 +24,25 @@ glazewm_binding_mode:
     options:
       hide_if_no_active: false
       label_if_no_active: "No binding mode active"
+      default_icon: "\uf071"
+      icons: 
+        none: ""
+        resize: "\uf071"
+        pause: "\uf28c"
+      binding_modes_to_cycle_through: [
+        "none", # none handles if no binding mode is active
+        "resize",
+        "pause"
+      ]
       container_padding:
         top: 0
         left: 0
         bottom: 0
         right: 0
       callbacks:
-        on_left: "disable_binding_mode"
-        on_middle: "do_nothing"
-        on_right: "toggle_label"
+        on_left: "next_binding_mode"
+        on_middle: "toggle_label"
+        on_right: "disable_binding_mode"
 
     # By default binding mode names are fetched from GlazeWM and "display_name" option takes priority over "name".
 ```
@@ -40,12 +53,17 @@ glazewm_binding_mode:
 - **glazewm_server_uri:** Optional GlazeWM server uri if it ever changes on GlazeWM side.
 - **hide_if_no_active:** Hide the widget when no binding mode is active.
 - **label_if_no_active:** Label to display when no binding mode is active.
+- **default_icon:** Default icon for the binding modes where no other icon is defined.
+- **icons:** A dictionary mapping binding mode names to their respective icons. The keys are the binding mode names, and the values are the icon strings. If no icon is defined for a binding mode, the `default_icon` will be used. `'none'` represents no binding mode active.
+- **binding_modes_to_cycle_through:** Binding Mode names to cycle through with callbacks `next_binding_mode` and `prev_binding_mode`. Use `'none'` to handle no binding mode active.
 - **container_padding**: Explicitly set padding inside widget container. Use this option to set padding inside the widget container. You can set padding for top, left, bottom and right sides of the widget container.
 - **callbacks:** A dictionary specifying the callbacks for mouse events. The keys are `on_left`, `on_middle`, and `on_right`, and the values are the names of the callback functions.
   - **callback functions**:
     - `toggle_label`: Toggles the label of the widget.
     - `do_nothing`: Does nothing when clicked.
     - `disable_binding_mode`: Disables the binding mode when clicked.
+    - `next_binding_mode`: Switches to the next binding mode.
+    - `prev_binding_mode`: Switches to the previous binding mode.
 - **animation:** A dictionary specifying the animation settings for the widget. It contains three keys: `enabled`, `type`, and `duration`. The `type` can be `fadeInOut` and the `duration` is the animation duration in milliseconds.
 - **container_shadow:** Container shadow options.
 - **label_shadow:** Label shadow options.
@@ -76,7 +94,16 @@ binding_modes:
 .glazewm-binding-mode .label {
 }
 
-.glazewm-binding-mode .icon {
+.glazewm-binding-mode .label-offline {
+}
+
+.glazewm-binding-mode .icon.none {
+}
+
+.glazewm-binding-mode .icon.pause {
+}
+
+.glazewm-binding-mode .icon.resize {
 }
 ```
 
@@ -95,7 +122,20 @@ binding_modes:
     font-size: 12px;
 }
 
-.glazewm-binding-mode .icon {
+.glazewm-binding-mode .label-offline {
+    color: var(--subtext0);
+    font-size: 10px;
+}
+
+.glazewm-binding-mode .icon.none {
+    color: var(--blue);
+}
+
+.glazewm-binding-mode .icon.resize {
+    color: var(--yellow);
+}
+
+.glazewm-binding-mode .icon.pause {
     color: var(--red);
 }
 ```

--- a/src/core/utils/glazewm/client.py
+++ b/src/core/utils/glazewm/client.py
@@ -88,6 +88,9 @@ class GlazewmClient(QObject):
     def disable_binding_mode(self, binding_mode_name: str):
         self._websocket.sendTextMessage(f"command wm-disable-binding-mode --name {binding_mode_name}")
 
+    def enable_binding_mode(self, binding_mode_name: str):
+        self._websocket.sendTextMessage(f"command wm-enable-binding-mode --name {binding_mode_name}")
+
     def connect(self):
         logger.debug(f"Connecting to {self._uri}...")
         self._websocket.open(self._uri)

--- a/src/core/validation/widgets/glazewm/binding_mode.py
+++ b/src/core/validation/widgets/glazewm/binding_mode.py
@@ -1,9 +1,20 @@
 DEFAULTS = {
-    'label': '<span>\uf071</span> {binding_mode}',
-    'label_alt': '<span>\uf071</span> Current mode: {binding_mode}',
+    'label': '<span>{icon}</span> {binding_mode}',
+    'label_alt': '<span>{icon}</span> Current mode: {binding_mode}',
     'glazewm_server_uri': 'ws://localhost:6123',
     'hide_if_no_active': True,
     'label_if_no_active': 'No binding mode active',
+    'default_icon': '\uf071',
+    'icons': {
+        'none': '',
+        'resize': '\uf071',
+        'pause': '\uf28c',
+    },
+    'binding_modes_to_cycle_through' : [
+        'none',
+        'resize',
+        'pause',
+    ],
     'default_shadow': {
         'enabled': False,
         'color': 'black',
@@ -17,9 +28,9 @@ DEFAULTS = {
     },
     'container_padding': {'top': 0, 'left': 0, 'bottom': 0, 'right': 0},
     'callbacks': {
-        'on_left': 'disable_binding_mode',
-        'on_middle': "do_nothing",
-        'on_right': "toggle_label"
+        'on_left': 'next_binding_mode',
+        'on_middle': 'toggle_label',
+        'on_right': 'disable_binding_mode'
     }
 }
 
@@ -43,6 +54,29 @@ VALIDATION_SCHEMA = {
     'label_if_no_active': {
         'type': 'string',
         'default': DEFAULTS['label_if_no_active'],
+    },
+    'default_icon': {
+        'type': 'string',
+        'default': DEFAULTS['default_icon'],
+    },
+    'icons': {
+        'type': 'dict',
+        'required': False,
+        'default': DEFAULTS['icons'],
+        'keysrules': {
+            'type': 'string',
+        },
+        'valuesrules': {
+            'type': 'string',
+        },
+    },
+    'binding_modes_to_cycle_through': {
+        'type': 'list',
+        'default': DEFAULTS['binding_modes_to_cycle_through'],
+        'schema': {
+            'type': 'string',
+            'required': False,
+        }
     },
     'container_shadow': {
         'type': 'dict',


### PR DESCRIPTION
This PR implements multiple new features to improve the usage of the binding mode widget.

## Cycling through modes
- new callbacks `next_binding_mode` and `prev_binding_mode`, with these the user can cycle through workspaces in order that is given in the `binding_modes_to_cycle_through` option.  Example for the  `binding_modes_to_cycle_through` option: `['none', 'resize', 'pause']`

## Icons improvement
- `icons` option enables user to specify an icon for each binding mode based on the name of the mode.
   - example `{'pause' : '\uf28c'}`
- `default_icon` option is used for the modes where the user didn't specify an icon

## CSS improvement
- added class to handle offline labels
- added classes for each of the different mode icons specified