### PR TITLE
Added CPU thresholds, RAM Histogram, Disk Thresholds

### DIFF
--- a/docs/widgets/(Widget)-CPU.md
+++ b/docs/widgets/(Widget)-CPU.md
@@ -8,6 +8,7 @@
 | `histogram_icons`     | list    | `['\u2581', '\u2581', '\u2582', '\u2583', '\u2584', '\u2585', '\u2586', '\u2587', '\u2588']` | Icons representing CPU usage histograms.                                    |
 | `histogram_num_columns` | integer | `10`                                                                    | The number of columns in the histogram.                                     |
 | `callbacks`           | dict    | `{'on_left': 'toggle_label', 'on_middle': 'do_nothing', 'on_right': 'do_nothing'}` | Callback functions for different mouse button actions.                      |
+| `cpu_thresholds` | dict  | `{'low': 25, 'medium': 50, 'high': 90}`                                 | Thresholds for Cpu usage levels. |
 | `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
 | `container_padding`  | dict | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}`      | Explicitly set padding inside widget container. |
 | `container_shadow`   | dict   | `None`                  | Container shadow options.                       |
@@ -23,6 +24,10 @@ cpu:
     label: "<span>\uf4bc</span> {info[percent][total]}%"
     label_alt: "<span>\uf437</span> {info[histograms][cpu_percent]}"
     update_interval: 2000
+    cpu_thresholds:
+      low: 25
+      medium: 50
+      high: 90
     histogram_icons:
       - '\u2581' # 0%
       - '\u2581' # 10%
@@ -48,6 +53,7 @@ cpu:
 - **label**: The format string for the CPU usage label. You can use placeholders like `{info[percent][total]}` to dynamically insert CPU information.
 - **label_alt**: The alternative format string for the CPU usage label. Useful for displaying additional CPU details.
 - **update_interval**: The interval in milliseconds at which the widget updates its information. Minimum is 1000 ms (1 second).
+- **cpu_thresholds:** A dictionary specifying the thresholds for cpu usage levels. The keys are `low`, `medium`, and `high`, and the values are the percentage thresholds.
 - **histogram_icons**: A list of icons representing different levels of CPU usage in the histogram. 8 icons are typically used, representing usage from 0% to 80%+.
 - **histogram_num_columns**: The number of columns to display in the CPU usage histogram.
 - **callbacks**: A dictionary specifying the callbacks for mouse events. The keys are `on_left`, `on_middle`, and `on_right`, and the values are the names of the callback functions.
@@ -96,6 +102,10 @@ cpu:
 .cpu-widget .widget-container .label {}
 .cpu-widget .widget-container .label.alt {}
 .cpu-widget .widget-container .icon {}
+.cpu-widget .label.status-low {}
+.cpu-widget .label.status-medium {}
+.cpu-widget .label.status-high {}
+.cpu-widget .label.status-critical {}
 /* CPU progress bar styles if enabled */
 .cpu-widget .progress-circle {} 
 ```

--- a/docs/widgets/(Widget)-Disk.md
+++ b/docs/widgets/(Widget)-Disk.md
@@ -8,6 +8,7 @@
 | `update_interval` | integer | `60`                                                                  | The interval in seconds to update the disk widget. Must be between 0 and 3600. |
 | `group_label` | dict | `{'volume_labels': ["C"], 'show_label_name': True, 'blur': True, 'round_corners': True, 'round_corners_type': 'normal','border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Group labels for multiple disks. This will show the labels of multiple disks in a popup window. |
 | `callbacks`       | dict    | `{'on_left': 'do_nothing', 'on_middle': 'do_nothing', 'on_right': "exec explorer C:\\"}` | Callbacks for mouse events. |
+| `disk_thresholds` | dict  | `{'low': 25, 'medium': 50, 'high': 90}`                                 | Thresholds for Disk usage levels. |
 | `container_padding`  | dict | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}`      | Explicitly set padding inside widget container. |
 | `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
 | `container_shadow`   | dict   | `None`                  | Container shadow options.                       |
@@ -42,6 +43,10 @@ disk:
         color: "black"
         radius: 3
         offset: [ 1, 1 ]
+      disk_thresholds:
+          low: 25
+          medium: 50
+          high: 90
 ```
 
 ## Description of Options
@@ -51,6 +56,7 @@ disk:
 - **volume_label:** Partition/volume which you want to show in the bar.
 - **decimal_display:** The number of decimal to show, defaul 1 (min 0 max 3).
 - **update_interval:** The interval in seconds to update the disk widget. Must be between 0 and 3600.
+- **disk_thresholds:** A dictionary specifying the thresholds for disk usage levels. The keys are `low`, `medium`, and `high`, and the values are the percentage thresholds.
 - **group_label:** Group labels for multiple disks. This will show the labels of multiple disks in a popup window.
   - **volume_labels:** List of volume labels to show in the group label.
   - **show_label_name:** Show the label name in the group label.

--- a/docs/widgets/(Widget)-Memory.md
+++ b/docs/widgets/(Widget)-Memory.md
@@ -5,6 +5,7 @@
 | `label_alt`       | string  | `'\uf4bc VIRT: {virtual_mem_percent}% SWAP: {swap_mem_percent}%'`        | The alternative format string for the memory widget. Displays virtual and swap memory percentages. |
 | `update_interval` | integer | `5000`                                                                  | The interval in milliseconds to update the memory widget. Must be between 0 and 60000. |
 | `callbacks`       | dict    | `{'on_left': 'toggle_label', 'on_middle': 'do_nothing', 'on_right': 'do_nothing'}` | Callbacks for mouse events on the memory widget. |
+| `histogram_icons`     | list    | `['\u2581', '\u2581', '\u2582', '\u2583', '\u2584', '\u2585', '\u2586', '\u2587', '\u2588']` | Icons representing RAM usage histograms.                                    |
 | `memory_thresholds` | dict  | `{'low': 25, 'medium': 50, 'high': 90}`                                 | Thresholds for memory usage levels. |
 | `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
 | `container_padding`  | dict | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}`      | Explicitly set padding inside widget container.                            |
@@ -29,6 +30,16 @@ memory:
       low: 25
       medium: 50
       high: 90
+    histogram_icons:
+      - '\u2581' # 0%
+      - '\u2581' # 10%
+      - '\u2582' # 20%
+      - '\u2583' # 30%
+      - '\u2584' # 40%
+      - '\u2585' # 50%
+      - '\u2586' # 60%
+      - '\u2587' # 70%
+      - '\u2588' # 80%+
     label_shadow:
       enabled: true
       color: "black"
@@ -43,6 +54,7 @@ memory:
 - **update_interval:** The interval in milliseconds to update the memory widget. Must be between 0 and 60000.
 - **callbacks:** A dictionary specifying the callbacks for mouse events. The keys are `on_left`, `on_middle`, and `on_right`, and the values are the names of the callback functions.
 - **memory_thresholds:** A dictionary specifying the thresholds for memory usage levels. The keys are `low`, `medium`, and `high`, and the values are the percentage thresholds.
+- **histogram_icons**: A list of icons representing different levels of Memory usage in the histogram. 8 icons are typically used, representing usage from 0% to 80%+ cam be used by puttinh `{histogram}` in label.
 - **animation:** A dictionary specifying the animation settings for the widget. It contains three keys: `enabled`, `type`, and `duration`. The `type` can be `fadeInOut` and the `duration` is the animation duration in milliseconds.
 - **container_padding**: Explicitly set padding inside widget container. Use this option to set padding inside the widget container. You can set padding for top, left, bottom and right sides of the widget container.
 - **container_shadow:** Container shadow options.

--- a/src/core/validation/widgets/yasb/cpu.py
+++ b/src/core/validation/widgets/yasb/cpu.py
@@ -7,6 +7,11 @@ DEFAULTS = {
     "animation": {"enabled": True, "type": "fadeInOut", "duration": 200},
     "container_padding": {"top": 0, "left": 0, "bottom": 0, "right": 0},
     "callbacks": {"on_left": "toggle_label", "on_middle": "do_nothing", "on_right": "do_nothing"},
+    "cpu_thresholds": {
+        "low": 25,
+        "medium": 50,
+        "high": 90,
+    },
 }
 
 VALIDATION_SCHEMA = {
@@ -97,5 +102,15 @@ VALIDATION_SCHEMA = {
             },
         },
         "default": DEFAULTS["callbacks"],
+    },
+    "cpu_thresholds": {
+        "type": "dict",
+        "required": False,
+        "schema": {
+            "low": {"type": "integer", "default": DEFAULTS["cpu_thresholds"]["low"], "min": 0, "max": 100},
+            "medium": {"type": "integer", "default": DEFAULTS["cpu_thresholds"]["medium"], "min": 0, "max": 100},
+            "high": {"type": "integer", "default": DEFAULTS["cpu_thresholds"]["high"], "min": 0, "max": 100},
+        },
+        "default": DEFAULTS["cpu_thresholds"],
     },
 }

--- a/src/core/validation/widgets/yasb/disk.py
+++ b/src/core/validation/widgets/yasb/disk.py
@@ -20,6 +20,11 @@ DEFAULTS = {
     "animation": {"enabled": True, "type": "fadeInOut", "duration": 200},
     "container_padding": {"top": 0, "left": 0, "bottom": 0, "right": 0},
     "callbacks": {"on_left": "toggle_label", "on_middle": "do_nothing", "on_right": "do_nothing"},
+    "disk_thresholds": {
+        "low": 25,
+        "medium": 50,
+        "high": 90,
+    },
 }
 
 VALIDATION_SCHEMA = {
@@ -127,4 +132,14 @@ VALIDATION_SCHEMA = {
         },
         "default": DEFAULTS["callbacks"],
     },
+    "disk_thresholds": {
+        "type": "dict",
+        "required": False,
+        "schema": {
+            "low": {"type": "integer", "default": DEFAULTS["disk_thresholds"]["low"], "min": 0, "max": 100},
+            "medium": {"type": "integer", "default": DEFAULTS["disk_thresholds"]["medium"], "min": 0, "max": 100},
+            "high": {"type": "integer", "default": DEFAULTS["disk_thresholds"]["high"], "min": 0, "max": 100},
+        },
+        "default": DEFAULTS["disk_thresholds"],
+    }
 }

--- a/src/core/validation/widgets/yasb/memory.py
+++ b/src/core/validation/widgets/yasb/memory.py
@@ -2,6 +2,7 @@ DEFAULTS = {
     "label": "\uf4bc {virtual_mem_free}/{virtual_mem_total}",
     "label_alt": "\uf4bc VIRT: {virtual_mem_percent}% SWAP: {swap_mem_percent}%",
     "update_interval": 5000,
+    "histogram_icons": ["\u2581", "\u2581", "\u2582", "\u2583", "\u2584", "\u2585", "\u2586", "\u2587", "\u2588"],
     "animation": {"enabled": True, "type": "fadeInOut", "duration": 200},
     "container_padding": {"top": 0, "left": 0, "bottom": 0, "right": 0},
     "callbacks": {"on_left": "toggle_label", "on_middle": "do_nothing", "on_right": "do_nothing"},
@@ -16,6 +17,14 @@ VALIDATION_SCHEMA = {
     "label": {"type": "string", "default": DEFAULTS["label"]},
     "label_alt": {"type": "string", "default": DEFAULTS["label_alt"]},
     "update_interval": {"type": "integer", "default": DEFAULTS["update_interval"], "min": 1000, "max": 60000},
+    "histogram_icons": {
+        "type": "list",
+        "required": False,
+        "default": DEFAULTS["histogram_icons"],
+        "minlength": 9,
+        "maxlength": 9,
+        "schema": {"type": "string"},
+    },
     "memory_thresholds": {
         "type": "dict",
         "required": False,

--- a/src/core/widgets/yasb/cpu.py
+++ b/src/core/widgets/yasb/cpu.py
@@ -29,6 +29,7 @@ class CpuWidget(BaseWidget):
         animation: dict[str, str],
         container_padding: dict[str, int],
         callbacks: dict[str, str],
+        cpu_thresholds: dict[str, int],
         label_shadow: dict = None,
         container_shadow: dict = None,
         progress_bar: dict = None,
@@ -44,6 +45,7 @@ class CpuWidget(BaseWidget):
         self._padding = container_padding
         self._label_shadow = label_shadow
         self._container_shadow = container_shadow
+        self._cpu_thresholds = cpu_thresholds
         self._progress_bar = progress_bar
 
         self.progress_widget = None
@@ -161,6 +163,9 @@ class CpuWidget(BaseWidget):
                     formatted_text = part.format(info=cpu_info)
                     active_widgets[widget_index].setText(formatted_text)
                     active_widgets[widget_index].setProperty("class", label_class)
+                    active_widgets[widget_index].setProperty(
+                        "class", f"{label_class} status-{self._get_cpu_threshold(current_perc)}"
+                    )
                     active_widgets[widget_index].setStyleSheet("")
                 widget_index += 1
 
@@ -180,3 +185,13 @@ class CpuWidget(BaseWidget):
         bar_index = int((num - num_min) / (num_max - num_min) * (len(self._histogram_icons) - 1))
         bar_index = min(max(bar_index, 0), len(self._histogram_icons) - 1)
         return self._histogram_icons[bar_index]
+
+    def _get_cpu_threshold(self, cpu_percent) -> str:
+        if cpu_percent <= self._cpu_thresholds["low"]:
+            return "low"
+        elif self._cpu_thresholds["low"] < cpu_percent <= self._cpu_thresholds["medium"]:
+            return "medium"
+        elif self._cpu_thresholds["medium"] < cpu_percent <= self._cpu_thresholds["high"]:
+            return "high"
+        elif self._cpu_thresholds["high"] < cpu_percent:
+            return "critical"

--- a/src/core/widgets/yasb/memory.py
+++ b/src/core/widgets/yasb/memory.py
@@ -23,6 +23,7 @@ class MemoryWidget(BaseWidget):
         label: str,
         label_alt: str,
         update_interval: int,
+        histogram_icons: list[str],
         animation: dict[str, str],
         callbacks: dict[str, str],
         memory_thresholds: dict[str, int],
@@ -33,6 +34,7 @@ class MemoryWidget(BaseWidget):
     ):
         super().__init__(class_name="memory-widget")
         self._memory_thresholds = memory_thresholds
+        self._histogram_icons = histogram_icons
         self._show_alt_label = False
         self._label_content = label
         self._label_alt_content = label_alt
@@ -117,6 +119,9 @@ class MemoryWidget(BaseWidget):
             "{swap_mem_free}": naturalsize(swap_mem.free, True, True),
             "{swap_mem_percent}": swap_mem.percent,
             "{swap_mem_total}": naturalsize(swap_mem.total, True, True),
+            "{histogram}": "".join([self._get_histogram_bar(virtual_mem.percent, 0, 100)])
+                .encode("utf-8")
+                .decode("unicode_escape")
         }
 
         if self._progress_bar["enabled"] and self.progress_widget:
@@ -165,3 +170,9 @@ class MemoryWidget(BaseWidget):
             return "high"
         elif self._memory_thresholds["high"] < virtual_memory_percent:
             return "critical"
+    def _get_histogram_bar(self, num, num_min, num_max):
+        if num_max == num_min:
+            return self._histogram_icons[0]
+        bar_index = int((num - num_min) / (num_max - num_min) * (len(self._histogram_icons) - 1))
+        bar_index = min(max(bar_index, 0), len(self._histogram_icons) - 1)
+        return self._histogram_icons[bar_index]


### PR DESCRIPTION
- **Added CPU thresholds**
	- The CPU widget can now be programmed to change color based upon percentage used just like RAM
- **Added RAM Histogram icons**
	- The RAM Widget can now have histogram icons like the CPU allowing support for Ascii Progress bars
- **Added Disk Thresholds**
	- Disk Widget can now be programmed to change color based upon percentage used just like RAM
	
Changes Demo
<img width="687" height="43" alt="image" src="https://github.com/user-attachments/assets/18602979-a739-4bef-9fcb-938f825ac61d" />
