### PR TITLE
feat(glazewm): improve scroll with new glazewm commands

### DIFF
--- a/src/core/utils/glazewm/client.py
+++ b/src/core/utils/glazewm/client.py
@@ -94,6 +94,12 @@ class GlazewmClient(QObject):
     def enable_binding_mode(self, binding_mode_name: str):
         self._websocket.sendTextMessage(f"command wm-enable-binding-mode --name {binding_mode_name}")
 
+    def focus_next_workspace(self):
+        self._websocket.sendTextMessage("command focus --next-active-workspace-on-monitor")
+
+    def focus_prev_workspace(self):
+        self._websocket.sendTextMessage("command focus --prev-active-workspace-on-monitor")
+
     def connect(self):
         if self._websocket.state() == QAbstractSocket.SocketState.ConnectedState:
             return

--- a/src/core/widgets/glazewm/workspaces.py
+++ b/src/core/widgets/glazewm/workspaces.py
@@ -236,36 +236,8 @@ class GlazewmWorkspacesWidget(BaseWidget):
                 return btn
         return None
 
-    def _get_next_workspace(self) -> GlazewmWorkspaceButton | None:
-        active_workspace = self._get_active_workspace()
-        if not active_workspace:
-            return None
-        active_index = list(self.workspaces.keys()).index(active_workspace.workspace_name)
-        next_index = (active_index + 1) % len(self.workspaces)
-        return self.workspaces[list(self.workspaces.keys())[next_index]]
-
-    def _get_prev_workspace(self) -> GlazewmWorkspaceButton | None:
-        active_workspace = self._get_active_workspace()
-        if not active_workspace:
-            return None
-        active_index = list(self.workspaces.keys()).index(active_workspace.workspace_name)
-        prev_index = (active_index - 1) % len(self.workspaces)
-        return self.workspaces[list(self.workspaces.keys())[prev_index]]
-
-    def _focus_next_workspace(self):
-        next_workspace = self._get_next_workspace()
-        if not next_workspace:
-            return
-        self.glazewm_client.activate_workspace(next_workspace.workspace_name)
-
-    def _focus_prev_workspace(self):
-        prev_workspace = self._get_prev_workspace()
-        if not prev_workspace:
-            return
-        self.glazewm_client.activate_workspace(prev_workspace.workspace_name)
-
     def wheelEvent(self, event: QWheelEvent):
         if event.angleDelta().y() > 0:
-            self._focus_next_workspace()
+            self.glazewm_client.focus_next_workspace()
         elif event.angleDelta().y() < 0:
-            self._focus_prev_workspace()
+            self.glazewm_client.focus_prev_workspace()


### PR DESCRIPTION
Improves the workspace scrolling feature with the new `--prev-active-workspace-on-monitor` and `--next-active-workspace-on-monitor` commands for a cleaner solution.

> [!CAUTION]
> Latest GlazeWM version is required.