### PR TITLE
fix no shared timer in wallpaper widget #464

### DIFF
--- a/src/core/widgets/yasb/wallpapers.py
+++ b/src/core/widgets/yasb/wallpapers.py
@@ -33,7 +33,8 @@ class WallpapersWidget(BaseWidget):
 
     user32 = ctypes.windll.user32
     validation_schema = VALIDATION_SCHEMA
-    _timer_running = False
+    # Shared state for all Wallpaper instances
+    _shared_timer_running = False
 
     def __init__(
         self,
@@ -124,11 +125,11 @@ class WallpapersWidget(BaseWidget):
 
     def start_timer(self):
         """Start the timer for automatic wallpaper changes."""
-        if not self._timer_running:
+        if not WallpapersWidget._shared_timer_running:
             if self.timer_interval and self.timer_interval > 0:
                 self.timer.timeout.connect(self._timer_callback)
                 self.timer.start(self.timer_interval)
-                self._timer_running = True
+                WallpapersWidget._shared_timer_running = True
 
     def _create_dynamically_label(self, content: str):
         """Create labels dynamically based on the provided content."""


### PR DESCRIPTION
Made the timer shared across all instances of the wallpaper widget.
Fixed the bug by making _timer_running a shared state. I checked how it was done in the Pomodoro Widget to implement the fix.

Only the boolean is shared, not the timer itself, since there’s no need for more. The timer value isn’t shown to the user.

First contribution 😄