### PR TITLE
Fix typo in custom widget label placeholder option

### DIFF
--- a/src/core/validation/widgets/yasb/custom.py
+++ b/src/core/validation/widgets/yasb/custom.py
@@ -1,5 +1,5 @@
 DEFAULTS = {
-    "lable_placeholder": "Loading...",
+    "label_placeholder": "Loading...",
     "label_max_length": None,
     "exec_options": {
         "run_cmd": None,
@@ -27,7 +27,7 @@ VALIDATION_SCHEMA = {
     },
     "label": {"type": "string", "required": True},
     "label_alt": {"type": "string", "default": True},
-    "lable_placeholder": {"type": "string", "required": False, "default": DEFAULTS["lable_placeholder"]},
+    "label_placeholder": {"type": "string", "required": False, "default": DEFAULTS["label_placeholder"]},
     "label_max_length": {"type": "integer", "nullable": True, "default": DEFAULTS["label_max_length"], "min": 1},
     "exec_options": {
         "type": "dict",

--- a/src/core/widgets/yasb/custom.py
+++ b/src/core/widgets/yasb/custom.py
@@ -55,7 +55,7 @@ class CustomWidget(BaseWidget):
         self,
         label: str,
         label_alt: str,
-        lable_placeholder: str,
+        label_placeholder: str,
         label_max_length: int,
         exec_options: dict,
         callbacks: dict,
@@ -76,7 +76,7 @@ class CustomWidget(BaseWidget):
         self._show_alt_label = False
         self._label_content = label
         self._label_alt_content = label_alt
-        self._lable_placeholder = lable_placeholder
+        self._label_placeholder = label_placeholder
         self._animation = animation
         self._padding = container_padding
         self._label_shadow = label_shadow
@@ -141,7 +141,7 @@ class CustomWidget(BaseWidget):
                 else:
                     label = QLabel(part)
                     label.setProperty("class", "label alt" if is_alt else "label")
-                    label.setText(self._lable_placeholder)
+                    label.setText(self._label_placeholder)
                 label.setAlignment(Qt.AlignmentFlag.AlignCenter)
                 self._set_cursor(label)
                 add_shadow(label, self._label_shadow)


### PR DESCRIPTION
This change corrects the typo in the custom widget label placeholder option from "lable_placeholder" to "label_placeholder".

It's a minor issue and the typo doesn't exist in the docs, but a fix is a fix :)