### PR TITLE
Add possibility to hide the systray icon with 'show_systray'

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -49,6 +49,7 @@ Valid options are:
 | `watch_config`         | boolean    | `true`        | Reload bar when config is changed. |
 | `debug`      | boolean  | `false`   | Enable debug mode to see more logs |
 | `update_check`      | boolean  | `true`   | Enable automatic update check. This works only if the application is installed. |
+| `show_systray`      | boolean  | `true`   | Enable the YASB systray icon. |
 
 
 ## Komorebi settings for tray menu

--- a/src/core/validation/config.py
+++ b/src/core/validation/config.py
@@ -47,9 +47,9 @@ CONFIG_SCHEMA = {
         },
     },
     "show_systray": {
-    "type": "boolean",
-    "default": True,
-    "required": False,
+        "type": "boolean",
+        "default": True,
+        "required": False,
     },
     "bars": {
         "type": "dict",

--- a/src/core/validation/config.py
+++ b/src/core/validation/config.py
@@ -46,6 +46,11 @@ CONFIG_SCHEMA = {
             "reload_command": "komorebic reload-configuration",
         },
     },
+    "show_systray": {
+    "type": "boolean",
+    "default": True,
+    "required": False,
+    },
     "bars": {
         "type": "dict",
         "keysrules": {"type": "string"},

--- a/src/main.py
+++ b/src/main.py
@@ -75,8 +75,9 @@ def main():
     app.aboutToQuit.connect(stop_observer)
 
     # Build system tray icon
-    tray_manager = SystemTrayManager(manager)
-    tray_manager.show()
+    if config.get("show_systray", True):
+        tray_manager = SystemTrayManager(manager)
+        tray_manager.show()
 
     # Initialize auto update service
     if config["update_check"] and getattr(sys, "frozen", False):


### PR DESCRIPTION
Let user define a parameter "show_systray"
The goal is to remove the YASB systray icon when the parameter is set to False

show_systray is True by default