### PR TITLE
fix(GlazeWM): fix monitor name check for windows 10

### DIFF
--- a/src/core/utils/widgets/glazewm/client.py
+++ b/src/core/utils/widgets/glazewm/client.py
@@ -173,15 +173,11 @@ class GlazewmClient(QObject):
         for mon in data:
             monitor_name: str | None = mon.get("hardwareId")
             handle: int | None = mon.get("handle")
-            if monitor_name is None or handle is None:
-                logger.warning(f"Monitor name or hwnd not found | name: {monitor_name}, handle: {handle}")
-                continue
-            if not monitor_name:
-                monitor_name = f"Unknown ({handle})"
-                logger.warning(f"Monitor name not found. Replacing with {monitor_name}")
             if not handle:
                 logger.warning("Monitor handle not found")
                 continue
+            if not monitor_name:
+                monitor_name = f"Unknown_{handle}"
             workspaces_data = [
                 Workspace(
                     name=child.get("name", ""),


### PR DESCRIPTION
Potential fix for Windows 10 GlazeWM issue where it was not sending the monitor's name properly.
Could not repro this on my Windows 10 VM though. YASB v1.8.2 worked perfectly fine with GlazeWM v3.9.1.

- If monitor name is missing, use the default placeholder instead.
- Remove warning from monitor name check.
- Fail early if monitor hwnd is not sent by GlazeWM.