### PR TITLE
fix(volume): handle mute status on absent audio device

### DIFF
--- a/src/core/widgets/yasb/volume.py
+++ b/src/core/widgets/yasb/volume.py
@@ -437,7 +437,7 @@ class VolumeWidget(BaseWidget):
                 self._mute_text if mute_status == 1 else f"{round(self.volume.GetMasterVolumeLevelScalar() * 100)}%"
             )
         except Exception:
-            icon_volume, level_volume = "", "No Device"
+            mute_status, icon_volume, level_volume = None, "", "No Device"
 
         label_options = {"{icon}": icon_volume, "{level}": level_volume}
 


### PR DESCRIPTION
Currently, the app can crash where no audio device is present. This also displays the "No Device" text again on missing audio device.

Commit with earlier fix:
https://github.com/amnweb/yasb/commit/da7d991255bf6fea2d9d6b4ba68f1f0399308d10 

Commit introducing the bug:
https://github.com/amnweb/yasb/commit/e8aa0581306938d95d28a4b8236c1d3fbc4c606d

Logs from crashes I have been having:
```
...
2025-08-10 21:42:22,933 [INFO] [MainThread] [root/log.py:59]: YASB v1.7.9
2025-08-10 21:42:22,934 [INFO] [Thread-1 (_run_server)] [cli_server/cli_server.py:212]: CLI server started v1.1.2
2025-08-10 21:42:22,934 [INFO] [MainThread] [cli_server/cli_server.py:104]: Log pipe server started
2025-08-10 21:42:23,084 [DEBUG] [MainThread] [comtypes/__init__.py:149]: CoInitializeEx(None, 2)
2025-08-10 21:42:23,472 [DEBUG] [MainThread] [tzlocal/win32.py:55]: Looking up time zone info from registry
2025-08-10 21:42:24,634 [INFO] [MainThread] [root/bar_manager.py:74]: Starting WindowsNotificationEventListener...
2025-08-10 21:42:24,635 [INFO] [MainThread] [root/watcher.py:54]: Created file watcher for path C:\Users\fero1\.config\yasb
2025-08-10 21:42:24,653 [DEBUG] [MainThread] [qasync._windows._EventPoller/_windows.py:213]: Starting (proactor: <_IocpProactor overlapped#=0 result#=0>)...
2025-08-10 21:42:24,653 [DEBUG] [Dummy-6] [qasync._windows._EventWorker/_windows.py:192]: Thread started
2025-08-10 21:48:14,661 [DEBUG] [MainThread] [qasync._windows._EventPoller/_windows.py:218]: Stopping worker thread...
2025-08-10 22:00:34,142 [INFO] [MainThread] [root/log.py:59]: YASB v1.7.9
2025-08-10 22:00:34,142 [INFO] [Thread-1 (_run_server)] [cli_server/cli_server.py:212]: CLI server started v1.1.2
2025-08-10 22:00:34,142 [INFO] [MainThread] [cli_server/cli_server.py:104]: Log pipe server started
2025-08-10 22:00:34,264 [DEBUG] [MainThread] [comtypes/__init__.py:149]: CoInitializeEx(None, 2)
2025-08-10 22:00:34,604 [DEBUG] [MainThread] [tzlocal/win32.py:55]: Looking up time zone info from registry
2025-08-10 22:00:35,373 [INFO] [MainThread] [root/bar_manager.py:74]: Starting WindowsNotificationEventListener...
2025-08-10 22:00:35,373 [INFO] [MainThread] [root/watcher.py:54]: Created file watcher for path C:\Users\fero1\.config\yasb
2025-08-10 22:00:35,388 [DEBUG] [MainThread] [qasync._windows._EventPoller/_windows.py:213]: Starting (proactor: <_IocpProactor overlapped#=0 result#=0>)...
2025-08-10 22:00:35,392 [DEBUG] [Dummy-6] [qasync._windows._EventWorker/_windows.py:192]: Thread started
2025-08-10 22:13:44,610 [DEBUG] [MainThread] [qasync._windows._EventPoller/_windows.py:218]: Stopping worker thread...
2025-08-10 22:13:44,622 [DEBUG] [Dummy-6] [qasync._windows._EventWorker/_windows.py:201]: Exiting thread
2025-08-10 22:13:44,622 [DEBUG] [MainThread] [qasync._windows._IocpProactor/_windows.py:75]: Closing
2025-08-11 18:32:40,210 [INFO] [MainThread] [root/log.py:59]: YASB v1.7.9
2025-08-11 18:32:40,210 [INFO] [Thread-1 (_run_server)] [cli_server/cli_server.py:212]: CLI server started v1.1.2
2025-08-11 18:32:40,210 [INFO] [MainThread] [cli_server/cli_server.py:104]: Log pipe server started
2025-08-11 18:32:40,265 [DEBUG] [MainThread] [comtypes/__init__.py:149]: CoInitializeEx(None, 2)
2025-08-11 18:32:40,368 [DEBUG] [MainThread] [tzlocal/win32.py:55]: Looking up time zone info from registry
2025-08-11 18:32:40,622 [INFO] [MainThread] [root/bar_manager.py:74]: Starting WindowsNotificationEventListener...
2025-08-11 18:32:40,625 [INFO] [MainThread] [root/watcher.py:54]: Created file watcher for path C:\Users\fero1\.config\yasb
2025-08-11 18:32:40,642 [DEBUG] [MainThread] [qasync._windows._EventPoller/_windows.py:213]: Starting (proactor: <_IocpProactor overlapped#=0 result#=0>)...
2025-08-11 18:32:40,642 [DEBUG] [Dummy-6] [qasync._windows._EventWorker/_windows.py:192]: Thread started
2025-08-11 19:34:28,666 [ERROR] [MainThread] [root/volume.py:559]: Failed to initialize volume interface: (-2147023728, 'Element not found.', (None, None, None, 0, None))
2025-08-11 19:34:28,668 [ERROR] [MainThread] [root/main.py:101]: Unhandled exception
Traceback (most recent call last):
  File "D:\a\yasb\yasb\src\core\widgets\yasb\volume.py", line 462, in _update_label
UnboundLocalError: cannot access local variable 'mute_status' where it is not associated with a value
2025-08-11 20:58:07,275 [INFO] [MainThread] [root/log.py:59]: YASB v1.7.9
2025-08-11 20:58:07,276 [INFO] [Thread-1 (_run_server)] [cli_server/cli_server.py:212]: CLI server started v1.1.2
2025-08-11 20:58:07,276 [INFO] [MainThread] [cli_server/cli_server.py:104]: Log pipe server started
2025-08-11 20:58:07,419 [DEBUG] [MainThread] [comtypes/__init__.py:149]: CoInitializeEx(None, 2)
2025-08-11 20:58:07,808 [DEBUG] [MainThread] [tzlocal/win32.py:55]: Looking up time zone info from registry
2025-08-11 20:58:09,012 [INFO] [MainThread] [root/bar_manager.py:74]: Starting WindowsNotificationEventListener...
2025-08-11 20:58:09,013 [INFO] [MainThread] [root/watcher.py:54]: Created file watcher for path C:\Users\fero1\.config\yasb
2025-08-11 20:58:09,031 [DEBUG] [MainThread] [qasync._windows._EventPoller/_windows.py:213]: Starting (proactor: <_IocpProactor overlapped#=0 result#=0>)...
2025-08-11 20:58:09,031 [DEBUG] [Dummy-6] [qasync._windows._EventWorker/_windows.py:192]: Thread started
2025-08-11 21:16:54,237 [ERROR] [MainThread] [root/volume.py:559]: Failed to initialize volume interface: (-2147023728, 'Element not found.', (None, None, None, 0, None))
2025-08-11 21:16:54,238 [ERROR] [MainThread] [root/main.py:101]: Unhandled exception
Traceback (most recent call last):
  File "D:\a\yasb\yasb\src\core\widgets\yasb\volume.py", line 462, in _update_label
UnboundLocalError: cannot access local variable 'mute_status' where it is not associated with a value
2025-08-12 19:00:33,350 [INFO] [MainThread] [root/log.py:59]: YASB v1.7.9
2025-08-12 19:00:33,350 [INFO] [Thread-1 (_run_server)] [cli_server/cli_server.py:212]: CLI server started v1.1.2
2025-08-12 19:00:33,350 [INFO] [MainThread] [cli_server/cli_server.py:104]: Log pipe server started
2025-08-12 19:00:33,404 [DEBUG] [MainThread] [comtypes/__init__.py:149]: CoInitializeEx(None, 2)
...
```