### PR TITLE
feat(weather_widget): weather widget icon mapping improvements

### DIFF
--- a/docs/widgets/(Widget)-Weather.md
+++ b/docs/widgets/(Widget)-Weather.md
@@ -9,7 +9,7 @@
 | `show_alerts`   | boolean | `False`                                                                 | Whether to show weather alerts. |
 | `units`         | string  | `'metric'`                                                              | The units for the weather data. Can be `'metric'` or `'imperial'`. |
 | `api_key`       | string  | `'0'`                                                                   | The API key for accessing the weather service. |
-| `icons`         | dict    | `{ 'sunnyDay': '\ue30d', 'clearNight': '\ue32b', 'cloudyDay': '\ue312', 'cloudyNight': '\ue311', 'rainyDay': '\udb81\ude7e', 'rainyNight': '\udb81\ude7e', 'snowyIcyDay': '\udb81\udd98', 'snowyIcyNight': '\udb81\udd98', 'blizzard': '\uebaa', 'default': '\uebaa' }` | A dictionary of icons for different weather conditions. |
+| `icons`         | dict    | `{ 'sunnyDay': '\ue30d', 'clearNight': '\ue32b', 'cloudyDay': '\ue312', 'cloudyNight': '\ue311', 'rainyDay': '\udb81\ude7e', 'rainyNight': '\udb81\ude7e', 'snowyIcyDay': '\udb81\udd98', 'snowyIcyNight': '\udb81\udd98', 'blizzardDay': '\uebaa', 'default': '\uebaa' }` | A dictionary of icons for different weather conditions. |
 | `callbacks`     | dict    | `{ 'on_left': 'do_nothing', 'on_middle': 'do_nothing', 'on_right': 'do_nothing' }` | Callbacks for mouse events on the weather widget. |
 | `weather_card`  | dict    | `{ blur': True, 'round_corners': True, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0, 'icon_size': 64 }` | Configuration for the weather card popup display. Controls visibility, appearance, and positioning. |
 | `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
@@ -35,18 +35,23 @@ weather:
       on_left: "toggle_card"
       on_middle: "do_nothing"
       on_right: "toggle_label"
-    icons: 
-      sunnyDay: "\ue30d"
-      clearNight: "\ue32b"
-      cloudyDay: "\udb81\udd99"
-      cloudyNight: "\ue311"
-      rainyDay: "\udb81\ude7e"
-      rainyNight: "\udb81\ude7e"
-      snowyIcyDay: "\udb81\udd98"
-      snowyIcyNight: "\udb81\udd98"
-      blizzard: "\uebaa"
-      default: "\uebaa"
-    weather_card: 
+    icons:
+      sunnyDay: '\ue30d'
+      clearNight: '\ue32b'
+      cloudyDay: '\ue312'
+      cloudyNight: '\ue311'
+      rainyDay: '\ue308'
+      rainyNight: '\ue333'
+      snowyIcyDay: '\ue30a'
+      snowyIcyNight: '\ue335'
+      blizzardDay: '\udb83\udf36'
+      blizzardNight: '\udb83\udf36'
+      foggyDay: '\ue303'
+      foggyNight: '\ue346'
+      thunderstormDay: '\ue30f'
+      thunderstormNight: '\ue338'
+      default: '\uebaa'
+    weather_card:
       blur: True
       round_corners: True
       round_corners_type: "normal"
@@ -95,13 +100,22 @@ weather:
 .weather-widget .label {}
 .weather-widget .label.alt {}
 .weather-widget .icon {}
+
+/* Individual weather icons */
+.weather-widget .icon.sunnyDay {}
+.weather-widget .icon.clearNight {}
 .weather-widget .icon.cloudyDay {}
-.weather-widget .icon.cloudyNight {} 
-.weather-widget .icon.rainyDay {} 
-.weather-widget .icon.rainyNight {} 
-.weather-widget .icon.snowyIcyDay {} 
-.weather-widget .icon.snowyIcyNight {} 
-.weather-widget .icon.blizzard {} 
+.weather-widget .icon.cloudyNight {}
+.weather-widget .icon.rainyDay {}
+.weather-widget .icon.rainyNight {}
+.weather-widget .icon.snowyIcyDay {}
+.weather-widget .icon.snowyIcyNight {}
+.weather-widget .icon.blizzardDay {}
+.weather-widget .icon.blizzardNight {}
+.weather-widget .icon.foggyDay {}
+.weather-widget .icon.foggyNight {}
+.weather-widget .icon.thunderstormDay {}
+.weather-widget .icon.thunderstormNight {}
 .weather-widget .icon.default {}
 
 /* Weather card style */

--- a/src/core/validation/widgets/yasb/weather.py
+++ b/src/core/validation/widgets/yasb/weather.py
@@ -19,7 +19,12 @@ DEFAULTS = {
         'rainyNight': '\udb81\ude7e',
         'snowyIcyDay': '\udb81\udd98',
         'snowyIcyNight': '\udb81\udd98',
-        'blizzard': '\uebaa',
+        'blizzardDay': '\uebaa',
+        'blizzardNight': '\uebaa',
+        'foggyDay': '\ue303',
+        'foggyNight': '\ue346',
+        'thunderstormDay': '\ue30f',
+        'thunderstormNight': '\ue338',
         'default': '\uebaa'
     },
     'weather_card': {
@@ -119,9 +124,29 @@ VALIDATION_SCHEMA: dict[str, Any] = {
                 'type': 'string',
                 'default': DEFAULTS['icons']['snowyIcyNight'],
             },
-            'blizzard': {
+            'blizzardDay': {
                 'type': 'string',
-                'default': DEFAULTS['icons']['blizzard'],
+                'default': DEFAULTS['icons']['blizzardDay'],
+            },
+            'blizzardNight': {
+                'type': 'string',
+                'default': DEFAULTS['icons']['blizzardNight'],
+            },
+            'foggyDay': {
+                'type': 'string',
+                'default': DEFAULTS['icons']['foggyDay'],
+            },
+            'foggyNight': {
+                'type': 'string',
+                'default': DEFAULTS['icons']['foggyNight'],
+            },
+            'thunderstormDay': {
+                'type': 'string',
+                'default': DEFAULTS['icons']['thunderstormDay'],
+            },
+            'thunderstormNight': {
+                'type': 'string',
+                'default': DEFAULTS['icons']['thunderstormNight'],
             },
             'default': {
                 'type': 'string',


### PR DESCRIPTION
This one will break configs, but I noticed that the icons were not showing properly (https://github.com/amnweb/yasb/discussions/272) and since we are fixing the typo here (#274) I figured it's a good time to extend the icons a bit. Issue mentioned might be because of the weather API changes and how we parsed the string before:
```py
icon_string = f"{conditions_data[0].lower() + conditions_data[1:]}{'Day' if current['is_day'] == 1 else 'Night'}".strip()
```
Now it's all based on codes and nothing else.

Changelog:
- Fixes the issue where the icon mapping was not correct for some weather conditions.
- Adds a new icon mapping for the weather widget.
- Changes the weather text for `condition_text`.
- Changes the "is_day" from int to "Day/Night" string.
- Fixes a small issue with the signal connection to `_update_label`