### PR TITLE
fix(systray): fix .NET app crash

### DIFF
--- a/src/core/utils/systray/tasks_service.py
+++ b/src/core/utils/systray/tasks_service.py
@@ -1,0 +1,97 @@
+import atexit
+import logging
+import os
+
+from PyQt6.QtCore import QObject
+from win32con import WM_USER
+
+from core.utils.systray.utils import NativeWindowEx, get_exe_path_from_hwnd
+from core.utils.win32.bindings import (
+    DefWindowProc,
+    FindWindowEx,
+    RegisterShellHookWindow,
+    RegisterWindowMessage,
+    SetProp,
+    SetTaskmanWindow,
+)
+
+WM_SHELLHOOKMESSAGE = RegisterWindowMessage("SHELLHOOK")
+WM_TASKBARCREATED = RegisterWindowMessage("TaskbarCreated")
+TASKBARBUTTONCREATEDMESSAGE = RegisterWindowMessage("TaskbarButtonCreated")
+
+logger = logging.getLogger("systray_widget")
+
+
+class TasksService(QObject):
+    """
+    Barebones tasks service to handle taskbar related messages
+    Some apps will crash if these messages are not handled
+    This can also be handled right in the systray monitor client but it's better to have a separate thread
+    """
+
+    def __init__(self):
+        self.yasb_systray_hwnd: int | None = None
+        self.hwnd = None
+        self.tasks_window = None
+        atexit.register(self.destroy)
+
+    def run(self):
+        self.tasks_window = NativeWindowEx(self._window_proc, "YasbTasksHookWindow")
+        self.hwnd = self.tasks_window.hwnd
+
+        # This might be unnecessary for .NET app fix
+        SetTaskmanWindow(self.hwnd)
+        RegisterShellHookWindow(self.hwnd)
+        # ---
+
+        self.set_taskbar_list_hwnd()
+        self.tasks_window.start_message_loop()
+
+    def __del__(self):
+        """Ensure proper cleanup"""
+        self.destroy()
+
+    def destroy(self):
+        """Clean up window"""
+        if self.tasks_window:
+            self.tasks_window.destroy()
+
+    def find_yasb_systray_hwnd(self):
+        """Find Yasb systray monitor hwnd"""
+        hwnd = 0
+        while True:
+            hwnd = FindWindowEx(0, hwnd, "Shell_TrayWnd", None)
+            if hwnd == 0:
+                break
+            exe = get_exe_path_from_hwnd(hwnd)
+            if exe and os.path.basename(exe) != "explorer.exe":
+                return hwnd
+        return 0
+
+    def set_taskbar_list_hwnd(self):
+        """Set the TaskbandHWND prop to the Yasb systray window"""
+        if not self.yasb_systray_hwnd:
+            self.yasb_systray_hwnd = self.find_yasb_systray_hwnd()
+            logging.debug(f"Found yasb systray hwnd: {self.yasb_systray_hwnd}")
+        if self.yasb_systray_hwnd == 0:
+            logger.error("Failed to find yasb systray hwnd")
+            return
+
+        if self.hwnd and self.yasb_systray_hwnd:
+            logger.debug(f"Adding TaskbandHWND prop to hwnd {self.yasb_systray_hwnd}")
+            # This redirects relevant messages from TrayMonitor to the TasksService window
+            SetProp(self.yasb_systray_hwnd, "TaskbandHWND", self.hwnd)
+
+    def _window_proc(self, hwnd: int, uMsg: int, wParam: int, lParam: int) -> int:
+        """
+        Window procedure for handling shell hook messages
+        For now it just returns DefWindowProc on for all relevant messages
+        """
+        if uMsg == WM_TASKBARCREATED:
+            self.set_taskbar_list_hwnd()
+            return 0
+        elif uMsg == WM_SHELLHOOKMESSAGE:
+            return DefWindowProc(hwnd, uMsg, wParam, lParam)
+        elif uMsg >= WM_USER:
+            return DefWindowProc(hwnd, uMsg, wParam, lParam)
+        return DefWindowProc(hwnd, uMsg, wParam, lParam)

--- a/src/core/utils/systray/utils.py
+++ b/src/core/utils/systray/utils.py
@@ -2,20 +2,99 @@
 
 import ctypes as ct
 import logging
-from ctypes import byref, windll
+from ctypes import GetLastError, byref, windll
 from ctypes.wintypes import (
+    MSG,
     POINT,
+)
+from typing import Callable
+
+from win32con import (
+    WM_CLOSE,
+    WS_CLIPCHILDREN,
+    WS_CLIPSIBLINGS,
+    WS_EX_TOOLWINDOW,
+    WS_EX_TOPMOST,
+    WS_POPUP,
 )
 
 from core.utils.win32.bindings import (
     CloseHandle,
+    CreateWindowEx,
     GetWindowThreadProcessId,
     OpenProcess,
+    PostMessage,
     QueryFullProcessImageNameW,
 )
+from core.utils.win32.structs import WNDCLASS, WNDPROC
+
+logger = logging.getLogger("systray_widget")
 
 user32 = windll.user32
 gdi32 = windll.gdi32
+kernel32 = windll.kernel32
+
+
+class NativeWindowEx:
+    """
+    Native window utility class
+    Creates a native window with the specified parameters
+    A window procedure is required to handle messages
+    """
+
+    def __init__(
+        self,
+        window_proc: Callable[[int, int, int, int], int],
+        class_name: str,
+        title: str | None = None,
+        width: int = 0,
+        height: int = 0,
+    ):
+        if not title:
+            title = class_name
+
+        self.wc = WNDCLASS()
+        self.wc.lpfnWndProc = WNDPROC(window_proc)
+        self.wc.hInstance = kernel32.GetModuleHandleW(None)
+        self.wc.lpszClassName = class_name
+
+        if not user32.RegisterClassW(byref(self.wc)):
+            logger.debug("Window registration failed")
+            return
+
+        self.hwnd: int = CreateWindowEx(
+            WS_EX_TOOLWINDOW | WS_EX_TOPMOST,
+            class_name,
+            title,
+            WS_POPUP | WS_CLIPCHILDREN | WS_CLIPSIBLINGS,
+            0,
+            0,
+            width,
+            height,
+            None,
+            None,
+            self.wc.hInstance,
+            None,
+        )
+
+        if not self.hwnd:
+            logger.critical("Window creation failed")
+            return
+
+    def start_message_loop(self):
+        """
+        Start the message loop
+        Call this last after everything is set set up
+        """
+        msg = MSG()
+        while user32.GetMessageW(byref(msg), None, 0, 0) > 0:
+            user32.TranslateMessage(byref(msg))
+            user32.DispatchMessageW(byref(msg))
+
+    def destroy(self):
+        if self.hwnd != 0:
+            logger.debug(f"Destroying window {self.hwnd}")
+            PostMessage(self.hwnd, WM_CLOSE, 0, 0)
 
 
 def cursor_position():
@@ -35,11 +114,14 @@ def get_exe_path_from_hwnd(hwnd: int) -> str | None:
     process_id = ct.c_ulong(0)
     GetWindowThreadProcessId(hwnd, ct.byref(process_id))
 
+    if process_id.value == 0:
+        return None
+
     # Open process to get module handle
     PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
     h_process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, process_id.value)
     if not h_process:
-        logging.debug("Could not open process with PID %d", process_id.value)
+        logger.debug(f"Could not open process ID {process_id.value}. Err: {GetLastError()}")
         return None
 
     try:

--- a/src/core/utils/win32/bindings.py
+++ b/src/core/utils/win32/bindings.py
@@ -66,7 +66,6 @@ user32.CreateWindowExW.argtypes = [
 ]
 user32.CreateWindowExW.restype = HWND
 
-user32.SetWindowPos.restype = c_int
 user32.SetWindowPos.argtypes = [
     HWND,
     HWND,
@@ -76,39 +75,55 @@ user32.SetWindowPos.argtypes = [
     INT,
     UINT,
 ]
+user32.SetWindowPos.restype = c_int
 
-user32.DestroyWindow.restype = c_int
 user32.DestroyWindow.argtypes = [HWND]
+user32.DestroyWindow.restype = c_int
 
-user32.RegisterWindowMessageW.restype = UINT
 user32.RegisterWindowMessageW.argtypes = [LPCWSTR]
+user32.RegisterWindowMessageW.restype = UINT
 
-user32.SendNotifyMessageW.restype = c_int
+user32.RegisterShellHookWindow.argtypes = [HWND]
+user32.RegisterShellHookWindow.restype = BOOL
+
+user32.DeregisterShellHookWindow.argtypes = [HWND]
+user32.DeregisterShellHookWindow.restype = BOOL
+
+user32.SetPropW.argtypes = [HWND, LPCWSTR, HANDLE]
+user32.SetPropW.restype = BOOL
+
+user32.RemovePropW.argtypes = [HWND, LPCWSTR]
+user32.RemovePropW.restype = BOOL
+
+user32.SetTaskmanWindow.argtypes = [HWND]
+user32.SetTaskmanWindow.restype = BOOL
+
 user32.SendNotifyMessageW.argtypes = [HWND, UINT, WPARAM, LPARAM]
+user32.SendNotifyMessageW.restype = c_int
 
-user32.PostMessageW.restype = c_int
 user32.PostMessageW.argtypes = [HWND, UINT, WPARAM, LPARAM]
+user32.PostMessageW.restype = c_int
 
-user32.SetTimer.restype = c_int
 user32.SetTimer.argtypes = [HWND, UINT, UINT, LPVOID]
+user32.SetTimer.restype = c_int
 
-user32.FindWindowW.restype = HWND
 user32.FindWindowW.argtypes = [LPCWSTR, LPCWSTR]
+user32.FindWindowW.restype = HWND
 
-user32.FindWindowExW.restype = HWND
 user32.FindWindowExW.argtypes = [HWND, HWND, LPCWSTR, LPCWSTR]
+user32.FindWindowExW.restype = HWND
 
-user32.SendMessageW.restype = c_int
 user32.SendMessageW.argtypes = [HWND, UINT, WPARAM, LPARAM]
+user32.SendMessageW.restype = c_int
 
-user32.IsWindow.restype = BOOL
 user32.IsWindow.argtypes = [HWND]
+user32.IsWindow.restype = BOOL
 
-user32.GetWindowThreadProcessId.restype = DWORD
 user32.GetWindowThreadProcessId.argtypes = [HWND, LPDWORD]
+user32.GetWindowThreadProcessId.restype = DWORD
 
-user32.AllowSetForegroundWindow.restype = BOOL
 user32.AllowSetForegroundWindow.argtypes = [DWORD]
+user32.AllowSetForegroundWindow.restype = BOOL
 
 user32.GetIconInfo.argtypes = [HICON, POINTER(ICONINFO)]
 user32.GetIconInfo.restype = BOOL
@@ -119,14 +134,14 @@ user32.GetDC.restype = HDC
 user32.ReleaseDC.argtypes = [HANDLE, HDC]
 user32.ReleaseDC.restype = c_int
 
-kernel32.OpenProcess.restype = HANDLE
 kernel32.OpenProcess.argtypes = [DWORD, BOOL, DWORD]
+kernel32.OpenProcess.restype = HANDLE
 
-kernel32.QueryFullProcessImageNameW.restype = BOOL
 kernel32.QueryFullProcessImageNameW.argtypes = [HANDLE, DWORD, LPWSTR, LPDWORD]
+kernel32.QueryFullProcessImageNameW.restype = BOOL
 
-kernel32.CloseHandle.restype = BOOL
 kernel32.CloseHandle.argtypes = [HANDLE]
+kernel32.CloseHandle.restype = BOOL
 
 kernel32.CreateNamedPipeW.argtypes = [
     LPCWSTR,
@@ -265,6 +280,26 @@ def RegisterWindowMessage(lpString: str):
     return user32.RegisterWindowMessageW(lpString)
 
 
+def RegisterShellHookWindow(hwnd: int) -> bool:
+    return user32.RegisterShellHookWindow(hwnd)
+
+
+def DeregisterShellHookWindow(hwnd: int) -> bool:
+    return user32.DeregisterShellHookWindow(hwnd)
+
+
+def SetProp(hwnd: int, lpString: str, hData: int) -> bool:
+    return user32.SetPropW(hwnd, lpString, hData)
+
+
+def RemoveProp(hwnd: int, lpString: str) -> bool:
+    return user32.RemovePropW(hwnd, lpString)
+
+
+def SetTaskmanWindow(hwnd: int) -> bool:
+    return user32.SetTaskmanWindow(hwnd)
+
+
 def SendNotifyMessage(hwnd: int, msg: int, wParam: int, lParam: int) -> int:
     return user32.SendNotifyMessageW(hwnd, msg, wParam, lParam)
 
@@ -382,8 +417,8 @@ def CreateNamedPipe(
     )
 
 
-def ConnectNamedPipe(hNamedPipe: int, lpOverlapped: int | None = None) -> None:
-    return(kernel32.ConnectNamedPipe(hNamedPipe, lpOverlapped))
+def ConnectNamedPipe(hNamedPipe: int, lpOverlapped: int | None = None) -> bool:
+    return bool(kernel32.ConnectNamedPipe(hNamedPipe, lpOverlapped))
 
 
 def DisconnectNamedPipe(hNamedPipe: int) -> bool:
@@ -391,7 +426,7 @@ def DisconnectNamedPipe(hNamedPipe: int) -> bool:
 
 
 def WaitNamedPipe(hNamedPipe: str, nTimeOut: int) -> bool:
-    return kernel32.WaitNamedPipeW(hNamedPipe, nTimeOut)
+    return bool(kernel32.WaitNamedPipeW(hNamedPipe, nTimeOut))
 
 
 def CreateEvent(

--- a/src/core/utils/win32/media.py
+++ b/src/core/utils/win32/media.py
@@ -125,9 +125,6 @@ class WindowsMedia(metaclass=Singleton):
         is_setup=False,
         is_overridden=False,
     ):
-        if DEBUG:
-            self._log.debug('MediaCallback: _on_current_session_changed')
-
         with self._current_session_lock:
             if not is_overridden:
                 self._current_session = manager.get_current_session()
@@ -182,8 +179,6 @@ class WindowsMedia(metaclass=Singleton):
 
     @_current_session_only
     def _on_playback_info_changed(self, session: Session, args: PlaybackInfoChangedEventArgs):
-        if DEBUG:
-            self._log.info('MediaCallback: _on_playback_info_changed')
         with self._playback_info_lock:
             self._playback_info = session.get_playback_info()
             
@@ -217,9 +212,6 @@ class WindowsMedia(metaclass=Singleton):
 
     @_current_session_only
     def _on_media_properties_changed(self, session: Session, args: MediaPropertiesChangedEventArgs):
-        if DEBUG:
-            self._log.debug('MediaCallback: _on_media_properties_changed')
-        
         with self._media_info_lock:
             try:
                 try:
@@ -247,9 +239,6 @@ class WindowsMedia(metaclass=Singleton):
 
     @_current_session_only
     async def _update_media_properties(self, session: Session):
-        if DEBUG:
-            self._log.debug('MediaCallback: Attempting media info update')
-
         try:
             media_info = await session.try_get_media_properties_async()
 
@@ -271,8 +260,6 @@ class WindowsMedia(metaclass=Singleton):
         # Perform callbacks
         for callback in callbacks:
             callback(self._media_info)
-        if DEBUG:
-            self._log.debug('MediaCallback: Media info update finished')
 
     @staticmethod
     def _properties_2_dict(obj) -> dict[str, Any]:


### PR DESCRIPTION
Fixes .NET app crashes caused by apps not being able to call the real systray functions and get a proper success/handled response.

- Added a new thread and service to handle taskbar messages
- Real systray handle is now cached
- Abstracted the win32 window creation into `NativeWindowEx`
- `bindings.py` cleanup
- Logging cleanup
- Improved `get_exe_path_from_hwnd` error handling
- Removed even more unnecessary `media.py` logging spam