### PR TITLE
fix(weather): added hourly "now" line min length (>10px)

### DIFF
--- a/src/core/utils/widgets/weather/widgets.py
+++ b/src/core/utils/widgets/weather/widgets.py
@@ -340,10 +340,12 @@ class HourlyTemperatureLineWidget(QFrame):
                     line_from = temp_rect.height() + 10
                 line_to = height - text_wind_icon_height - 10
 
-                painter.drawLine(
-                    int(line_x),
-                    int(line_from),
-                    int(line_x),
-                    int(line_to),
-                )
+                # Only draw the line if it's not too short
+                if (line_to - line_from) > 10:
+                    painter.drawLine(
+                        int(line_x),
+                        int(line_from),
+                        int(line_x),
+                        int(line_to),
+                    )
         painter.end()


### PR DESCRIPTION
Hourly `Now` indicator line will have minimum length of 11 pixels. Avoids drawing very short dot-like line.

<img width="84" height="87" alt="image" src="https://github.com/user-attachments/assets/09094668-39a4-4fda-9b97-724dbc9900bb" />
