### PR TITLE
feat(update-check): implement update check service and configuration

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -35,7 +35,7 @@ QT_SCALE_FACTOR_ROUNDING_POLICY="PassThrough"
 | `watch_stylesheet`         | boolean | `true`        | Reload bar when style is changed. |
 | `watch_config`         | boolean    | `true`        | Reload bar when config is changed. |
 | `debug`      | boolean  | `false`   | Enable debug mode to see more logs |
-
+| `update_check`      | boolean  | `true`   | Enable automatic update check. This works only if the application is installed. |
 
 ## Komorebi settings for tray menu
 | Option            | Type    | Default       | Description |

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -3,6 +3,7 @@
 watch_stylesheet: true
 watch_config: true
 debug: false
+update_check: true # Enable automatic update check.
 komorebi:
   start_command: "komorebic start --whkd"
   stop_command: "komorebic stop --whkd"

--- a/src/core/bar_manager.py
+++ b/src/core/bar_manager.py
@@ -54,7 +54,10 @@ class BarManager(QObject):
             logging.error(f"Error loading config: {e}")
             return
         if config and (config != self.config):
-            if any(config[key] != self.config[key] for key in ["bars", "widgets", "komorebi", "debug", "env_file"]):
+            if any(
+                config[key] != self.config[key]
+                for key in ["bars", "widgets", "komorebi", "debug", "env_file", "update_check"]
+            ):
                 self.config = config
                 reload_application("Reloading Application because of config change.")
             else:

--- a/src/core/utils/update_check.py
+++ b/src/core/utils/update_check.py
@@ -1,0 +1,45 @@
+import json
+import logging
+import threading
+import urllib.request
+
+from core.utils.utilities import ToastNotifier
+from settings import BUILD_VERSION, SCRIPT_PATH
+
+
+class UpdateCheckService:
+    _instance = None
+
+    def __new__(cls, *args, **kwargs):
+        if not cls._instance:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        if hasattr(self, "_initialized") and self._initialized:
+            return
+        self._initialized = True
+        self.current_version = BUILD_VERSION
+        self.icon_path = f"{SCRIPT_PATH}/assets/images/app_transparent.png"
+        threading.Thread(target=self.check_for_update, daemon=True).start()
+
+    def check_for_update(self):
+        try:
+            url = "https://api.github.com/repos/amnweb/yasb/releases/latest"
+            with urllib.request.urlopen(url, timeout=10) as response:
+                data = response.read()
+                release_info = json.loads(data)
+                latest_version = release_info["tag_name"].lstrip("v")
+            if latest_version != self.current_version:
+                toaster = ToastNotifier()
+                toaster.show(
+                    icon_path=self.icon_path,
+                    title="Update Available",
+                    message=f"New version {latest_version} is available!",
+                    launch_url="https://github.com/amnweb/yasb/releases/latest",
+                    scenario="reminder",
+                )
+        except urllib.error.URLError:
+            logging.warning("UpdateCheckService Failed to check for updates: Network error.")
+        except Exception as e:
+            logging.warning(f"UpdateCheckService Failed to check for updates: {e}")

--- a/src/core/utils/utilities.py
+++ b/src/core/utils/utilities.py
@@ -319,11 +319,32 @@ class ToastNotifier:
         self.manager = ToastNotificationManager.get_default()
         self.toaster = self.manager.create_toast_notifier_with_id(get_app_identifier())
 
-    def show(self, icon_path: str, title: str, message: str, duration: str = "short") -> None:
+    def show(
+        self,
+        icon_path: str,
+        title: str,
+        message: str,
+        duration: str = "short",
+        launch_url: str = None,
+        scenario: str = None,
+    ) -> None:
         # refer to https://learn.microsoft.com/en-us/uwp/schemas/tiles/toastschema/schema-root
+        scenario = ' scenario="reminder"' if scenario else ""
+        actions = (
+            f"""
+            <actions>
+                <action
+                    content="Download &amp; Install"
+                    activationType="protocol"
+                    arguments="{launch_url}"/>
+            </actions>
+            """
+            if launch_url
+            else ""
+        )
         xml = XmlDocument()
         xml.load_xml(f"""
-        <toast activationType="protocol" duration="{duration}">
+        <toast activationType="protocol" duration="{duration}"{scenario}>
             <visual>
                 <binding template="ToastGeneric">
                     <image placement="appLogoOverride" hint-crop="circle" src="{icon_path}"/>
@@ -331,6 +352,7 @@ class ToastNotifier:
                     <text>{message}</text>
                 </binding>
             </visual>
+            {actions}
         </toast>
         """)
         notification = ToastNotification(xml)

--- a/src/core/validation/config.py
+++ b/src/core/validation/config.py
@@ -19,6 +19,11 @@ CONFIG_SCHEMA = {
         "required": False,
         "default": None,
     },
+    "update_check": {
+        "type": "boolean",
+        "default": False,
+        "required": False,
+    },
     "komorebi": {
         "type": "dict",
         "schema": {

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from core.event_service import EventService
 from core.log import init_logger
 from core.tray import SystemTrayManager
 from core.utils.controller import start_cli_server
+from core.utils.update_check import UpdateCheckService
 from core.watcher import create_observer
 from env_loader import load_env, set_font_engine
 
@@ -76,6 +77,14 @@ def main():
     # Build system tray icon
     tray_manager = SystemTrayManager(manager)
     tray_manager.show()
+
+    # Initialize auto update service
+    if config["update_check"] and getattr(sys, "frozen", False):
+        try:
+            auto_update_service = UpdateCheckService()
+            app.auto_update_service = auto_update_service
+        except Exception as e:
+            logging.error(f"Failed to start auto update service: {e}")
 
     with loop:
         loop.run_forever()


### PR DESCRIPTION
The app should automatically check for updates on startup and display a notification if a new version is available. The notification will remain visible until the user dismisses it or clicks Download & Install.
New config options `update_check` (disabled by default)

![Screenshot 2025-07-01 150335](https://github.com/user-attachments/assets/39acfc76-ee05-4ee8-888a-10f9253dbbb3)
