### PR TITLE
feat(cli): add toggle-widget command for widget visibility control

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -15,6 +15,7 @@ The YASB CLI is a command line interface that allows you to interact with the YA
 - `hide-bar` - Hide the status bar.
 - `show-bar` - Show the status bar.
 - `toggle-bar` - Toggle the visibility of the status bar.
+- `toggle-widget` - Toggle the visibility of specific widget.
 - `update` - Update aplicattion to the latest version.
 - `log` - Show the status bar logs in the terminal.
 - `reset` - Restore default config files and clear cache
@@ -76,3 +77,18 @@ To toggle the visibility of the status bar on a specific screen, use the followi
 yasbc toggle-bar --screen <screen_name>
 ```
 
+## Toggle Widget Visibility
+To toggle the visibility of a specific widget on screen, use the following command:
+```bash
+yasbc toggle-widget launchpad --screen 'DELL P2419H (2)'
+```
+To toggle the visibility of a specific widget on screen where is mouse cursor, use the following command:
+```bash
+yasbc toggle-widget launchpad --follow-mouse
+```
+To toggle the visibility of a specific widget on screens where is focused window, use the following command:
+```bash
+yasbc toggle-widget launchpad --follow-focused
+```
+> [!NOTE]
+> The `toggle-widget` command is not available for all widgets, it is only available for widgets that support toggling visibility. On each widget page, you can find information about the widget and whether it supports toggling visibility.

--- a/docs/widgets/(Widget)-Launchpad.md
+++ b/docs/widgets/(Widget)-Launchpad.md
@@ -1,6 +1,6 @@
 # Launchpad Widget
 
-The Launchpad widget provides a customizable application launcher grid, similar to macOS Launchpad. It allows you to quickly launch, add, edit, or remove applications from a visually organized popup.
+The Launchpad widget provides a customizable application launcher grid, similar to macOS Launchpad. It allows you to quickly launch, add, edit, or remove applications from a visually organized popup. Launchpad supports drag-and-drop functionality, search, and context menus for managing your applications. It's support UWP apps, executables and URLs making it a versatile tool for accessing your favorite programs.
 
 ## Options
 
@@ -9,7 +9,7 @@ The Launchpad widget provides a customizable application launcher grid, similar 
 | `label`               | string   | `'<span>\udb85\udcde</span>'`| The label/icon for the widget on the bar.                                   |
 | `search_placeholder`  | string   | `"Search applications..."`     | Placeholder text for the search field.                                      |
 | `app_icon_size`       | int      | `64`                   | Size of application icons in pixels.                                        |
-| `window`              | dict     | `{fullscreen: False, width: 800, height: 600}`                | Popup window size and fullscreen options.                                   |
+| `window`              | dict     | `{fullscreen: False, width: 800, height: 600, overlay_block: true}`                | Popup window size and fullscreen options.                                   |
 | `window_style`        | dict     | `{enable_blur: True, round_corners: True, round_corners_type: "normal", border_color: "system"}`                | Popup window styling (blur, corners, border, etc).                          |
 | `window_animation`    | dict     | `{fade_in_duration: 400, fade_out_duration: 400}`                | Animation settings for showing/hiding the popup.                            |
 | `animation`           | dict     | `{enabled: True, type: "fadeInOut", duration: 200}`                | Widget animation settings.                                                  |
@@ -19,6 +19,7 @@ The Launchpad widget provides a customizable application launcher grid, similar 
 | `container_shadow`    | dict     | `None`                 | Container shadow options.                                                   |
 | `app_title_shadow`    | dict     | `None`                 | Shadow options for app titles.                                              |
 | `app_icon_shadow`     | dict     | `None`                 | Shadow options for app icons.                                               |
+| `shortcuts`           | dict     | `{add_app: "Ctrl+N", edit_app: "F2", show_context_menu: "Shift+F10", delete_app: "Delete"}` | Keyboard shortcuts for popup actions. |
 
 ## Example Configuration
 
@@ -33,6 +34,7 @@ launchpad:
       fullscreen: false
       width: 800
       height: 600
+      overlay_block: true
     window_style:
       enable_blur: true
       round_corners: true
@@ -55,6 +57,31 @@ launchpad:
       radius: 8
 ```
 
+## Shortcuts
+
+You can customize keyboard shortcuts for common actions in the Launchpad popup using the `shortcuts` option.  
+The following shortcuts are available by default:
+
+| Shortcut Name         | Default Key      | Action                                      |
+|-----------------------|------------------|---------------------------------------------|
+| `add_app`             | `Ctrl+N`         | Add a new application                       |
+| `edit_app`            | `F2`             | Edit the currently selected application     |
+| `show_context_menu`   | `Shift+F10`      | Show the context menu for the popup         |
+| `delete_app`          | `Delete`         | Delete the currently selected application   |
+
+You can override these in your configuration, for example:
+
+```yaml
+launchpad:
+  type: "yasb.launchpad.LaunchpadWidget"
+  options:
+    shortcuts:
+      add_app: "Ctrl+N"
+      edit_app: "F2"
+      show_context_menu: "Shift+F10"
+      delete_app: "Delete"
+```
+
 ## Description of Options
 
 - **label:** The label/icon for the widget on the bar.
@@ -64,14 +91,48 @@ launchpad:
 - **label_shadow:** Shadow options for the label.
 - **container_shadow:** Shadow options for the widget container.
 - **window:** Popup window size and fullscreen options.
+  - ***fullscreen:*** Whether the popup should be fullscreen.
+  - ***width:*** Width of the popup window.
+  - ***height:*** Height of the popup window.
+  - ***overlay_block:*** Whether the popup should block interaction with the main window.
 - **window_style:** Popup window styling (blur, round corners, border, etc).
+  - ***enable_blur:*** Whether to enable background blur for the popup.
+  - ***round_corners:*** Whether to round the corners of the popup window.
+  - ***round_corners_type:*** Type of corner rounding ("normal" or "small").
+  - ***border_color:*** Color of the popup window border (can be "system" HEX or None).
 - **window_animation:** Animation settings for showing/hiding the popup.
-- **animation:** Widget animation settings.
+  - ***fade_in_duration:*** Duration of the fade-in animation in milliseconds.
+  - ***fade_out_duration:*** Duration of the fade-out animation in milliseconds.
+- **animation:** Widget label animation settings.
+  - ***enabled:*** Whether animations are enabled.
+  - ***type:*** Type of animation ("fadeInOut").
+  - ***duration:*** Duration of the animation in milliseconds.
 - **callbacks:** Mouse event callbacks (`on_left`, `on_middle`, `on_right`).
 - **app_title_shadow:** Shadow options for app titles.
+  - ***enabled:*** Whether to enable shadow for app titles.
+  - ***color:*** Color of the shadow (HEX, HEX with alpha or name).
+  - ***offset:*** Offset of the shadow in pixels (x, y).
+  - ***radius:*** Radius of the shadow blur.
 - **app_icon_shadow:** Shadow options for app icons.
-
----
+  - ***enabled:*** Whether to enable shadow for app icons.
+  - ***color:*** Color of the shadow (HEX, HEX with alpha or name).
+  - ***offset:*** Offset of the shadow in pixels (x, y).
+  - ***radius:*** Radius of the shadow blur.
+- **label_shadow**: Shadow options for the widget label.
+  - ***enabled:*** Whether to enable shadow for the label.
+  - ***color:*** Color of the shadow (HEX, HEX with alpha or name).
+  - ***offset:*** Offset of the shadow in pixels (x, y).
+  - ***radius:*** Radius of the shadow blur.
+- **container_shadow**: Shadow options for the widget container.
+  - ***enabled:*** Whether to enable shadow for the container.
+  - ***color:*** Color of the shadow (HEX, HEX with alpha or name).
+  - ***offset:*** Offset of the shadow in pixels (x, y).
+  - ***radius:*** Radius of the shadow blur.
+- **shortcuts**: Keyboard shortcuts for common actions in the Launchpad popup.
+  - **Ctrl+N**: Open the "Add New App" dialog.
+  - **F2**: Edit the currently focused/selected app.
+  - **Delete**: Delete the currently focused/selected app (with confirmation).
+  - **Shift+F10**: Open the context menu for additional actions.
 
 ## Widget Description
 The Launchpad widget is a powerful and user-friendly application launcher designed for quick access to your favorite programs, scripts, files, or web links. Inspired by the macOS Launchpad, it presents your apps in a visually organized grid popup, complete with search, drag-and-drop reordering, and context menu actions. All your launchpad app entries and their icons are safely stored in your configuration directory, making it easy to back up, migrate, or edit your app list manually if needed
@@ -80,19 +141,30 @@ The Launchpad widget is a powerful and user-friendly application launcher design
 - **App Grid:** Displays your applications as icons with titles in a grid layout.
 - **Quick Launch:** Click any icon to instantly launch the associated executable, script, or open a URL in your default browser.
 - **Search:** Filter your apps in real-time using the search bar.
-- **Drag & Drop:** Reorder apps by dragging icons, or move them to the end of the list.
+- **Drag & Drop:** Drag and drop shortcut icons or executables into the grid to add them to your launchpad. Reorder apps by dragging them around.
 - **Context Menu:** Right-click any app for options to edit, delete, or change the order of your apps (A-Z, Z-A, recent, oldest).
 - **Add/Edit Apps:** Easily add new apps or edit existing ones, including setting a custom icon and title.
 - **Customizable Appearance:** Supports custom icon sizes, window blur, rounded corners, shadows, and more via configuration.
 - **Keyboard Navigation:** Navigate the grid and launch apps using arrow keys and Enter.
 - **Animations:** Smooth fade-in and fade-out animations for the popup window.
 
-
+> **Note:**  
+> The Launchpad widget supports autocomplete for application names when adding or editing apps. In most cases, the icon will be extracted automatically for executables and shortcuts. However, for some applications (especially certain UWP apps or unusual shortcuts), icon extraction may not always succeed. If this happens, you can manually select an icon file.
 
 ## Example Style
 
 ```css
-/* Context menu style */
+/* Widget style */
+.launchpad-widget {
+    padding: 0 6px 0 6px;
+}
+.launchpad-widget .label {}
+.launchpad-widget .icon {
+    font-size: 16px;
+    color: #89b4fa;
+}
+
+/* Launchpad context menu style */
 .launchpad .context-menu {
     background-color: #202020;
     border: none;
@@ -126,7 +198,8 @@ The Launchpad widget is a powerful and user-friendly application launcher design
     color: #666666;
     background-color: transparent;
 }
-/* App dialog style */
+
+/* Launchpad App dialog style */
 .launchpad .app-dialog {
     font-family: 'Segoe UI';
     background-color: #202020;
@@ -177,11 +250,16 @@ The Launchpad widget is a powerful and user-friendly application launcher design
     padding: 0 6px;
     margin: 10px 0 5px 6px;
     min-height: 28px;
+    outline: none;
 }
 .launchpad .app-dialog .buttons-container .button {
     margin: 10px 0 5px 0px;
     font-size: 13px;
 }
+.launchpad .app-dialog .button:focus {
+    border: 2px solid #adadad;
+}
+.launchpad .app-dialog .button:focus,
 .launchpad .app-dialog .button:hover {
     background-color: #4A4A4A;
 }
@@ -192,6 +270,8 @@ The Launchpad widget is a powerful and user-friendly application launcher design
 .launchpad .app-dialog .button.save {
     background-color: #0078D4;
 }
+.launchpad .app-dialog .button.add:focus,
+.launchpad .app-dialog .button.save:focus,
 .launchpad .app-dialog .button.add:hover,
 .launchpad .app-dialog .button.save:hover {
     background-color: #0066B2;
@@ -203,6 +283,7 @@ The Launchpad widget is a powerful and user-friendly application launcher design
 .launchpad .app-dialog .button.delete {
     background-color: #bd2d14;
 }
+.launchpad .app-dialog .button.delete:focus,
 .launchpad .app-dialog .button.delete:hover {
     background-color: #b30f00;
 }
@@ -220,8 +301,18 @@ The Launchpad widget is a powerful and user-friendly application launcher design
     padding: 8px 12px;
     margin: 4px 0px;
 }
-
-/* Popup style */
+/* Launchpad popup style */
+.launchpad .drop-overlay {
+    background-color: rgba(24, 25, 27, 0.8);
+    border:4px dashed #3c80ff;
+}
+.launchpad .drop-overlay .text {
+    color: #ffffff;
+    font-family: 'Segoe UI';
+    font-size: 64px;
+    font-weight: 600;
+    text-transform: uppercase;
+}
 .launchpad .launchpad-container {
     background-color: rgba(24, 25, 27, 0.8);
 }
@@ -278,7 +369,13 @@ The Launchpad widget is a powerful and user-friendly application launcher design
     margin-top: 2px;
     font-weight: 600
 }
+/* App icon .launchpad .app-icon or URL icon .launchpad .app-icon.url */
+.launchpad .app-icon.url .title{
+    color: #52f1d2;
+}
 ```
+> [!NOTE]
+> Launchpad widget supports toggle visibility using the `toggle-widget launchpad` command in the CLI. More information about the CLI commands can be found in the [CLI documentation](https://github.com/amnweb/yasb/wiki/CLI#toggle-widget-visibility).
 
 ## Preview
 

--- a/docs/widgets/(Widget)-Power-Menu.md
+++ b/docs/widgets/(Widget)-Power-Menu.md
@@ -72,3 +72,6 @@ power_menu:
 .power-menu-popup .button.force_restart {}
 
 ```
+
+> [!NOTE]
+> Power Menu widget supports toggle visibility using the `toggle-widget powermenu` command in the CLI. More information about the CLI commands can be found in the [CLI documentation](https://github.com/amnweb/yasb/wiki/CLI#toggle-widget-visibility).

--- a/docs/widgets/(Widget)-Wallpapers.md
+++ b/docs/widgets/(Widget)-Wallpapers.md
@@ -75,6 +75,9 @@ wallpapers:
 
 > Gallery options above fit screen for 1920x1080 resolution. You may need to adjust the values for other resolutions.
 
+> [!NOTE]
+> Wallapers widget supports toggle visibility using the `toggle-widget wallpapers` command in the CLI. More information about the CLI commands can be found in the [CLI documentation](https://github.com/amnweb/yasb/wiki/CLI#toggle-widget-visibility).
+
 ## Example Style
 ```css
 .wallpapers-widget {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "watchdog",
     "pycaw",
     "pillow==11.1",
+    "icoextract",
     "qasync",
     "obs-websocket-py",
     "pyvda",

--- a/src/cli.py
+++ b/src/cli.py
@@ -242,6 +242,14 @@ class CLIHandler:
         toggle_bar_parser = subparsers.add_parser("toggle-bar", help="Toggle the bar on a specific screen")
         toggle_bar_parser.add_argument("-s", "--screen", type=str, help="Screen name (optional)")
 
+        widget_toggle_parser = subparsers.add_parser("toggle-widget", help="Toggle a widget show/hide")
+        widget_toggle_parser.add_argument("widget_name", type=str, help="Name of the widget to toggle")
+        widget_toggle_parser.add_argument("-s", "--screen", type=str, help="Screen name (optional)")
+        widget_toggle_parser.add_argument("--follow-mouse", action="store_true", help="Follow mouse cursor (optional)")
+        widget_toggle_parser.add_argument(
+            "--follow-focus", action="store_true", help="Follow focused window (optional)"
+        )
+
         subparsers.add_parser("reset", help="Restore default config files and clear cache")
 
         subparsers.add_parser("help", help="Show help message")
@@ -301,6 +309,20 @@ class CLIHandler:
         elif args.command == "toggle-bar":
             screen_arg = f" --screen {args.screen}" if args.screen else ""
             self.send_command_to_application(f"toggle-bar{screen_arg}")
+            sys.exit(0)
+
+        elif args.command == "toggle-widget":
+            if not args.widget_name:
+                sys.exit(1)
+            if args.screen:
+                arg = f" --screen {args.screen}" if args.screen else ""
+            elif args.follow_mouse:
+                arg = " --follow-mouse"
+            elif args.follow_focus:
+                arg = " --follow-focus"
+            else:
+                arg = ""
+            self.send_command_to_application(f"toggle-widget {args.widget_name}{arg}")
             sys.exit(0)
 
         elif args.command == "update":
@@ -463,6 +485,7 @@ class CLIHandler:
                   show-bar                  Show the bar on all or a specific screen
                   hide-bar                  Hide the bar on all or a specific screen
                   toggle-bar                Toggle the bar on all or a specific screen
+                  toggle-widget             Toggle a widget show/hide
                   update                    Update the application
                   log                       Tail yasb process logs (cancel with Ctrl-C)
                   reset                     Restore default config files and clear cache

--- a/src/core/bar_manager.py
+++ b/src/core/bar_manager.py
@@ -10,6 +10,7 @@ from PyQt6.QtWidgets import QApplication
 from core.bar import Bar
 from core.config import get_config, get_stylesheet
 from core.event_service import EventService
+from core.global_state import set_bar_screens
 from core.utils.controller import reload_application
 from core.utils.utilities import get_screen_by_name
 from core.utils.widget_builder import WidgetBuilder
@@ -97,13 +98,14 @@ class BarManager(QObject):
                         logging.warning(f"Screen '{resolved_name}' from config not found among connected screens.")
                         continue
                     assigned_screens.add(resolved_name)
-
+        initialized_screens = set()
         for bar_name, bar_config in self.config["bars"].items():
             if bar_config["screens"] == ["*"]:
                 for screen in QApplication.screens():
                     if screen.name() in assigned_screens:
                         continue
                     self.create_bar(bar_config, bar_name, screen, init)
+                    initialized_screens.add(screen.name())
             else:
                 for screen_name in bar_config["screens"]:
                     resolved_name = primary_screen_name if screen_name == "primary" else screen_name
@@ -113,7 +115,8 @@ class BarManager(QObject):
                     screen = get_screen_by_name(resolved_name)
                     if screen:
                         self.create_bar(bar_config, bar_name, screen, init)
-
+                        initialized_screens.add(screen.name())
+        set_bar_screens(initialized_screens)
         self.run_listeners_in_threads()
         self._widget_builder.raise_alerts_if_errors_present()
 

--- a/src/core/global_state.py
+++ b/src/core/global_state.py
@@ -1,0 +1,17 @@
+"""
+Global state management for the application.
+This module provides functions to manage the global state of the application
+"""
+
+bar_screens = set()
+
+
+def set_bar_screens(screens):
+    """Set the screens where the bar should be displayed."""
+    global bar_screens
+    bar_screens = set(screens)
+
+
+def get_bar_screens():
+    """Get the screens where the bar should be displayed."""
+    return bar_screens

--- a/src/core/utils/cli_server.py
+++ b/src/core/utils/cli_server.py
@@ -252,7 +252,7 @@ class CliPipeHandler:
 
         logger.info(f"CLI server received command: {full_command}")
 
-        if command in ["stop", "reload", "show-bar", "hide-bar", "toggle-bar"]:
+        if command in ["stop", "reload", "show-bar", "hide-bar", "toggle-bar", "toggle-widget"]:
             success = WriteFile(pipe, b"ACK")
             if not success:
                 logger.error(f"Write ACK failed. Err: {GetLastError()}")

--- a/src/core/utils/controller.py
+++ b/src/core/utils/controller.py
@@ -7,6 +7,7 @@ from PyQt6.QtWidgets import QApplication
 
 from core.event_service import EventService
 from core.utils.cli_server import CliPipeHandler
+from core.utils.win32.utilities import find_focused_screen
 
 
 def reload_application(msg="Reloading Application...", forced=False):
@@ -56,11 +57,26 @@ def process_cli_command(command: str):
 
     if base_command == "reload":
         reload_application("Reloading Application from CLI...")
+
     elif base_command == "stop":
         exit_application("Exiting Application from CLI...")
+
     elif base_command in ["show-bar", "hide-bar", "toggle-bar"]:
         action = base_command.split("-")[0]
         EventService().emit_event("handle_bar_cli", action, screen_name)
+
+    elif base_command == "toggle-widget":
+        from core.global_state import get_bar_screens
+
+        available_screens = get_bar_screens()
+        if "--follow-mouse" in command:
+            screen_name = find_focused_screen(follow_mouse=True, follow_window=False, screens=available_screens)
+        elif "--follow-focus" in command:
+            screen_name = find_focused_screen(follow_mouse=False, follow_window=True, screens=available_screens)
+
+        widget_name = parts[1] if len(parts) > 1 else None
+        if screen_name is not None:
+            EventService().emit_event("handle_widget_cli", widget_name, screen_name)
 
 
 def start_cli_server():

--- a/src/core/utils/launchpad/app_loader.py
+++ b/src/core/utils/launchpad/app_loader.py
@@ -1,0 +1,129 @@
+import os
+
+from PyQt6.QtCore import (
+    QThread,
+    pyqtSignal,
+)
+
+_APPS_CACHE = None
+
+
+class AppListLoader(QThread):
+    """
+    Thread to load the list of applications from the Windows Start Menu and UWP apps.
+    This class caches the results to avoid reloading on subsequent calls.
+    """
+
+    apps_loaded = pyqtSignal(list)
+
+    @staticmethod
+    def clear_cache():
+        global _APPS_CACHE
+        _APPS_CACHE = None
+
+    def run(self):
+        global _APPS_CACHE
+        if _APPS_CACHE is not None:
+            self.apps_loaded.emit(_APPS_CACHE)
+            return
+
+        import glob
+        import subprocess
+
+        filter_keywords = {"uninstall", "readme", "help", "documentation", "license", "setup", "installer"}
+
+        start_menu_dirs = [
+            os.path.expandvars(r"%APPDATA%\Microsoft\Windows\Start Menu\Programs"),
+            os.path.expandvars(r"%PROGRAMDATA%\Microsoft\Windows\Start Menu\Programs"),
+        ]
+        apps = []
+        seen_names = set()
+        seen_keys = set()
+
+        def should_filter_app(name):
+            """Check if app name contains any filter keywords"""
+            name_lower = name.lower()
+            return any(keyword in name_lower for keyword in filter_keywords)
+
+        for dir in start_menu_dirs:
+            for lnk in glob.glob(os.path.join(dir, "**", "*.lnk"), recursive=True):
+                name = os.path.splitext(os.path.basename(lnk))[0]
+                if should_filter_app(name):
+                    continue
+                key = (name.lower(), lnk.lower())
+                if key not in seen_keys:
+                    apps.append((name, lnk, None))
+                    seen_keys.add(key)
+                    seen_names.add(name.lower())
+
+        try:
+            ps_script = "Get-StartApps | ForEach-Object { [PSCustomObject]@{Name=$_.Name;AppID=$_.AppID} } | ConvertTo-Json -Compress"
+            result = subprocess.run(
+                [
+                    "powershell",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-NoLogo",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-Command",
+                    ps_script,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                creationflags=subprocess.CREATE_NO_WINDOW,
+            )
+            if result.returncode == 0:
+                import json as _json
+
+                uwp_list = _json.loads(result.stdout)
+                if isinstance(uwp_list, dict):
+                    uwp_list = [uwp_list]
+                for entry in uwp_list:
+                    name = entry.get("Name")
+                    appid = entry.get("AppID")
+                    if name and appid and name.lower() not in seen_names and not should_filter_app(name):
+                        apps.append((name, f"UWP::{appid}", None))
+                        seen_names.add(name.lower())
+        except Exception:
+            pass
+
+        _APPS_CACHE = apps
+        self.apps_loaded.emit(apps)
+
+
+class ShortcutResolver:
+    @staticmethod
+    def resolve_lnk_target(lnk_path, warning_callback=None):
+        """
+        Resolve the target path, icon location, and display name from a .lnk file.
+        If warning_callback is provided, it will be called with an error message on failure.
+        Returns (full_command, icon_path, app_name) or (None, None, None) on error.
+        """
+        try:
+            import win32com.client
+
+            shell = win32com.client.Dispatch("WScript.Shell")
+            shortcut = shell.CreateShortcut(lnk_path)
+            target_path = shortcut.TargetPath
+            arguments = shortcut.Arguments
+            icon_path = shortcut.IconLocation
+            app_name = os.path.splitext(os.path.basename(lnk_path))[0]
+            # Combine target and arguments for the real launch command
+            if arguments:
+                full_command = f'"{target_path}" {arguments}'
+            else:
+                full_command = target_path
+            if icon_path:
+                icon_path = icon_path.split(",")[0]
+            if icon_path and os.path.isfile(icon_path):
+                return full_command, icon_path, app_name
+            elif target_path and os.path.isfile(target_path):
+                return full_command, target_path, app_name
+            else:
+                return full_command, None, app_name
+        except Exception:
+            if warning_callback:
+                warning_callback("Failed to resolve shortcut: {lnk_path}")
+            return None, None, None

--- a/src/core/utils/launchpad/icon_extractor.py
+++ b/src/core/utils/launchpad/icon_extractor.py
@@ -1,0 +1,248 @@
+import json
+import logging
+import os
+import re
+import tempfile
+import time
+import urllib.request
+from urllib.parse import urljoin, urlparse
+
+from icoextract import IconExtractor
+from PIL import Image
+
+logging.getLogger("icoextract").setLevel(logging.ERROR)
+
+
+class IconExtractorUtil:
+    """
+    Extract the icon from a file (ico, exe, dll) and save as PNG in the icons dir.
+    Falls back to extracting from a mun file if available.
+    For UWP apps, it tries to extract the icon from the AppxManifest.xml.
+    Returns the PNG path or None.
+    """
+
+    @staticmethod
+    def extract_icon_from_path(file_path, icons_dir):
+        ext = os.path.splitext(file_path)[1].lower()
+        base = os.path.splitext(os.path.basename(file_path))[0]
+        temp_png = os.path.join(icons_dir, f"{base}_{int(time.time() * 1000)}.png")
+
+        if ext == ".ico":
+            try:
+                im = Image.open(file_path)
+                largest = im
+                max_size = im.width * im.height
+                for frame in range(getattr(im, "n_frames", 1)):
+                    im.seek(frame)
+                    size = im.width * im.height
+                    if size > max_size:
+                        largest = im.copy()
+                        max_size = size
+                largest.save(temp_png, format="PNG")
+                return temp_png
+            except Exception:
+                return None
+
+        mun_candidate = None
+        system32 = os.path.join(os.environ.get("WINDIR", r"C:\Windows"), "System32")
+        sysres = os.path.join(os.environ.get("WINDIR", r"C:\Windows"), "SystemResources")
+        basename = os.path.basename(file_path)
+        if file_path.lower().startswith(system32.lower()) and basename.lower().endswith(".exe"):
+            mun_candidate = os.path.join(sysres, f"{basename}.mun")
+
+        try:
+            extractor = IconExtractor(file_path)
+            data = extractor.get_icon(num=0)
+            img = Image.open(data)
+            img.save(temp_png, format="PNG")
+            return temp_png
+        except Exception:
+            if mun_candidate and os.path.exists(mun_candidate):
+                try:
+                    extractor = IconExtractor(mun_candidate)
+                    data = extractor.get_icon(num=0)
+                    img = Image.open(data)
+                    img.save(temp_png, format="PNG")
+                    return temp_png
+                except Exception:
+                    return None
+            return None
+
+    def extract_uwp_icon(appid, install_location=None):
+        import ctypes
+        import locale
+        import os
+        import xml.etree.ElementTree as ET
+        from glob import glob
+        from pathlib import Path
+
+        if not install_location or not os.path.isdir(install_location):
+            return None
+
+        manifest_path = os.path.join(install_location, "AppxManifest.xml")
+        if not os.path.isfile(manifest_path):
+            return None
+
+        try:
+            tree = ET.parse(manifest_path)
+            root = tree.getroot()
+            velement = root.find(".//VisualElements")
+            if velement is None:
+                velement = root.find(".//{http://schemas.microsoft.com/appx/manifest/uap/windows10}VisualElements")
+            if velement is None or "Square44x44Logo" not in velement.attrib:
+                return None
+
+            logofile = Path(velement.attrib["Square44x44Logo"])
+            logopattern = str(logofile.parent / "**") + "\\" + str(logofile.stem) + "*" + str(logofile.suffix)
+            package_path = Path(install_location)
+            logofiles = glob(logopattern, recursive=True, root_dir=package_path)
+            logofiles = [x.lower() for x in logofiles]
+            if not logofiles:
+                return None
+
+            def filter_logos(logofiles, qualifiers, values):
+                for qualifier in qualifiers:
+                    for value in values:
+                        filtered_files = list(filter(lambda x: (qualifier + "-" + value in x), logofiles))
+                        if filtered_files:
+                            return filtered_files
+                return logofiles
+
+            langs = []
+            current_lang_code = ctypes.windll.kernel32.GetUserDefaultUILanguage()
+            if current_lang_code in locale.windows_locale:
+                current_lang = locale.windows_locale[current_lang_code].lower().replace("_", "-")
+                current_lang_short = current_lang.split("-", 1)[0]
+                langs += [current_lang, current_lang_short]
+            if "en" not in langs:
+                langs += ["en", "en-us"]
+
+            if langs:
+                logofiles = filter_logos(logofiles, ["lang", "language"], langs)
+            logofiles = filter_logos(logofiles, ["contrast"], ["standard"])
+            logofiles = filter_logos(logofiles, ["alternateform", "altform"], ["unplated"])
+            logofiles = filter_logos(logofiles, ["contrast"], ["standard"])
+            logofiles = filter_logos(logofiles, ["scale"], ["100", "150", "200"])
+
+            def get_size(p):
+                try:
+                    with Image.open(package_path / p) as img:
+                        return img.width * img.height
+                except Exception:
+                    return 0
+
+            logofiles.sort(key=get_size, reverse=True)
+            if not logofiles:
+                return None
+            return str(package_path / logofiles[0])
+        except Exception as e:
+            logging.error(f"Failed to parse manifest or find logo: {e}")
+            return None
+
+
+class UrlExtractorUtil:
+    """
+    Extract the icon and title from URL and save as PNG in the icons dir.
+    Falls back to extracting from the manifest.json or manifest.webmanifest.
+    Returns the PNG path and page title or None if not found.
+    """
+
+    @staticmethod
+    def extract_from_url(url, icons_dir):
+        try:
+            parsed = urlparse(url)
+            base_url = f"{parsed.scheme}://{parsed.netloc}"
+
+            manifest_url = None
+            page_title = None
+            try:
+                with urllib.request.urlopen(url, timeout=3) as resp:
+                    html = resp.read().decode("utf-8", errors="ignore")
+                title_match = re.search(r"<title\b[^>]*>(.*?)</title>", html, re.IGNORECASE | re.DOTALL)
+
+                if title_match:
+                    page_title = title_match.group(1).strip()
+                    if len(page_title) > 30:
+                        page_title = page_title[:30] + "..."
+                match = re.search(r'<link[^>]+rel=["\']manifest["\'][^>]*href=["\']([^"\']+)["\']', html, re.IGNORECASE)
+                if match:
+                    manifest_url = urljoin(base_url, match.group(1))
+            except Exception:
+                manifest_url = None
+
+            # Fallback to default manifest locations if not found in HTML
+            # This is useful for sites that don't explicitly link to a manifest
+            manifest_urls = []
+            if manifest_url:
+                manifest_urls.append(manifest_url)
+            manifest_urls += [
+                urljoin(base_url, "manifest.webmanifest"),
+                urljoin(base_url, "manifest.json"),
+            ]
+
+            manifest = None
+            manifest_base_url = None
+            for m_url in manifest_urls:
+                try:
+                    with urllib.request.urlopen(m_url, timeout=2) as resp:
+                        if resp.status == 200:
+                            manifest = json.loads(resp.read().decode("utf-8"))
+                            manifest_base_url = m_url
+                            break
+                except Exception:
+                    continue
+            if not manifest or "icons" not in manifest:
+                return None, page_title
+
+            # Find the largest icon >=192x192
+            icons = manifest["icons"]
+            best_icon = None
+            best_size = 0
+            for icon in icons:
+                purpose = icon.get("purpose", "").strip().lower()
+                if purpose == "monochrome":
+                    continue
+                sizes = icon.get("sizes", "")
+                if not sizes:
+                    continue
+                for size in sizes.split():
+                    try:
+                        w, h = map(int, size.lower().split("x"))
+                        if w >= 192 and h >= 192:
+                            best_icon = icon
+                            break
+                        if w * h > best_size:
+                            fallback_icon = icon
+                            best_size = w * h
+                    except Exception:
+                        continue
+                if best_icon:
+                    break
+
+            if not best_icon and "fallback_icon" in locals():
+                best_icon = fallback_icon
+            if not best_icon:
+                return None, page_title
+
+            icon_src = best_icon.get("src")
+            if not icon_src:
+                return None, page_title
+
+            # Use the manifest's URL as the base for relative icon URLs
+            icon_url = urljoin(manifest_base_url, icon_src) if manifest_base_url else urljoin(base_url, icon_src)
+            try:
+                with urllib.request.urlopen(icon_url, timeout=5) as icon_resp:
+                    if icon_resp.status != 200:
+                        return None, page_title
+                    icon_data = icon_resp.read()
+            except Exception:
+                return None, page_title
+
+            temp_dir = tempfile.gettempdir()
+            temp_png = os.path.join(temp_dir, f"{int(time.time() * 1000)}.png")
+            with open(temp_png, "wb") as f:
+                f.write(icon_data)
+            return temp_png, page_title
+        except Exception as e:
+            logging.error(f"Failed to extract icon from url {url}: {e}")
+            return None, None

--- a/src/core/validation/widgets/yasb/launchpad.py
+++ b/src/core/validation/widgets/yasb/launchpad.py
@@ -2,7 +2,7 @@ DEFAULTS = {
     "label": "\udb85\udcde",
     "search_placeholder": "Search applications...",
     "app_icon_size": 64,
-    "window": {"fullscreen": False, "width": 800, "height": 600},
+    "window": {"fullscreen": False, "width": 800, "height": 600, "overlay_block": True},
     "window_animation": {"fade_in_duration": 400, "fade_out_duration": 400},
     "window_style": {
         "enable_blur": True,
@@ -11,6 +11,7 @@ DEFAULTS = {
         "border_color": "system",
     },
     "animation": {"enabled": True, "type": "fadeInOut", "duration": 200},
+    "shortcuts": {"add_app": "Ctrl+N", "edit_app": "F2", "show_context_menu": "Shift+F10", "delete_app": "Delete"},
     "container_padding": {"top": 0, "left": 0, "bottom": 0, "right": 0},
     "callbacks": {"on_left": "toggle_launchpad", "on_right": "do_nothing", "on_middle": "do_nothing"},
 }
@@ -25,6 +26,7 @@ VALIDATION_SCHEMA = {
             "fullscreen": {"type": "boolean", "default": DEFAULTS["window"]["fullscreen"]},
             "width": {"type": "integer", "default": DEFAULTS["window"]["width"]},
             "height": {"type": "integer", "default": DEFAULTS["window"]["height"]},
+            "overlay_block": {"type": "boolean", "default": DEFAULTS["window"]["overlay_block"]},
         },
         "default": DEFAULTS["window"],
     },
@@ -59,6 +61,16 @@ VALIDATION_SCHEMA = {
             "duration": {"type": "integer", "default": DEFAULTS["animation"]["duration"]},
         },
         "default": DEFAULTS["animation"],
+    },
+    "shortcuts": {
+        "type": "dict",
+        "schema": {
+            "add_app": {"type": "string", "default": DEFAULTS["shortcuts"]["add_app"]},
+            "edit_app": {"type": "string", "default": DEFAULTS["shortcuts"]["edit_app"]},
+            "show_context_menu": {"type": "string", "default": DEFAULTS["shortcuts"]["show_context_menu"]},
+            "delete_app": {"type": "string", "default": DEFAULTS["shortcuts"]["delete_app"]},
+        },
+        "default": DEFAULTS["shortcuts"],
     },
     "container_padding": {
         "type": "dict",

--- a/src/core/widgets/yasb/launchpad.py
+++ b/src/core/widgets/yasb/launchpad.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 import subprocess
+import tempfile
 import time
 import webbrowser
 from functools import lru_cache
@@ -15,15 +16,17 @@ from PyQt6.QtCore import (
     QMimeData,
     QPropertyAnimation,
     QSize,
+    QStringListModel,
     Qt,
     QThread,
     QTimer,
     pyqtSignal,
 )
-from PyQt6.QtGui import QAction, QColor, QCursor, QDrag, QIcon, QPainter, QPixmap, QWheelEvent
+from PyQt6.QtGui import QAction, QColor, QCursor, QDrag, QIcon, QKeySequence, QPainter, QPixmap, QShortcut, QWheelEvent
 from PyQt6.QtSvg import QSvgRenderer
 from PyQt6.QtWidgets import (
     QApplication,
+    QCompleter,
     QDialog,
     QFileDialog,
     QFrame,
@@ -39,42 +42,45 @@ from PyQt6.QtWidgets import (
 )
 
 from core.config import HOME_CONFIGURATION_DIR
+from core.event_service import EventService
+from core.utils.launchpad.app_loader import AppListLoader, ShortcutResolver
+from core.utils.launchpad.icon_extractor import IconExtractorUtil, UrlExtractorUtil
 from core.utils.utilities import add_shadow, build_widget_label
 from core.utils.widgets.animation_manager import AnimationManager
 from core.utils.win32.blurWindow import Blur
-from core.utils.win32.utilities import qmenu_rounded_corners
+from core.utils.win32.utilities import get_foreground_hwnd, qmenu_rounded_corners, set_foreground_hwnd
 from core.validation.widgets.yasb.launchpad import VALIDATION_SCHEMA
 from core.widgets.base import BaseWidget
 
-# Global icon cache to persist across widget instances
 _ICON_CACHE = {}
 
 
-@lru_cache(maxsize=128)
-def load_and_scale_icon(icon_path: str, size: int) -> QPixmap:
+@lru_cache(maxsize=256)
+def load_and_scale_icon(icon_path: str, size: int, dpr=1.0) -> QPixmap:
     """Load and scale icon with caching, supports SVG"""
     try:
         ext = os.path.splitext(icon_path)[1].lower()
+        target_size = int(size * dpr)
         if ext == ".svg":
             renderer = QSvgRenderer(icon_path)
-            pixmap = QPixmap(size, size)
+            pixmap = QPixmap(target_size, target_size)
             pixmap.fill(Qt.GlobalColor.transparent)
             painter = QPainter(pixmap)
             renderer.render(painter)
             painter.end()
+            pixmap.setDevicePixelRatio(dpr)
             return pixmap
         else:
             pixmap = QPixmap(icon_path)
             if pixmap.isNull():
                 return QPixmap()
-            if pixmap.width() != size or pixmap.height() != size:
-                scaled_pixmap = pixmap.scaled(
-                    QSize(size, size),
-                    Qt.AspectRatioMode.KeepAspectRatio,
-                    Qt.TransformationMode.SmoothTransformation,
-                )
-                return scaled_pixmap
-            return pixmap
+            scaled_pixmap = pixmap.scaled(
+                QSize(target_size, target_size),
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+            scaled_pixmap.setDevicePixelRatio(dpr)
+            return scaled_pixmap
     except Exception as e:
         logging.error(f"Failed to load icon {icon_path}: {e}")
         return QPixmap()
@@ -88,13 +94,38 @@ class IconLoadWorker(QThread):
     def __init__(self, icon_requests):
         super().__init__()
         self.icon_requests = icon_requests
+        self._should_stop = False
+
+    def stop(self):
+        self._should_stop = True
 
     def run(self):
-        for icon_path, size in self.icon_requests:
+        for icon_path, size, dpr in self.icon_requests:
+            if self._should_stop:
+                break
             if os.path.isfile(icon_path):
-                pixmap = load_and_scale_icon(icon_path, size)
-                if not pixmap.isNull():
-                    self.icon_loaded.emit(icon_path, pixmap)
+                try:
+                    pixmap = load_and_scale_icon(icon_path, size, dpr)
+                    if not pixmap.isNull() and not self._should_stop:
+                        self.icon_loaded.emit(icon_path, pixmap)
+                except Exception as e:
+                    logging.error(f"Failed to load icon in worker: {e}")
+
+
+class UrlFetchWorker(QThread):
+    finished = pyqtSignal(object, object)  # icon_path, title
+
+    def __init__(self, url, icons_dir):
+        super().__init__()
+        self.url = url
+        self.icons_dir = icons_dir
+
+    def run(self):
+        try:
+            icon, title = UrlExtractorUtil.extract_from_url(self.url, self.icons_dir)
+            self.finished.emit(icon, title)
+        except Exception:
+            self.finished.emit(None, None)
 
 
 class AppDialog(QDialog):
@@ -129,7 +160,7 @@ class AppDialog(QDialog):
 
         self._warning_label = QLabel("")
         self._warning_label.setProperty("class", "warning-message")
-        self._warning_label.setWordWrap(True)
+
         self._warning_label.hide()
         content_layout.addWidget(self._warning_label)
 
@@ -139,6 +170,7 @@ class AppDialog(QDialog):
         self.title_edit.setPlaceholderText("Enter application title...")
         self.title_edit.setText(self.app_data.get("title", ""))
         self.title_edit.setProperty("class", "title-field")
+        self.title_edit.returnPressed.connect(self._on_title_edit_return)
         title_edit_palette = self.title_edit.palette()
         self.title_edit.setPalette(title_edit_palette)
         content_layout.addWidget(self.title_edit)
@@ -150,8 +182,10 @@ class AppDialog(QDialog):
         self.path_edit.setPlaceholderText("Application executable, command or url...")
         self.path_edit.setText(self.app_data.get("path", ""))
         self.path_edit.setProperty("class", "path-field")
+        self.path_edit.returnPressed.connect(self.accept)
         self.path_edit_palette = self.path_edit.palette()
         self.path_edit.setPalette(self.path_edit_palette)
+        self.path_edit.editingFinished.connect(self._fetch_url_info)
         h1.addWidget(self.path_edit)
 
         browse_btn = QPushButton("Browse")
@@ -167,6 +201,7 @@ class AppDialog(QDialog):
         self.icon_edit.setPlaceholderText("Icon file path...")
         self.icon_edit.setText(self.app_data.get("icon", ""))
         self.icon_edit.setProperty("class", "icon-field")
+        self.icon_edit.returnPressed.connect(self.accept)
         self.icon_edit_palette = self.icon_edit.palette()
         self.icon_edit.setPalette(self.icon_edit_palette)
         h2.addWidget(self.icon_edit)
@@ -197,6 +232,120 @@ class AppDialog(QDialog):
         layout.addWidget(button_container)
         self.setLayout(layout)
 
+        self._installed_apps = []
+        self._completer = QCompleter([])
+        self._completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        self._completer.setFilterMode(Qt.MatchFlag.MatchContains)
+        self._completer.setMaxVisibleItems(5)
+        self.title_edit.setCompleter(self._completer)
+        popup = self._completer.popup()
+        popup.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        popup.setStyleSheet("""
+            QListView::item {
+                padding: 8px;
+            }
+            QListView::item:selected,
+            QListView::item:focus,
+            QListView::item:selected:focus {
+                background-color: rgba(0, 120, 212, 0.521);
+            }
+            QListView:focus {
+                outline: none;
+                border: none;
+            }
+        """)
+
+        def on_title_selected(text):
+            for name, path, _ in self._installed_apps:
+                if name.lower() == text.lower():
+                    if path.startswith("UWP::"):
+                        appid = path.replace("UWP::", "")
+                        self.path_edit.setText(f"explorer.exe shell:AppsFolder\\{appid}")
+                        install_location = None
+                        try:
+                            ps_get_location = (
+                                f"Get-AppxPackage | Where-Object {{$_.PackageFamilyName -eq '{appid.split('!')[0]}'}} | "
+                                f"Select-Object -ExpandProperty InstallLocation"
+                            )
+                            result = subprocess.run(
+                                ["powershell", "-NoProfile", "-Command", ps_get_location],
+                                capture_output=True,
+                                text=True,
+                                timeout=5,
+                            )
+                            if result.returncode == 0:
+                                install_location = result.stdout.strip()
+                        except Exception:
+                            install_location = None
+
+                        uwp_icon = None
+                        if install_location:
+                            uwp_icon = IconExtractorUtil.extract_uwp_icon(appid, install_location=install_location)
+                        if uwp_icon and os.path.isfile(uwp_icon):
+                            ext = os.path.splitext(uwp_icon)[1].lower()
+                            if ext == ".png":
+                                self.icon_edit.setText(uwp_icon)
+                            else:
+                                self._show_warning("Failed to extract icon from UWP package.")
+                                self.icon_edit.setText("")
+                        else:
+                            self.icon_edit.setText("")
+                            self._show_warning("Could not locate icon for this UWP app.")
+
+                    else:
+                        self.path_edit.setText(path)
+                        temp_dir = tempfile.gettempdir()
+                        # If .lnk, resolve to target for icon extraction
+                        ext = os.path.splitext(path)[1].lower()
+                        icon_source = path
+                        if ext == ".lnk":
+                            _, icon_source, _ = ShortcutResolver.resolve_lnk_target(path, self._show_warning)
+                        if icon_source and isinstance(icon_source, str) and os.path.isfile(icon_source):
+                            icon_path = IconExtractorUtil.extract_icon_from_path(icon_source, temp_dir)
+                            if icon_path:
+                                self.icon_edit.setText(icon_path)
+                            else:
+                                self._show_warning("Failed to extract icon for the selected application.")
+                        else:
+                            self._show_warning("No valid icon source found for the selected application.")
+                    break
+
+        self._completer.activated.connect(on_title_selected)
+
+        def on_apps_loaded(apps):
+            self._installed_apps = apps
+            self._completer.setModel(QStringListModel([name for name, _, _ in apps]))
+
+        self._app_loader = AppListLoader()
+        self._app_loader.apps_loaded.connect(on_apps_loaded)
+        self._app_loader.start()
+
+    def _fetch_url_info(self):
+        path = self.path_edit.text().strip()
+        if path.startswith("http://") or path.startswith("https://"):
+            dialog_title = self.windowTitle()
+            icon_path = self.icon_edit.text().strip()
+            if not icon_path or not os.path.isfile(icon_path):
+                self.setWindowTitle("Fetching website info...")
+
+                def on_icon_fetched(icon, title):
+                    self.setWindowTitle(dialog_title)
+                    if icon and os.path.isfile(icon):
+                        self.icon_edit.setText(icon)
+                        if title and not self.title_edit.text().strip():
+                            self.title_edit.setText(title)
+                    else:
+                        self._show_warning("Could not find an icon for this website.")
+
+                self._url_fetch_worker = UrlFetchWorker(path, self.icons_dir)
+                self._url_fetch_worker.finished.connect(on_icon_fetched)
+                self._url_fetch_worker.start()
+
+    def _on_title_edit_return(self):
+        # Accept save or add only if completer is not visible
+        if not self._completer.popup().isVisible():
+            self.accept()
+
     def lineedit_context_menu(self, lineedit: QLineEdit):
         def show_custom_menu(point):
             menu = lineedit.createStandardContextMenu()
@@ -216,7 +365,7 @@ class AppDialog(QDialog):
         self._warning_label.show()
 
         self.adjustSize()
-        QTimer.singleShot(2000, self._hide_warning)
+        QTimer.singleShot(4000, self._hide_warning)
 
     def _hide_warning(self):
         """Hide warning message"""
@@ -239,42 +388,56 @@ class AppDialog(QDialog):
 
     def get_app_data(self):
         icon_path = self.icon_edit.text().strip()
+        original_icon = self.app_data.get("icon", "") if self.is_edit_mode else ""
+        icon_changed = icon_path != original_icon
 
-        if icon_path and self.icons_dir and os.path.isfile(icon_path):
+        if icon_changed and icon_path and self.icons_dir and os.path.isfile(icon_path):
             try:
                 title = self.title_edit.text().strip().lower()
                 safe_title = "".join(c for c in title if c.isalnum() or c in (" ", "-", "_")).rstrip().replace(" ", "_")
                 _, ext = os.path.splitext(icon_path)
                 if not ext:
                     ext = ".png"
-                new_filename = f"{safe_title}{ext}"
+                timestamp = int(time.time() * 1000)
+                new_filename = f"{safe_title}_{timestamp}{ext}"
                 new_icon_path = os.path.join(self.icons_dir, new_filename)
-                counter = 1
-                while os.path.exists(new_icon_path):
-                    new_filename = f"{safe_title}_{counter}{ext}"
-                    new_icon_path = os.path.join(self.icons_dir, new_filename)
-                    counter += 1
                 shutil.copy2(icon_path, new_icon_path)
                 icon_path = new_icon_path
             except Exception as e:
                 logging.error(f"Failed to copy icon: {e}")
+        path = self.path_edit.text().strip()
 
+        if path.startswith("http://") or path.startswith("https://"):
+            entry_type = "url"
+        else:
+            entry_type = "app"
         return {
             "title": self.title_edit.text().strip(),
             "path": self.path_edit.text().strip(),
             "icon": icon_path,
+            "type": entry_type,
         }
 
     def accept(self):
-        if not self.title_edit.text().strip():
+        title = self.title_edit.text().strip()
+        path = self.path_edit.text().strip()
+        icon = self.icon_edit.text().strip()
+
+        if not title:
             self._show_warning("Please enter a title.")
+            self.title_edit.setFocus()
             return
-        if not self.path_edit.text().strip():
-            self._show_warning("Please enter an application path.")
+
+        if not path:
+            self._show_warning("The specified path does not exist.")
+            self.path_edit.setFocus()
             return
-        if not self.icon_edit.text().strip():
-            self._show_warning("Please select an icon file.")
+
+        if not os.path.isfile(icon):
+            self._show_warning("The specified icon file does not exist.")
+            self.icon_edit.setFocus()
             return
+
         super().accept()
 
 
@@ -346,6 +509,7 @@ class TransparentOverlay(QWidget):
 
 class LaunchpadWidget(BaseWidget):
     validation_schema = VALIDATION_SCHEMA
+    handle_widget_cli = pyqtSignal(str, str)
 
     def __init__(
         self,
@@ -356,6 +520,7 @@ class LaunchpadWidget(BaseWidget):
         window_style: Dict[str, Any],
         window_animation: Dict[str, int],
         animation: Dict[str, Any],
+        shortcuts: Dict[str, str],
         container_padding: Dict[str, int],
         callbacks: Dict[str, str],
         label_shadow: Dict = None,
@@ -372,12 +537,13 @@ class LaunchpadWidget(BaseWidget):
         self._window_style = window_style
         self._window_animation = window_animation
         self._animation = animation
+        self._shortcuts = shortcuts
         self._padding = container_padding
         self._label_shadow = label_shadow
         self._container_shadow = container_shadow
         self._app_title_shadow = app_title_shadow
         self._app_icon_shadow = app_icon_shadow
-
+        self._dpr = 1.0
         # Setup directories and files
         self._launchpad_dir = os.path.join(HOME_CONFIGURATION_DIR, "launchpad")
         self._icons_dir = os.path.join(self._launchpad_dir, "icons")
@@ -389,11 +555,14 @@ class LaunchpadWidget(BaseWidget):
         # Initialize properties
         self._launchpad_popup = None
         self._overlay = None
+        self._drop_overlay = None
         self._is_closing = False
+        self._popup_from_cli = False
         self._app_icons = []
         self._all_apps = []
         self._icon_worker = None
         self._grid_columns = 0
+        self._num_drag_items = 0
 
         # Create a container widget for layout
         self._widget_container_layout = QHBoxLayout()
@@ -414,6 +583,21 @@ class LaunchpadWidget(BaseWidget):
         self.callback_right = callbacks["on_right"]
         self.callback_middle = callbacks["on_middle"]
 
+        self._previous_hwnd = None
+
+        self._event_service = EventService()
+        self.handle_widget_cli.connect(self._handle_widget_cli)
+        self._event_service.register_event("handle_widget_cli", self.handle_widget_cli)
+
+    def _handle_widget_cli(self, widget: str, screen: str):
+        """Handle widget CLI commands"""
+        if widget == "launchpad":
+            current_screen = self.window().screen() if self.window() else None
+            current_screen_name = current_screen.name() if current_screen else None
+            if not screen or (current_screen_name and screen.lower() == current_screen_name.lower()):
+                self._popup_from_cli = True
+                self._toggle_launchpad()
+
     def _toggle_launchpad(self):
         if self._animation["enabled"]:
             AnimationManager.animate(self, self._animation["type"], self._animation["duration"])
@@ -423,13 +607,19 @@ class LaunchpadWidget(BaseWidget):
             self._show_launchpad()
 
     def _show_launchpad(self):
+        self._dpr = self.screen().devicePixelRatio()
         if not self._launchpad_popup:
             self._launchpad_popup = self._create_launchpad_popup()
-        if not self._overlay:
+        if not self._overlay and not self._window["fullscreen"] and self._window["overlay_block"]:
             self._overlay = self._create_overlay()
 
+        if getattr(self, "_popup_from_cli", False):
+            self._previous_hwnd = get_foreground_hwnd()
+            self._popup_from_cli = False
+
         self._center_popup_on_screen()
-        self._overlay.show()
+        if self._overlay:
+            self._overlay.show()
         self._launchpad_popup.show()
         self._populate_grid()
         self._launchpad_popup.raise_()
@@ -443,7 +633,10 @@ class LaunchpadWidget(BaseWidget):
     def _create_app_icon_widget(self, app_data: Dict[str, Any]) -> QFrame:
         """Create an app icon widget"""
         app_icon = QFrame()
-        app_icon.setProperty("class", "app-icon")
+        if app_data.get("type") == "url":
+            app_icon.setProperty("class", "app-icon url")
+        else:
+            app_icon.setProperty("class", "app-icon")
         app_icon.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
         app_icon.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         app_icon.setAcceptDrops(True)
@@ -501,7 +694,7 @@ class LaunchpadWidget(BaseWidget):
             if event.button() == Qt.MouseButton.LeftButton:
                 app_icon._drag_start_position = event.pos()
             elif event.button() == Qt.MouseButton.RightButton:
-                self._show_app_context_menu(app_icon, event)
+                self._show_context_menu(event.pos(), app_data=app_icon.app_data, parent_widget=app_icon, event=event)
 
         app_icon.mousePressEvent = mousePressEvent
 
@@ -528,7 +721,11 @@ class LaunchpadWidget(BaseWidget):
         app_icon.mouseReleaseEvent = mouseReleaseEvent
 
         def dragEnterEvent(event):
-            if event.mimeData().hasText():
+            if event.mimeData().hasUrls():
+                self._show_drop_overlay()
+                event.acceptProposedAction()
+
+            elif event.mimeData().hasText():
                 event.acceptProposedAction()
                 app_icon._drop_highlight = True
                 app_icon.setProperty("isDropTarget", True)
@@ -539,10 +736,14 @@ class LaunchpadWidget(BaseWidget):
                     }
                 """)
                 app_icon.update()
+            else:
+                event.ignore()
 
         app_icon.dragEnterEvent = dragEnterEvent
 
         def dragLeaveEvent(event):
+            if self._overlay and self._overlay.isVisible():
+                self._hide_drop_overlay()
             app_icon._drop_highlight = False
             app_icon.setProperty("isDropTarget", False)
             app_icon.setStyleSheet("")
@@ -573,14 +774,14 @@ class LaunchpadWidget(BaseWidget):
             app_icon.icon_label.setText("")
             app_icon._icon_loaded = True
             return
-        cache_key = f"{icon_path}_{self._app_icon_size}"
+        cache_key = f"{icon_path}_{self._app_icon_size}_{self._dpr}"
         if cache_key in _ICON_CACHE:
             app_icon.icon_label.setPixmap(_ICON_CACHE[cache_key])
             app_icon.icon_label.setStyleSheet("")
             app_icon._icon_loaded = True
             return
         try:
-            pixmap = load_and_scale_icon(icon_path, self._app_icon_size)
+            pixmap = load_and_scale_icon(icon_path, self._app_icon_size, self._dpr)
             if not pixmap.isNull():
                 _ICON_CACHE[cache_key] = pixmap
                 app_icon.icon_label.setPixmap(pixmap)
@@ -629,49 +830,84 @@ class LaunchpadWidget(BaseWidget):
             except Exception as e:
                 logging.error(f"Failed to launch app {app_data.get('title', 'Unknown')}: {e}")
 
-    def _show_app_context_menu(self, app_icon, event):
-        self._menu = QMenu(app_icon)
-        self._menu.setProperty("class", "context-menu")
-        self._menu.aboutToShow.connect(self._on_app_context_menu_shown)
+    def _show_context_menu(self, pos, app_data=None, parent_widget=None, event=None):
+        """
+        Show context menu for the launchpad or an app icon
+        """
+        menu_parent = parent_widget if parent_widget else self._launchpad_popup
+        menu = QMenu(menu_parent)
+        menu.setProperty("class", "context-menu")
+        qmenu_rounded_corners(menu)
 
-        edit_action = QAction("Edit", app_icon)
-        edit_action.triggered.connect(lambda: self._edit_app(app_icon.app_data))
-        self._menu.addAction(edit_action)
+        if app_data:
+            edit_action = QAction("Edit", menu_parent)
+            edit_action.triggered.connect(lambda: self._edit_app(app_data))
+            menu.addAction(edit_action)
 
-        add_action = QAction("Add New App", app_icon)
-        add_action.triggered.connect(lambda: self._add_new_app())
-        self._menu.addAction(add_action)
+        add_action = QAction("Add New App", menu_parent)
+        add_action.triggered.connect(self._add_new_app)
+        menu.addAction(add_action)
 
-        self._menu.addSeparator()
-        order_action_az = QAction("Order A-Z", app_icon)
+        menu.addSeparator()
+
+        order_action_az = QAction("Order A-Z", menu_parent)
         order_action_az.triggered.connect(lambda: self._order_apps("az"))
-        self._menu.addAction(order_action_az)
-        order_action_za = QAction("Order Z-A", app_icon)
+        menu.addAction(order_action_az)
+        order_action_za = QAction("Order Z-A", menu_parent)
         order_action_za.triggered.connect(lambda: self._order_apps("za"))
-        self._menu.addAction(order_action_za)
-        order_action_recent = QAction("Order by Recent", app_icon)
+        menu.addAction(order_action_za)
+        order_action_recent = QAction("Order by Recent", menu_parent)
         order_action_recent.triggered.connect(lambda: self._order_apps("recent"))
-        self._menu.addAction(order_action_recent)
-        order_action_oldest = QAction("Order by Oldest", app_icon)
+        menu.addAction(order_action_recent)
+        order_action_oldest = QAction("Order by Oldest", menu_parent)
         order_action_oldest.triggered.connect(lambda: self._order_apps("oldest"))
-        self._menu.addAction(order_action_oldest)
-        self._menu.addSeparator()
+        menu.addAction(order_action_oldest)
 
-        delete_action = QAction("Delete", app_icon)
-        delete_action.triggered.connect(lambda: self._delete_app(app_icon.app_data))
-        self._menu.addAction(delete_action)
+        menu.addSeparator()
 
-        self._menu.addSeparator()
+        if app_data:
+            delete_action = QAction("Delete", menu_parent)
+            delete_action.triggered.connect(lambda: self._delete_app(app_data))
+            menu.addAction(delete_action)
+            menu.addSeparator()
 
-        exit_action = QAction("Exit Launchpad")
+        exit_action = QAction("Exit Launchpad", menu_parent)
         exit_action.triggered.connect(self._hide_launchpad)
-        self._menu.addAction(exit_action)
+        menu.addAction(exit_action)
 
-        self._menu.exec(app_icon.mapToGlobal(event.pos()))
+        if event:
+            menu.exec(parent_widget.mapToGlobal(event.pos()))
+        else:
+            menu.exec(self._launchpad_popup.mapToGlobal(pos))
 
-    def _on_app_context_menu_shown(self):
-        """Handle app context menu shown event"""
-        qmenu_rounded_corners(self._menu)
+    def _show_drop_overlay(self):
+        """Show the drop overlay when dragging items over the launchpad"""
+        if self._num_drag_items > 1:
+            overlay_label = f"Drop {self._num_drag_items} Apps Here"
+        else:
+            overlay_label = "Drop App Here"
+
+        if self._drop_overlay:
+            # Update label text if overlay already exists
+            label = self._drop_overlay.findChild(QLabel)
+            if label:
+                label.setText(overlay_label)
+            self._drop_overlay.show()
+            return
+
+        overlay = QWidget(self._launchpad_popup)
+        overlay.setProperty("class", "drop-overlay")
+        overlay.setGeometry(self._launchpad_popup.rect())
+        label = QLabel(overlay_label, overlay)
+        label.setProperty("class", "text")
+        label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        label.setGeometry(0, 0, overlay.width(), overlay.height())
+        overlay.show()
+        self._drop_overlay = overlay
+
+    def _hide_drop_overlay(self):
+        if self._drop_overlay:
+            self._drop_overlay.hide()
 
     def _create_launchpad_popup(self):
         """Create the launchpad popup window"""
@@ -711,7 +947,7 @@ class LaunchpadWidget(BaseWidget):
 
         self.popup.fade_out_animation.finished.connect(self._on_fade_out_finished)
         self.popup.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
-        self.popup.customContextMenuRequested.connect(self._show_add_menu)
+        self.popup.customContextMenuRequested.connect(lambda pos: self._show_context_menu(pos))
 
         window_layout = QVBoxLayout(self.popup)
         window_layout.setContentsMargins(0, 0, 0, 0)
@@ -782,12 +1018,40 @@ class LaunchpadWidget(BaseWidget):
         self.popup.grid_container = grid_container
         self.popup.grid_layout = grid_layout
 
+        self.popup.setAcceptDrops(True)
         self.popup.mousePressEvent = lambda event: self._handle_popup_mouse_press(self.popup, event)
         self.popup.keyPressEvent = lambda event: self._handle_popup_key_press(event)
         self.popup.showEvent = self._popup_show_event
         self.popup.closeEvent = self._popup_close_event
+        self.popup.dropEvent = self._popup_drop_event
+        self.popup.dragEnterEvent = self._popup_drag_enter_event
+        self.popup.dragLeaveEvent = self._popup_drag_leave_event
+        self.popup.enterEvent = self._popup_enter_event
+        self.popup.leaveEvent = self._popup_leave_event
+
+        shortcut_add = QShortcut(QKeySequence(self._shortcuts["add_app"]), self.popup)
+        shortcut_add.activated.connect(self._add_new_app)
+
+        shortcut_edit = QShortcut(QKeySequence(self._shortcuts["edit_app"]), self.popup)
+        shortcut_edit.activated.connect(self._edit_selected_app)
+
+        shortcut_menu = QShortcut(QKeySequence(self._shortcuts["show_context_menu"]), self.popup)
+        shortcut_menu.activated.connect(lambda: self._show_context_menu(self.popup.rect().center()))
+
+        shortcut_delete = QShortcut(QKeySequence(self._shortcuts["delete_app"]), self.popup)
+        shortcut_delete.activated.connect(self._delete_selected_app)
 
         return self.popup
+
+    def _edit_selected_app(self):
+        focused_icon = next((icon for icon in self._app_icons if icon.hasFocus()), None)
+        if focused_icon:
+            self._edit_app(focused_icon.app_data)
+
+    def _delete_selected_app(self):
+        focused_icon = next((icon for icon in self._app_icons if icon.hasFocus()), None)
+        if focused_icon:
+            self._delete_app(focused_icon.app_data)
 
     def _center_popup_on_screen(self):
         if not self._launchpad_popup:
@@ -808,6 +1072,89 @@ class LaunchpadWidget(BaseWidget):
         self._overlay = TransparentOverlay()
         self._overlay.overlay_clicked.connect(self._hide_launchpad)
         return self._overlay
+
+    def _get_file_description(self, path):
+        """Get the file description from Windows file properties."""
+        import win32api
+
+        try:
+            language, codepage = win32api.GetFileVersionInfo(path, "\\VarFileInfo\\Translation")[0]
+            stringFileInfo = "\\StringFileInfo\\%04X%04X\\%s" % (language, codepage, "FileDescription")
+            description = win32api.GetFileVersionInfo(path, stringFileInfo)
+        except:
+            description = "unknown"
+
+        return description
+
+    def _handle_file_drop(self, file_path, refresh_grid=True):
+        ext = os.path.splitext(file_path)[1].lower()
+        app_data = None
+
+        if ext == ".lnk":
+            target_path, icon_path, app_name = ShortcutResolver.resolve_lnk_target(file_path, self._warning_dialog)
+            if not app_name or not target_path:
+                self._warning_dialog(f"Failed to resolve shortcut: {file_path}")
+                return
+            if not icon_path:
+                icon_path = target_path
+            icon_png = IconExtractorUtil.extract_icon_from_path(icon_path, self._icons_dir)
+            if not icon_png:
+                self._warning_dialog(
+                    f"Failed to extract icon for application<br><b>{file_path}</b><br>Please select an icon manually."
+                )
+
+            app_data = (app_name, target_path, icon_png or "")
+
+        elif ext == ".exe":
+            title = self._get_file_description(file_path)
+            if not title:
+                self._warning_dialog(f"Failed to get description for executable: {file_path}")
+                return
+            icon_png = IconExtractorUtil.extract_icon_from_path(file_path, self._icons_dir)
+
+            if not icon_png:
+                self._warning_dialog(
+                    f"Failed to extract icon for application<br><b>{file_path}</b><br>Please select an icon manually."
+                )
+
+            app_data = (title, file_path, icon_png or "")
+
+        if app_data:
+            app_dict = {
+                "title": app_data[0],
+                "path": app_data[1],
+                "icon": app_data[2],
+                "id": int(time.time() * 1000),
+            }
+            apps = self._load_apps()
+            apps.append(app_dict)
+            self._save_apps(apps)
+            if self._launchpad_popup and refresh_grid:
+                self._populate_grid()
+
+    def _popup_drag_enter_event(self, event):
+        if event.mimeData().hasUrls():
+            urls = event.mimeData().urls()
+            self._num_drag_items = len(urls)
+            self._show_drop_overlay()
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def _popup_drag_leave_event(self, event):
+        self._hide_drop_overlay()
+        event.accept()
+
+    def _popup_drop_event(self, event):
+        self._hide_drop_overlay()
+        if event.mimeData().hasUrls():
+            file_paths = [url.toLocalFile() for url in event.mimeData().urls()]
+            for file_path in file_paths:
+                self._handle_file_drop(file_path, refresh_grid=False)
+            self._populate_grid()  # Refresh only once after all files are added
+            event.acceptProposedAction()
+        else:
+            event.ignore()
 
     def _handle_popup_mouse_press(self, popup, event):
         if event.button() == Qt.MouseButton.LeftButton:
@@ -847,8 +1194,7 @@ class LaunchpadWidget(BaseWidget):
             return
         current_index = next((i for i, icon in enumerate(self._app_icons) if icon.hasFocus()), -1)
         if current_index == -1:
-            if self._app_icons:
-                self._app_icons[0].setFocus()
+            self._focus_icon(0)
             return
         new_index = current_index
         if key == Qt.Key.Key_Left:
@@ -859,9 +1205,15 @@ class LaunchpadWidget(BaseWidget):
             new_index = max(0, current_index - self._grid_columns)
         elif key == Qt.Key.Key_Down:
             new_index = min(len(self._app_icons) - 1, current_index + self._grid_columns)
-        if 0 <= new_index < len(self._app_icons):
-            self._app_icons[new_index].setFocus()
-            self._scroll_to_icon(self._app_icons[new_index])
+        self._focus_icon(new_index)
+
+    def _popup_enter_event(self, event):
+        self.popup.setCursor(Qt.CursorShape.ArrowCursor)
+        QWidget.enterEvent(self.popup, event)
+
+    def _popup_leave_event(self, event):
+        self.popup.setCursor(Qt.CursorShape.ArrowCursor)
+        QWidget.leaveEvent(self.popup, event)
 
     def _scroll_to_icon(self, icon):
         """
@@ -906,9 +1258,6 @@ class LaunchpadWidget(BaseWidget):
             return
         grid_layout = self._launchpad_popup.grid_layout
         grid_container = self._launchpad_popup.grid_container
-        grid_container.setAcceptDrops(True)
-        grid_container.dragEnterEvent = lambda event: self._grid_drag_enter_event(event)
-        grid_container.dropEvent = lambda event: self._grid_drop_event(event)
         for i in reversed(range(grid_layout.count())):
             child = grid_layout.itemAt(i).widget()
             if child:
@@ -923,8 +1272,11 @@ class LaunchpadWidget(BaseWidget):
         else:
             filtered_apps = self._all_apps
         if not filtered_apps:
-            no_apps_label = QLabel("No applications found")
+            no_apps_label = QLabel(
+                f"No applications found<div style='font-size:14pt;margin-top:12px;font-weight:400'>press <b>{self._shortcuts['add_app']}</b> to add new apps</div>"
+            )
             no_apps_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            no_apps_label.setTextFormat(Qt.TextFormat.RichText)
             no_apps_label.setStyleSheet("font-size: 24pt;font-family: 'Segoe UI';padding: 40px")
             grid_layout.addWidget(no_apps_label, 0, 0, 1, 1)
             return
@@ -962,35 +1314,11 @@ class LaunchpadWidget(BaseWidget):
         for app_data in filtered_apps:
             icon_path = app_data.get("icon", "")
             if icon_path and os.path.isfile(icon_path):
-                cache_key = f"{icon_path}_{self._app_icon_size}"
+                cache_key = f"{icon_path}_{self._app_icon_size}_{self._dpr}"
                 if cache_key not in _ICON_CACHE:
-                    icon_requests.append((icon_path, self._app_icon_size))
+                    icon_requests.append((icon_path, self._app_icon_size, self._dpr))
         if icon_requests:
             self._start_background_loading(icon_requests)
-
-    def _grid_drag_enter_event(self, event):
-        if event.mimeData().hasText():
-            event.acceptProposedAction()
-
-    def _grid_drop_event(self, event):
-        if event.mimeData().hasText():
-            source_app_id = event.mimeData().text()
-            try:
-                apps = self._load_apps()
-                source_app = None
-                for i, app in enumerate(apps):
-                    if str(app.get("id", "")) == source_app_id:
-                        source_app = apps.pop(i)
-                        break
-                if source_app:
-                    apps.append(source_app)
-                    self._save_apps(apps)
-                    if self._launchpad_popup:
-                        current_search = self._launchpad_popup.search_input.text()
-                        self._populate_grid(current_search)
-            except Exception as e:
-                logging.error(f"Failed to move app to end: {e}")
-            event.acceptProposedAction()
 
     def _fade_in_popup(self):
         if self._window_animation["fade_in_duration"] > 0 and self._launchpad_popup:
@@ -1028,12 +1356,18 @@ class LaunchpadWidget(BaseWidget):
 
     def _cleanup_popup(self):
         if self._launchpad_popup:
+            self._cleanup_drop_overlay()
             self._launchpad_popup.hide()
             self._launchpad_popup.deleteLater()
             self._launchpad_popup = None
             self._app_icons.clear()
             self._all_apps.clear()
             self._is_closing = False
+            AppListLoader.clear_cache()
+
+        if self._previous_hwnd:
+            set_foreground_hwnd(self._previous_hwnd)
+            self._previous_hwnd = None
 
     def _cleanup_overlay(self):
         if self._overlay:
@@ -1041,43 +1375,26 @@ class LaunchpadWidget(BaseWidget):
             self._overlay.deleteLater()
             self._overlay = None
 
+    def _cleanup_drop_overlay(self):
+        if self._drop_overlay:
+            try:
+                self._drop_overlay.hide()
+                self._drop_overlay.deleteLater()
+            except Exception:
+                pass
+            self._drop_overlay = None
+
+    def _focus_icon(self, index: int = 0):
+        if self._app_icons and 0 <= index < len(self._app_icons):
+            icon = self._app_icons[index]
+            icon.setFocus()
+            icon.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+            self._scroll_to_icon(icon)
+        elif self._launchpad_popup:
+            self._launchpad_popup.search_input.setFocus()
+
     def _focus_first_icon(self):
-        if self._app_icons and len(self._app_icons) > 0:
-            first_icon = self._app_icons[0]
-            first_icon.setFocus()
-            first_icon.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
-        else:
-            if self._launchpad_popup:
-                self._launchpad_popup.search_input.setFocus()
-
-    def _show_add_menu(self, pos):
-        menu = QMenu(self._launchpad_popup)
-        menu.setProperty("class", "context-menu")
-        qmenu_rounded_corners(menu)
-        add_action = QAction("Add New App", self._launchpad_popup)
-        add_action.triggered.connect(self._add_new_app)
-        menu.addAction(add_action)
-        menu.addSeparator()
-
-        order_action_az = QAction("Order A-Z")
-        order_action_az.triggered.connect(lambda: self._order_apps("az"))
-        menu.addAction(order_action_az)
-        order_action_za = QAction("Order Z-A")
-        order_action_za.triggered.connect(lambda: self._order_apps("za"))
-        menu.addAction(order_action_za)
-
-        order_action_recent = QAction("Order by Recent")
-        order_action_recent.triggered.connect(lambda: self._order_apps("recent"))
-        menu.addAction(order_action_recent)
-        order_action_oldest = QAction("Order by Oldest")
-        order_action_oldest.triggered.connect(lambda: self._order_apps("oldest"))
-        menu.addAction(order_action_oldest)
-        menu.addSeparator()
-
-        exit_action = QAction("Exit Launchpad")
-        exit_action.triggered.connect(self._hide_launchpad)
-        menu.addAction(exit_action)
-        menu.exec(self._launchpad_popup.mapToGlobal(pos))
+        self._focus_icon(0)
 
     def _start_background_loading(self, icon_requests):
         if self._icon_worker and self._icon_worker.isRunning():
@@ -1088,7 +1405,7 @@ class LaunchpadWidget(BaseWidget):
         self._icon_worker.start()
 
     def _on_background_icon_loaded(self, icon_path: str, pixmap: QPixmap):
-        cache_key = f"{icon_path}_{self._app_icon_size}"
+        cache_key = f"{icon_path}_{self._app_icon_size}_{self._dpr}"
         _ICON_CACHE[cache_key] = pixmap
         for app_icon in self._app_icons:
             if hasattr(app_icon, "app_data") and app_icon.app_data.get("icon", "") == icon_path:
@@ -1098,7 +1415,7 @@ class LaunchpadWidget(BaseWidget):
                     app_icon._icon_loaded = True
 
     def _recalculate_grid_columns(self):
-        """Recalculate the number of columns based on available width and icon size (assuming spacing and margins are 0)"""
+        """Recalculate the number of columns based on available width and icon size"""
         scrollbar_width = 0
         scroll_area = self._launchpad_popup.scroll_area
         if scroll_area.verticalScrollBar().isVisible():
@@ -1151,11 +1468,53 @@ class LaunchpadWidget(BaseWidget):
             self._save_apps(apps)
             if icon_changed:
                 self._cleanup_unused_icons()
-            for cache_key in list(_ICON_CACHE.keys()):
-                if old_icon in cache_key or new_icon in cache_key:
-                    del _ICON_CACHE[cache_key]
             if self._launchpad_popup:
                 self._populate_grid()
+
+    def _warning_dialog(self, message: str):
+        """Show a warning dialog with a message"""
+        dialog = QDialog(self._launchpad_popup if self._launchpad_popup else None)
+        dialog.setWindowTitle("Warning")
+        dialog.setMinimumSize(400, 150)
+        dialog.setWindowFlags(
+            Qt.WindowType.Dialog
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.WindowTitleHint
+            | Qt.WindowType.CustomizeWindowHint
+            | Qt.WindowType.MSWindowsFixedSizeDialogHint
+        )
+        dialog.setProperty("class", "app-dialog")
+
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        content_container = QWidget()
+        content_layout = QVBoxLayout(content_container)
+        content_layout.setContentsMargins(20, 20, 20, 0)
+        content_layout.setSpacing(0)
+
+        message_label = QLabel(message)
+        message_label.setWordWrap(True)
+        message_label.setProperty("class", "message")
+        message_label.setTextFormat(Qt.TextFormat.RichText)
+        content_layout.addWidget(message_label)
+        layout.addWidget(content_container)
+
+        button_container = QFrame()
+        button_container.setProperty("class", "buttons-container")
+        button_layout = QHBoxLayout(button_container)
+        button_layout.setContentsMargins(0, 0, 0, 0)
+
+        ok_btn = QPushButton("OK")
+        ok_btn.setProperty("class", "button")
+        ok_btn.clicked.connect(dialog.accept)
+        button_layout.addWidget(ok_btn)
+
+        layout.addWidget(button_container)
+        dialog.setLayout(layout)
+
+        dialog.exec()
 
     def _delete_app(self, app_data: Dict[str, Any]):
         """Delete an app with modern styled confirmation dialog"""
@@ -1196,7 +1555,6 @@ class LaunchpadWidget(BaseWidget):
         cancel_btn.clicked.connect(dialog.reject)
         button_layout.addWidget(cancel_btn)
 
-        # Delete button with red styling
         delete_btn = QPushButton("Delete")
         delete_btn.setProperty("class", "button delete")
         delete_btn.clicked.connect(dialog.accept)
@@ -1204,11 +1562,18 @@ class LaunchpadWidget(BaseWidget):
 
         layout.addWidget(button_container)
         dialog.setLayout(layout)
-
+        delete_btn.setAutoDefault(True)
+        delete_btn.setDefault(True)
+        delete_btn.setFocus()
         result = dialog.exec()
         if result == QDialog.DialogCode.Accepted:
             apps = self._load_apps()
             app_id = app_data.get("id")
+            prev_focus_index = None
+            for i, app in enumerate(apps):
+                if app.get("id") == app_id:
+                    prev_focus_index = i - 1 if i > 0 else 0
+                    break
             if app_id is not None:
                 apps = [app for app in apps if app.get("id") != app_id]
             else:
@@ -1217,6 +1582,11 @@ class LaunchpadWidget(BaseWidget):
             self._cleanup_unused_icons()
             if self._launchpad_popup:
                 self._populate_grid()
+                if self._app_icons:
+                    if prev_focus_index is not None and 0 <= prev_focus_index < len(self._app_icons):
+                        self._app_icons[prev_focus_index].setFocus()
+                    else:
+                        self._app_icons[0].setFocus()
 
     def _cleanup_unused_icons(self):
         try:
@@ -1235,6 +1605,11 @@ class LaunchpadWidget(BaseWidget):
                         os.remove(unused_icon_path)
                     except Exception as e:
                         logging.warning(f"Failed to remove unused icon {filename}: {e}")
+
+                    for cache_key in list(_ICON_CACHE.keys()):
+                        if filename in cache_key:
+                            del _ICON_CACHE[cache_key]
+
         except Exception as e:
             logging.error(f"Failed to cleanup unused icons: {e}")
 
@@ -1243,14 +1618,6 @@ class LaunchpadWidget(BaseWidget):
             if os.path.exists(self._data_file):
                 with open(self._data_file, "r", encoding="utf-8") as f:
                     apps = json.load(f)
-                needs_save = False
-                for app in apps:
-                    if "id" not in app:
-                        app["id"] = int(time.time() * 1000)
-                        needs_save = True
-                        time.sleep(0.001)
-                if needs_save:
-                    self._save_apps(apps)
                 return apps
         except Exception as e:
             logging.error(f"Failed to load apps from {self._data_file}: {e}")

--- a/src/core/widgets/yasb/wallpapers.py
+++ b/src/core/widgets/yasb/wallpapers.py
@@ -20,6 +20,7 @@ from core.utils.alert_dialog import raise_info_alert
 from core.utils.utilities import add_shadow
 from core.utils.widgets.animation_manager import AnimationManager
 from core.utils.widgets.wallpapers_gallery import ImageGallery
+from core.utils.win32.utilities import get_foreground_hwnd, set_foreground_hwnd
 from core.validation.widgets.yasb.wallpapers import VALIDATION_SCHEMA
 from core.widgets.base import BaseWidget
 from settings import DEBUG
@@ -27,6 +28,7 @@ from settings import DEBUG
 
 class WallpapersWidget(BaseWidget):
     set_wallpaper_signal = pyqtSignal(str)
+    handle_widget_cli = pyqtSignal(str, str)
 
     user32 = ctypes.windll.user32
     validation_schema = VALIDATION_SCHEMA
@@ -64,6 +66,7 @@ class WallpapersWidget(BaseWidget):
 
         self._last_image = None
         self._is_running = False
+        self._popup_from_cli = False
 
         # Construct container
         self._widget_container_layout: QHBoxLayout = QHBoxLayout()
@@ -90,6 +93,33 @@ class WallpapersWidget(BaseWidget):
         self.callback_timer = "change_background"
         if self._change_automatically:
             self.start_timer()
+
+        self._previous_hwnd = None
+        self.handle_widget_cli.connect(self._handle_widget_cli)
+        self._event_service.register_event("handle_widget_cli", self.handle_widget_cli)
+
+    def _handle_widget_cli(self, widget: str, screen: str):
+        """Handle widget CLI commands"""
+        if widget == "wallpapers":
+            current_screen = self.window().screen() if self.window() else None
+            current_screen_name = current_screen.name() if current_screen else None
+            if not screen or (current_screen_name and screen.lower() == current_screen_name.lower()):
+                self._popup_from_cli = True
+                self._toggle_widget()
+
+    def _toggle_widget(self):
+        """Toggle the visibility of the widget."""
+        if self._image_gallery is not None and self._image_gallery.isVisible():
+            self._image_gallery.fade_out_and_close_gallery()
+            if self._previous_hwnd:
+                set_foreground_hwnd(self._previous_hwnd)
+                self._previous_hwnd = None
+        else:
+            if getattr(self, "_popup_from_cli", False):
+                self._previous_hwnd = get_foreground_hwnd()
+                self._popup_from_cli = False
+            self._image_gallery = ImageGallery(self._image_path, self._gallery)
+            self._image_gallery.fade_in_gallery(parent=self)
 
     def start_timer(self):
         """Start the timer for automatic wallpaper changes."""


### PR DESCRIPTION
- Introduced a new CLI command `toggle-widget` to show/hide specific widgets.
- Enhanced the command with options to follow the mouse cursor or focused window.
- Updated the CLI handler to process the new command and emit events for widget management.
- Added global state management for tracking screens where bars are displayed.