### PR TITLE
feat(clock): add per-hour icons support for ClockWidget

### DIFF
--- a/docs/widgets/(Widget)-Clock.md
+++ b/docs/widgets/(Widget)-Clock.md
@@ -2,13 +2,14 @@
 
 | Option              | Type    | Default                                                                               | Description                                                                                                         |
 | ------------------- | ------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `label`             | string  | `'\uf017 {%H:%M:%S}'`                                                                 | The format string for the clock. You can use placeholders like `{%H:%M:%S}` to dynamically insert time information. |
+| `label`             | string  | `'\uf017 {%H:%M:%S}'`                                                                 | The format string for the clock. You can use placeholders like `{%H:%M:%S}` or `{icon}` to dynamically insert time information. |
 | `label_alt`         | string  | `'\uf017 {%d-%m-%y %H:%M:%S}'`                                                        | The alternative format string for the clock. Useful for displaying additional time details.                         |
 | `class_name`        | string  | `""`                                                                                  | Additional CSS class name for the widget.                                    |
 | `tooltip`           | boolean | `True`                                                                                | Whether to show the tooltip on hover.                                                                               |
 | `locale`            | string  | `""`                                                                                  | The locale to use for the clock. If not specified, it defaults to an empty string.                                  |
 | `update_interval`   | integer | `1000`                                                                                | The interval in milliseconds to update the clock. Must be between 0 and 60000.                                      |
 | `timezones`         | list    | `[]`                                                                                  | A list of timezones to cycle through. Each timezone should be a valid timezone string.                              |
+| `icons`         | dict    | `{ 'clock_01': '\udb85\udc3f', ..., 'clock_12': '\udb85\udc4a'[, 'clock_13': '\udb85\udc3f', ..., 'clock_22': '\udb85\udc48','clock_23': '\udb85\udc49']}` | A dictionary of icons for the different times of day. |
 | `calendar` | dict | `{'blur': True, 'round_corners': True, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Calendar settings for the widget. |
 | `callbacks`         | dict    | `{'on_left': 'toggle_calendar', 'on_middle': 'next_timezone', 'on_right': 'toggle_label'}` | Callbacks for mouse events on the clock widget.                                                                     |
 | `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`                             | Animation settings for the widget.                                                                                  |
@@ -22,11 +23,28 @@
 clock:
   type: "yasb.clock.ClockWidget"
   options:
-    label: "\uf017 {%H:%M:%S}"
+    label: "<span>icon</span> {%H:%M:%S}"
     label_alt: "\uf017 {%d-%m-%y %H:%M:%S}"
     locale: ""
     update_interval: 1000
     timezones: []
+    icons:
+      clock_01 : "\udb85\udc3f"
+      clock_02 : "\udb85\udc40"
+      clock_03 : "\udb85\udc41"
+      clock_04 : "\udb85\udc42"
+      clock_05 : "\udb85\udc43"
+      clock_06 : "\udb85\udc44"
+      clock_07 : "\udb85\udc45"
+      clock_08 : "\udb85\udc46"
+      clock_09 : "\udb85\udc47"
+      clock_10 : "\udb85\udc48"
+      clock_11 : "\udb85\udc49"
+      clock_12 : "\udb85\udc4a"
+      clock_16 : "SNACK TIME !"
+      clock_21 : "Zzz..."
+      clock_22 : "Zzz..."
+      clock_23 : "Zzz..."
     calendar: 
       blur: True
       round_corners: True
@@ -47,13 +65,14 @@ clock:
 
 ## Description of Options
 
-- **label:** The format string for the clock. You can use placeholders like `{%H:%M:%S}` to dynamically insert time information.
+- **label:** The format string for the clock. You can use placeholders like `{%H:%M:%S}` or `{icon}` to dynamically insert time information.
 - **label_alt:** The alternative format string for the clock. Useful for displaying additional time details.
 - **class_name:** Additional CSS class name for the widget. This can be used to apply custom styles.
 - **locale:** The locale to use for the clock. If not specified, it defaults to an empty string.
 - **tooltip:** Whether to show the tooltip on hover.
 - **update_interval:** The interval in milliseconds to update the clock. Must be between 0 and 60000.
 - **timezones:** A list of timezones to cycle through. If value is empty YASB will looking up time zone info from registry
+- **icons:** A dictionary mapping clock hours to icons. Keys are in the format clock_HH where HH is the hour in 24h format (00–23). By default, `clock_13` to `clock_23` reuse the icons from `clock_01` to `clock_11`, unless explicitly defined.
 - **calendar:** A dictionary specifying the calendar settings for the widget. It contains the following keys:
   - **blur:** Enable blur effect for the calendar.
   - **round_corners:** Enable round corners for the calendar (this option is not supported on Windows 10).
@@ -86,6 +105,12 @@ Clock format https://docs.python.org/3/library/time.html#time.strftime
 .clock-widget .widget-container .label.alt {
 }
 .clock-widget .widget-container .icon {
+}
+.clock-widget .icon {
+}
+.clock-widget .icon.clock_02 {
+}
+.clock-widget .label.clock_15 {
 }
 ```
 

--- a/src/core/validation/widgets/yasb/clock.py
+++ b/src/core/validation/widgets/yasb/clock.py
@@ -6,6 +6,7 @@ DEFAULTS = {
     "locale": "",
     "tooltip": True,
     "timezones": [],
+    "icons": {},
     "calendar": {
         "blur": True,
         "round_corners": True,
@@ -30,6 +31,13 @@ VALIDATION_SCHEMA = {
     "tooltip": {"type": "boolean", "required": False, "default": DEFAULTS["tooltip"]},
     "update_interval": {"type": "integer", "default": 1000, "min": 0, "max": 60000},
     "timezones": {"type": "list", "default": DEFAULTS["timezones"], "schema": {"type": "string", "required": False}},
+    "icons": {
+        "type": "dict",
+        "required": False,
+        "default": {},
+        "keysrules": {"type": "string", "regex": "^clock_\\d{2}$"},
+        "valuesrules": {"type": "string"},
+    },
     "calendar": {
         "type": "dict",
         "required": False,

--- a/src/core/widgets/yasb/clock.py
+++ b/src/core/widgets/yasb/clock.py
@@ -2,10 +2,11 @@ import locale
 import re
 from datetime import datetime
 from itertools import cycle
+from typing import cast
 
 import pytz
 from PyQt6.QtCore import QDate, QLocale, Qt
-from PyQt6.QtWidgets import QCalendarWidget, QHBoxLayout, QLabel, QSizePolicy, QTableView, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import QCalendarWidget, QHBoxLayout, QLabel, QSizePolicy, QStyle, QTableView, QVBoxLayout, QWidget
 from tzlocal import get_localzone_name
 
 from core.utils.utilities import PopupWidget, add_shadow, build_widget_label
@@ -65,6 +66,7 @@ class ClockWidget(BaseWidget):
         animation: dict[str, str],
         container_padding: dict[str, int],
         callbacks: dict[str, str],
+        icons: dict[str, str] = None,
         label_shadow: dict = None,
         container_shadow: dict = None,
     ):
@@ -83,6 +85,8 @@ class ClockWidget(BaseWidget):
         self._label_alt_content = label_alt
         self._label_shadow = label_shadow
         self._container_shadow = container_shadow
+        self._icons = icons or {}
+        self._current_hour = None
         # Construct container
         self._widget_container_layout: QHBoxLayout = QHBoxLayout()
         self._widget_container_layout.setSpacing(0)
@@ -130,12 +134,31 @@ class ClockWidget(BaseWidget):
             widget.setVisible(self._show_alt_label)
         self._update_label()
 
+    def _get_icon_for_hour(self, hour: int) -> str:
+        key = f"clock_{hour:02d}"
+        icon = self._icons.get(key)
+        if icon is None and 13 <= hour <= 23:
+            fallback_key = f"clock_{hour - 12:02d}"
+            icon = self._icons.get(fallback_key, "")
+        return icon or ""
+    
+    def _reload_css(self, label: QLabel):
+        style = cast(QStyle, label.style())
+        style.unpolish(label)
+        style.polish(label)
+        label.update()
+
     def _update_label(self):
         active_widgets = self._widgets_alt if self._show_alt_label else self._widgets
         active_label_content = self._label_alt_content if self._show_alt_label else self._label_content
         label_parts = re.split("(<span.*?>.*?</span>)", active_label_content)
         label_parts = [part for part in label_parts if part]
         widget_index = 0
+        now = datetime.now(pytz.timezone(self._active_tz))
+        current_hour = f"{now.hour:02d}"
+        hour_changed = (self._current_hour != current_hour)
+        if hour_changed:
+            self._current_hour = current_hour
         if self._locale:
             org_locale_time = locale.getlocale(locale.LC_TIME)
             try:
@@ -146,8 +169,16 @@ class ClockWidget(BaseWidget):
             part = part.strip()
             if part and widget_index < len(active_widgets) and isinstance(active_widgets[widget_index], QLabel):
                 if "<span" in part and "</span>" in part:
-                    icon = re.sub(r"<span.*?>|</span>", "", part).strip()
-                    active_widgets[widget_index].setText(icon)
+                    icon_placeholder = re.sub(r"<span.*?>|</span>", "", part).strip()
+                    if icon_placeholder == "{icon}":
+                        if hour_changed:
+                            icon = self._get_icon_for_hour(now.hour)
+                            active_widgets[widget_index].setText(icon)
+                            hour_class = f"clock_{current_hour}"
+                            active_widgets[widget_index].setProperty("class", f"icon {hour_class}")
+                            self._reload_css(active_widgets[widget_index])
+                    else:
+                        active_widgets[widget_index].setText(icon_placeholder)
                 else:
                     try:
                         if self._locale:
@@ -164,6 +195,10 @@ class ClockWidget(BaseWidget):
                     except Exception:
                         format_label_content = part
                     active_widgets[widget_index].setText(format_label_content)
+                    if hour_changed:
+                        hour_class = f"clock_{current_hour}"
+                        active_widgets[widget_index].setProperty("class", f"label {hour_class}")
+                        self._reload_css(active_widgets[widget_index])
                 widget_index += 1
         if self._locale:
             locale.setlocale(locale.LC_TIME, org_locale_time)


### PR DESCRIPTION
This pull request introduces a new icons option in the YASB ClockWidget configuration. This option enables displaying a different icon (or text) depending on the current hour.

Details:

- Added the icons parameter in the YAML configuration, allowing a dictionary mapping each hour (clock_01, clock_02, …) to a Unicode character or a custom string.
- By default, times after 12:00 that are not explicitly defined in the icons revert to their corresponding icons in the interval clock_01 to clock_11.
- This feature enables richer visual customization of the clock widget, for example to indicate different moods or statuses depending on the hour.
- Documentation has been updated to explain how to use and configure this new option.
- No impact on existing widget functionality.

Thank you for your review and feedback!