### PR TITLE
feat(wifi): add `hide_if_ethernet` option

### DIFF
--- a/docs/widgets/(Widget)-WiFi.md
+++ b/docs/widgets/(Widget)-WiFi.md
@@ -9,6 +9,7 @@
 | `ethernet_label`   | string  | `"{wifi_icon}"`    | The label format during active Ethernet connection. |
 | `ethernet_label_alt`   | string  | `"{wifi_icon} {ip_addr}"`  | The alternative label format during active Ethernet connection. |
 | `ethernet_icon` | string | "\ueba9" | The icon to indicate Ethernet connection. |
+| `hide_if_ethernet` | boolean | `False` | Whether to hide the widget if an Ethernet connection is active. |
 | `callbacks`   | dict    | `{ 'on_left': 'next_layout', 'on_middle': 'toggle_monocle', 'on_right': 'prev_layout' }` | Callbacks for mouse events on the widget.    |
 | `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
 | `container_padding`  | dict | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}`      | Explicitly set padding inside widget container.      |
@@ -54,6 +55,7 @@ wifi:
 - **ethernet_label:** The format string for the WiFi Widget during active Ethernet connection. Default is `"{wifi_icon}"`.
 - **ethernet_label_alt:** The format string for the WiFi Widget during active Ethernet connection when the widget is in the alternative state. Default is `"{wifi_icon} {ip_addr}"`.
 - **ethernet_icon**: The icon that indicates an active Ethernet connection. It will be used as `{wifi_icon}` whenever there's no active WiFi connection. Default is "\ueba9".
+- **hide_if_ethernet:** A boolean value that determines whether to hide the widget if an Ethernet connection is active. Default is `False`.
 - **wifi_icons:** A list of icons to use for different WiFi signal strengths. Default is `["\udb82\udd2e","\udb82\udd1f","\udb82\udd22","\udb82\udd25","\udb82\udd28",]`.
 - **callbacks:** A dictionary of callbacks for mouse events on the widget. Default is `{'on_left': 'toggle_label', 'on_middle': 'do_nothing', 'on_right': 'do_nothing'}`.
 - **animation:** A dictionary specifying the animation settings for the widget. It contains three keys: `enabled`, `type`, and `duration`. The `type` can be `fadeInOut` and the `duration` is the animation duration in milliseconds.

--- a/src/core/validation/widgets/yasb/wifi.py
+++ b/src/core/validation/widgets/yasb/wifi.py
@@ -17,6 +17,7 @@ DEFAULTS = {
     'ethernet_label': "{wifi_icon}",
     'ethernet_label_alt': "{wifi_icon} {ip_addr}",
     'ethernet_icon': "\ueba9",
+    'hide_if_ethernet': False,
     'container_padding': {'top': 0, 'left': 0, 'bottom': 0, 'right': 0},
     'animation': {
         'enabled': True,
@@ -59,6 +60,10 @@ VALIDATION_SCHEMA = {
     'ethernet_icon': {
         'type': 'string',
         'default': DEFAULTS['ethernet_icon']
+    },
+    'hide_if_ethernet': {
+        'type': 'boolean',
+        'default': DEFAULTS['hide_if_ethernet']
     },
     'animation': {
         'type': 'dict',

--- a/src/core/widgets/yasb/wifi.py
+++ b/src/core/widgets/yasb/wifi.py
@@ -22,6 +22,7 @@ class WifiWidget(BaseWidget):
         ethernet_label: str,
         ethernet_label_alt: str,
         ethernet_icon: str,
+        hide_if_ethernet: bool,
         animation: dict[str, str],
         container_padding: dict[str, int],
         callbacks: dict[str, str],
@@ -38,6 +39,7 @@ class WifiWidget(BaseWidget):
         self._label_alt_content = label_alt
         self._ethernet_label_content = ethernet_label
         self._ethernet_label_alt_content = ethernet_label_alt
+        self._hide_if_ethernet = hide_if_ethernet
         self._animation = animation
         self._padding = container_padding
         self._label_shadow = label_shadow
@@ -145,6 +147,11 @@ class WifiWidget(BaseWidget):
             logging.error(f'Error in wifi widget update: {e}')
             wifi_icon = wifi_name = wifi_strength = "N/A"
 
+        if self._hide_if_ethernet and self._ethernet_active:
+            self.hide()
+            return
+
+        self.show()
         self._display_correct_label()
         if self._ethernet_active:
             active_widgets = self._widgets_ethernet_alt if self._show_alt_label else self._widgets_ethernet


### PR DESCRIPTION
This PR adds an option called `hide_if_ethernet` so if the PC or Laptop is connected to ethernet than the user can determine if they want to hide the widget or not.