### PR TITLE
feat(taskbar): add option to hide taskbar widget when empty

### DIFF
--- a/docs/widgets/(Widget)-Taskbar.md
+++ b/docs/widgets/(Widget)-Taskbar.md
@@ -8,6 +8,7 @@
 | `tooltip`  | boolean  | `True`        | Whether to show the tooltip on hover. |
 | `title_label`       | dict    | `{'enabled': False, 'show': 'focused', 'min_length': 10, 'max_length': 30}`                     | Title label configuration for displaying window titles.                     |
 | `monitor_exclusive` | boolean | `False` | Whether the application should be exclusive to the monitor. |
+| `hide_empty`        | boolean | `False` | Whether to hide the taskbar widget when there are no applications to display. |
 | `callbacks`         | dict    | `{'on_left': 'toggle_window', 'on_middle': 'do_nothing', 'on_right': 'close_app'}` | Callbacks for mouse events on the widget.                                   |
 | `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
 | `preview`           | dict    | `{'enabled': False, 'width': 240, 'delay': 400, 'padding': 8, 'margin': 8}` | Configuration for window preview thumbnails.                                |
@@ -58,6 +59,7 @@ taskbar:
   - processes: A list of process names to ignore.
   - titles: A list of window titles to ignore.
   - classes: A list of window classes to ignore.
+- **hide_empty:** A boolean indicating whether to hide the taskbar widget when there are no applications to display. If set to `True`, the taskbar will automatically hide itself when there are no open applications that meet the filtering criteria.
 - **callbacks:** A dictionary specifying the callbacks for mouse events. The keys are `on_left`, `on_middle`, and `on_right`, and the values are the names of the callback functions, which can be `toggle_window`, `do_nothing`, or `close_app`.
 - **animation:** A dictionary specifying the animation settings for the widget. It contains three keys: `enabled`, `type`, and `duration`. The `type` can be `fadeInOut` and the `duration` is the animation duration in milliseconds. When animation is enabled, it will be used both for click effects and for animating the addition or removal of applications in the taskbar (such as when apps are opened or closed).
 - **preview:** A dictionary specifying the configuration for window preview thumbnails. It includes:

--- a/src/core/validation/widgets/yasb/taskbar.py
+++ b/src/core/validation/widgets/yasb/taskbar.py
@@ -7,6 +7,7 @@ DEFAULTS = {
     "ignore_apps": {"classes": [], "processes": [], "titles": []},
     "animation": {"enabled": True, "type": "fadeInOut", "duration": 200},
     "title_label": {"enabled": False, "show": "focused", "min_length": 10, "max_length": 30},
+    "hide_empty": False,
     "container_padding": {"top": 0, "left": 0, "bottom": 0, "right": 0},
     "preview": {"enabled": False, "width": 240, "delay": 400, "padding": 8, "margin": 8},
     "callbacks": {"on_left": "toggle_window", "on_middle": "do_nothing", "on_right": "do_nothing"},
@@ -55,6 +56,7 @@ VALIDATION_SCHEMA = {
         },
         "default": DEFAULTS["animation"],
     },
+    "hide_empty": {"type": "boolean", "required": False, "default": DEFAULTS["hide_empty"]},
     "container_padding": {"type": "dict", "default": DEFAULTS["container_padding"], "required": False},
     "label_shadow": {
         "type": "dict",


### PR DESCRIPTION
- Introduced `hide_empty` boolean option to control visibility of the taskbar widget when no applications are displayed.