### PR TITLE
feat(widget): add option for label at center of progress bar 

### DIFF
--- a/docs/widgets/(Widget)-Brightness.md
+++ b/docs/widgets/(Widget)-Brightness.md
@@ -20,7 +20,7 @@
 | `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
 | `container_shadow`   | dict   | `None`                  | Container shadow options.                       |
 | `label_shadow`         | dict   | `None`                  | Label shadow options.                 |
-| `progress_bar`       | dict    | `{'enabled': False, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', animation: True}` | Progress bar settings.    |
+| `progress_bar`       | dict    | `{'enabled': False, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', animation: True, 'center_label': ''}` | Progress bar settings.    |
 ## Example Configuration
 
 ```yaml
@@ -95,6 +95,7 @@
   - **color**: The color of the progress bar. Color can be single color or gradient. For example, `color: "#57948a"` or `color: ["#57948a", "#ff0000"]"` for a gradient.
   - **background_color**: The background color of the progress bar.
   - **animation**: Whether to enable smooth change of the progress bar value.
+  - **center_label**: The label that will be centered inside the progress bar (can be styled using `.progress-circle`)
 
 ## Example Style
 ```css
@@ -102,6 +103,7 @@
 .brightness-widget .widget-container {}
 .brightness-widget .widget-container .label {}
 .brightness-widget .widget-container .icon {}
+.brightness-widget .progress-circle {}
 ```
 
 ## Style for the brightness menu

--- a/docs/widgets/(Widget)-CPU.md
+++ b/docs/widgets/(Widget)-CPU.md
@@ -13,7 +13,7 @@
 | `animation`         | dict    | `{'enabled': true, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
 | `container_shadow`   | dict   | `None`                  | Container shadow options.                       |
 | `label_shadow`         | dict   | `None`                  | Label shadow options.                 |
-| `progress_bar`       | dict    | `{'enabled': false, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': false}` | Progress bar settings.                                                      |
+| `progress_bar`       | dict    | `{'enabled': false, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': false, 'center_label': ''}` | Progress bar settings.                                                      |
 | `hide_decimal`       | bool    | `false`                                                                 | Whether to hide decimal places in the CPU widget.                          |
 
 ## Example Configuration
@@ -71,6 +71,7 @@ cpu:
   - **color**: The color of the progress bar. Color can be single color or gradient. For example, `color: "#57948a"` or `color: ["#57948a", "#ff0000"]"` for a gradient.
   - **background_color**: The background color of the progress bar.
   - **animation**: Whether to enable smooth change of the progress bar value.
+  - **center_label**: The label that will be centered inside the progress bar (can be styled using `.progress-circle`)
 
 ## Available Placeholders
 

--- a/docs/widgets/(Widget)-Disk.md
+++ b/docs/widgets/(Widget)-Disk.md
@@ -13,7 +13,7 @@
 | `animation`         | dict    | `{'enabled': true, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
 | `container_shadow`   | dict   | `None`                  | Container shadow options.                       |
 | `label_shadow`         | dict   | `None`                  | Label shadow options.                 |
-| `progress_bar`       | dict    | `{'enabled': false, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': false}` | Progress bar settings.    |
+| `progress_bar`       | dict    | `{'enabled': false, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': false, 'center_label': ''}` | Progress bar settings.    |
 
 ## Example Configuration
 
@@ -81,6 +81,7 @@ disk:
   - **color**: The color of the progress bar. Color can be single color or gradient. For example, `color: "#57948a"` or `color: ["#57948a", "#ff0000"]"` for a gradient.
   - **background_color**: The background color of the progress bar.
   - **animation**: Whether to enable smooth change of the progress bar value.
+  - **center_label**: The label that will be centered inside the progress bar (can be styled using `.progress-circle`)
 
 ## Widget Style
 ```css

--- a/docs/widgets/(Widget)-GPU.md
+++ b/docs/widgets/(Widget)-GPU.md
@@ -27,7 +27,7 @@ If you see a table with your GPU information, `nvidia-smi` is available. If you 
 | `animation`           | dict    | `{'enabled': true, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
 | `container_shadow`    | dict    | `{"enabled": False, "color": "black", "offset": [1, 1], "radius": 3}`                                                                  | Container shadow options.                                                   |
 | `label_shadow`        | dict    | `{"enabled": False, "color": "black", "offset": [1, 1], "radius": 3}`                                                                  | Label shadow options.                                                       |
-| `progress_bar`        | dict    | `{'enabled': false, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': false}` | Progress bar settings.                                                      |
+| `progress_bar`        | dict    | `{'enabled': false, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': false, 'center_label': ''}` | Progress bar settings.                                                      |
 | `hide_decimal`        | bool    | `false`                                                                 | Whether to hide decimal places in the GPU widget.                          |
 
 > **About `index`:** If you have multiple NVIDIA GPUs, you can set the `gpu_index` option to select which GPU to monitor. Create multiple GPU widgets with different `gpu_index` values (e.g., 0, 1, 2, ...) to display stats for each card separately.
@@ -82,6 +82,7 @@ gpu:
   - **color**: The color of the progress bar. Color can be single color or gradient.
   - **background_color**: The background color of the progress bar.
   - **animation**: Whether to enable smooth change of the progress bar value.
+  - **center_label**: The label that will be centered inside the progress bar (can be styled using `.progress-circle`)
 
 ## Available Placeholders
 

--- a/docs/widgets/(Widget)-Memory.md
+++ b/docs/widgets/(Widget)-Memory.md
@@ -11,7 +11,7 @@
 | `animation`         | dict    | `{'enabled': true, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
 | `container_shadow`   | dict   | `None`                  | Container shadow options.                       |
 | `label_shadow`         | dict   | `None`                  | Label shadow options.                 |
-| `progress_bar`       | dict    | `{'enabled': False, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': True}` | Progress bar settings.    |
+| `progress_bar`       | dict    | `{'enabled': False, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': True, 'center_label': ''}` | Progress bar settings.    |
 | `hide_decimal`       | boolean    | `false`                                                                 | Whether to hide decimal places in the memory widget. |
 
 ## Example Configuration
@@ -69,6 +69,7 @@ memory:
   - **color**: The color of the progress bar. Color can be single color or gradient. For example, `color: "#57948a"` or `color: ["#57948a", "#ff0000"]"` for a gradient.
   - **background_color**: The background color of the progress bar.
   - **animation**: Whether to enable smooth change of the progress bar value.
+  - **center_label**: The label that will be centered inside the progress bar (can be styled using `.progress-circle`)
 
 The `label` and `label_alt` options use format strings that can include placeholders for memory metrics. These placeholders will be replaced with actual values when the widget is rendered. You can use `{virtual_mem_free}`, `{virtual_mem_percent}`, `{virtual_mem_total}`, `{virtual_mem_avail}`, `{virtual_mem_used}`, `{virtual_mem_outof}`, `{swap_mem_free}`, `{swap_mem_percent}`, `{swap_mem_total}`
 

--- a/docs/widgets/(Widget)-Microphone.md
+++ b/docs/widgets/(Widget)-Microphone.md
@@ -14,7 +14,7 @@
 | `container_shadow`   | dict   | `None`                  | Container shadow options.                       |
 | `label_shadow`         | dict   | `None`                  | Label shadow options.                 |
 | `mic_menu` | dict | `{'blur': True, 'round_corners': True, 'round_corners_type': 'normal', 'border_color': 'system', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Menu settings for the widget. |
-| `progress_bar`       | dict    | `{'enabled': False, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', animation: True}` | Progress bar settings.    |
+| `progress_bar`       | dict    | `{'enabled': False, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', animation: True, 'center_label': ''}` | Progress bar settings.    |
 
 
 ## Example Configuration
@@ -76,6 +76,7 @@ microphone:
   - **color**: The color of the progress bar. Color can be single color or gradient. For example, `color: "#57948a"` or `color: ["#57948a", "#ff0000"]"` for a gradient.
   - **background_color**: The background color of the progress bar.
   - **animation**: Whether to enable smooth change of the progress bar value.
+  - **center_label**: The label that will be centered inside the progress bar (can be styled using `.progress-circle`)
 
 ## Example Style
 ```css

--- a/docs/widgets/(Widget)-Pomodoro.md
+++ b/docs/widgets/(Widget)-Pomodoro.md
@@ -22,7 +22,7 @@ This widget implements a Pomodoro timer, which is a time management method that 
 | `menu` | dict | See below | Configure the appearance and behavior of the timer menu. |
 | `container_shadow`   | dict   | `None`                  | Container shadow options.                       |
 | `label_shadow`         | dict   | `None`                  | Label shadow options.                 |
-| `progress_bar`       | dict    | `{'enabled': false, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': true}` | Progress bar settings.    |
+| `progress_bar`       | dict    | `{'enabled': false, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': true, 'center_label': ''}` | Progress bar settings.    |
 
 ## Example Configuration
 
@@ -115,6 +115,7 @@ pomodoro:
   - **color**: The color of the progress bar. Color can be single color or gradient. For example, `color: "#57948a"` or `color: ["#57948a", "#ff0000"]"` for a gradient.
   - **background_color**: The background color of the progress bar.
   - **animation**: Whether to enable smooth change of the progress bar value.
+  - **center_label**: The label that will be centered inside the progress bar (can be styled using `.progress-circle`)
 
 ## Available Callbacks
 

--- a/docs/widgets/(Widget)-Volume.md
+++ b/docs/widgets/(Widget)-Volume.md
@@ -14,7 +14,7 @@
 | `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`               | Animation settings for the widget.                                          |
 | `container_shadow`   | dict   | `None`                  | Container shadow options.                       |
 | `label_shadow`         | dict   | `None`                  | Label shadow options.                 |
-| `progress_bar`       | dict    | `{'enabled': false, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': true}` | Progress bar settings.    |
+| `progress_bar`       | dict    | `{'enabled': false, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': true, 'center_label': ''}` | Progress bar settings.    |
 
 
 ## Example Configuration
@@ -104,6 +104,7 @@ volume:
   - **color**: The color of the progress bar. Color can be single color or gradient. For example, `color: "#57948a"` or `color: ["#57948a", "#ff0000"]` for a gradient.
   - **background_color**: The background color of the progress bar.
   - **animation**: Whether to enable smooth change of the progress bar value.
+  - **center_label**: The label that will be centered inside the progress bar (can be styled using `.progress-circle`)
 
 ## Available Styles
 ```css

--- a/src/core/utils/utilities.py
+++ b/src/core/utils/utilities.py
@@ -160,6 +160,7 @@ def build_progress_widget(self, options: dict[str, Any]) -> None:
         thickness=options["thickness"],
         color=options["color"],
         background_color=options["background_color"],
+        center_label=options["center_label"],
         animation=options["animation"],
     )
     self.progress_widget = CircularProgressWidget(self.progress_data)

--- a/src/core/utils/widgets/circular_progress_bar.py
+++ b/src/core/utils/widgets/circular_progress_bar.py
@@ -14,9 +14,11 @@ class CircularProgressBar(QFrame):
         value: float = 0.0,
         color="#00C800",
         background_color: str = "#3C3C3C",
+        center_label: str = "",
         animation: bool = True,
     ):
         super().__init__(parent)
+        self.setProperty("class", "progress-circle")
 
         self._size = size
         self._thickness = thickness
@@ -24,6 +26,8 @@ class CircularProgressBar(QFrame):
         self._color_config = color
         self.setContentsMargins(0, 0, 0, 0)
         self._background_color = QColor(background_color)
+        self._center_label_template = center_label
+        self._center_label = center_label
         self._animation_enabled = animation
         self._animation = QPropertyAnimation(self, b"animatedValue")
         self._animation.setDuration(400)
@@ -74,6 +78,12 @@ class CircularProgressBar(QFrame):
         if rect.width() <= 0 or rect.height() <= 0:
             return
 
+        # Draw the text in the center
+        painter.setPen(self.palette().color(self.foregroundRole()))
+        painter.setFont(self.font())
+        painter.drawText(self.rect(), Qt.AlignmentFlag.AlignCenter, self._center_label)
+
+        # Draw the circular bar
         painter.setPen(QPen(self._background_color, self._thickness, Qt.PenStyle.SolidLine, Qt.PenCapStyle.FlatCap))
         painter.setBrush(Qt.BrushStyle.NoBrush)
         painter.drawArc(rect, 0, 360 * 16)
@@ -100,7 +110,13 @@ class CircularProgressBar(QFrame):
             self._value = new_value
             self._update_angles()
             self.update()
-
+            
+    def set_icon(self, icon: str):
+        """Set the center label text (icon)."""
+        if self._center_label == icon:
+            return
+        self._center_label = self._center_label_template.replace("{icon}", icon)
+        self.update()
 
 class CircularProgressWidget(QFrame):
     """A widget that contains a CircularProgressBar and exposes its API."""
@@ -117,3 +133,11 @@ class CircularProgressWidget(QFrame):
 
     def set_value(self, value: float):
         self._progress_bar.set_value(value)
+
+    def set_icon(self, icon: str):
+        self._progress_bar.set_icon(icon)
+
+    def set_class(self, class_name: str):
+        self._progress_bar.setProperty("class", f"progress-circle {class_name}")
+        self._progress_bar.style().unpolish(self._progress_bar)
+        self._progress_bar.style().polish(self._progress_bar)

--- a/src/core/validation/widgets/yasb/brightness.py
+++ b/src/core/validation/widgets/yasb/brightness.py
@@ -141,6 +141,7 @@ VALIDATION_SCHEMA = {
                 "default": "#00C800",
             },
             "background_color": {"type": "string", "default": "#3C3C3C"},
+            "center_label": {"type": "string", "default": ""},
             "position": {"type": "string", "allowed": ["left", "right"], "default": "left"},
             "animation": {
                 "type": "boolean",

--- a/src/core/validation/widgets/yasb/cpu.py
+++ b/src/core/validation/widgets/yasb/cpu.py
@@ -85,6 +85,7 @@ VALIDATION_SCHEMA = {
                 "default": "#00C800",
             },
             "background_color": {"type": "string", "default": "#3C3C3C"},
+            "center_label": {"type": "string", "default": ""},
             "position": {"type": "string", "allowed": ["left", "right"], "default": "left"},
             "animation": {
                 "type": "boolean",

--- a/src/core/validation/widgets/yasb/disk.py
+++ b/src/core/validation/widgets/yasb/disk.py
@@ -113,6 +113,7 @@ VALIDATION_SCHEMA = {
                 "default": "#00C800",
             },
             "background_color": {"type": "string", "default": "#3C3C3C"},
+            "center_label": {"type": "string", "default": ""},
             "position": {"type": "string", "allowed": ["left", "right"], "default": "left"},
             "animation": {
                 "type": "boolean",

--- a/src/core/validation/widgets/yasb/gpu.py
+++ b/src/core/validation/widgets/yasb/gpu.py
@@ -88,6 +88,7 @@ VALIDATION_SCHEMA = {
                 "default": "#00C800",
             },
             "background_color": {"type": "string", "default": "#3C3C3C"},
+            "center_label": {"type": "string", "default": ""},
             "position": {"type": "string", "allowed": ["left", "right"], "default": "left"},
             "animation": {
                 "type": "boolean",

--- a/src/core/validation/widgets/yasb/memory.py
+++ b/src/core/validation/widgets/yasb/memory.py
@@ -95,6 +95,7 @@ VALIDATION_SCHEMA = {
                 "default": "#00C800",
             },
             "background_color": {"type": "string", "default": "#3C3C3C"},
+            "center_label": {"type": "string", "default": ""},
             "position": {"type": "string", "allowed": ["left", "right"], "default": "left"},
             "animation": {
                 "type": "boolean",

--- a/src/core/validation/widgets/yasb/microphone.py
+++ b/src/core/validation/widgets/yasb/microphone.py
@@ -116,6 +116,7 @@ VALIDATION_SCHEMA = {
                 "default": "#00C800",
             },
             "background_color": {"type": "string", "default": "#3C3C3C"},
+            "center_label": {"type": "string", "default": ""},
             "position": {"type": "string", "allowed": ["left", "right"], "default": "left"},
             "animation": {
                 "type": "boolean",

--- a/src/core/validation/widgets/yasb/pomodoro.py
+++ b/src/core/validation/widgets/yasb/pomodoro.py
@@ -117,6 +117,7 @@ VALIDATION_SCHEMA = {
                 "default": "#00C800",
             },
             "background_color": {"type": "string", "default": "#3C3C3C"},
+            "center_label": {"type": "string", "default": ""},
             "position": {"type": "string", "allowed": ["left", "right"], "default": "left"},
             "animation": {
                 "type": "boolean",

--- a/src/core/validation/widgets/yasb/volume.py
+++ b/src/core/validation/widgets/yasb/volume.py
@@ -137,6 +137,7 @@ VALIDATION_SCHEMA = {
                 "default": "#00C800",
             },
             "background_color": {"type": "string", "default": "#3C3C3C"},
+            "center_label": {"type": "string", "default": ""},
             "position": {"type": "string", "allowed": ["left", "right"], "default": "left"},
             "animation": {
                 "type": "boolean",

--- a/src/core/widgets/yasb/brightness.py
+++ b/src/core/widgets/yasb/brightness.py
@@ -185,6 +185,7 @@ class BrightnessWidget(BaseWidget):
                     self.progress_widget,
                 )
             self.progress_widget.set_value(percent)
+            self.progress_widget.set_icon(icon)
 
         for part in label_parts:
             part = part.strip()

--- a/src/core/widgets/yasb/cpu.py
+++ b/src/core/widgets/yasb/cpu.py
@@ -175,6 +175,7 @@ class CpuWidget(BaseWidget):
                     self.progress_widget,
                 )
             self.progress_widget.set_value(current_perc)
+            self.progress_widget.set_class(f"status-{self._get_cpu_threshold(current_perc)}")
 
         for part in label_parts:
             part = part.strip()

--- a/src/core/widgets/yasb/disk.py
+++ b/src/core/widgets/yasb/disk.py
@@ -129,6 +129,7 @@ class DiskWidget(BaseWidget):
                 )
 
             self.progress_widget.set_value(percent_value)
+            self.progress_widget.set_class(f"status-{self._get_disk_threshold(percent_value)}")
 
         for part in label_parts:
             part = part.strip()

--- a/src/core/widgets/yasb/gpu.py
+++ b/src/core/widgets/yasb/gpu.py
@@ -204,6 +204,7 @@ class GpuWidget(BaseWidget):
                     self.progress_widget,
                 )
             self.progress_widget.set_value(gpu_data.utilization)
+            self.progress_widget.set_class(f"status-{self._get_gpu_threshold(gpu_data.utilization)}")
 
         for part in label_parts:
             part = part.strip()

--- a/src/core/widgets/yasb/memory.py
+++ b/src/core/widgets/yasb/memory.py
@@ -150,6 +150,7 @@ class MemoryWidget(BaseWidget):
                     self.progress_widget,
                 )
             self.progress_widget.set_value(virtual_mem.percent)
+            self.progress_widget.set_class(f"status-{self._get_virtual_memory_threshold(virtual_mem.percent)}")
 
         for part in label_parts:
             part = part.strip()

--- a/src/core/widgets/yasb/microphone.py
+++ b/src/core/widgets/yasb/microphone.py
@@ -166,6 +166,7 @@ class MicrophoneWidget(BaseWidget):
                 )
             numeric_value = int(re.search(r"\d+", min_level).group()) if re.search(r"\d+", min_level) else 0
             self.progress_widget.set_value(numeric_value)
+            self.progress_widget.set_icon(min_icon)
 
         for part in label_parts:
             part = part.strip()

--- a/src/core/widgets/yasb/pomodoro.py
+++ b/src/core/widgets/yasb/pomodoro.py
@@ -228,7 +228,9 @@ class PomodoroWidget(BaseWidget):
             elapsed = max_value - self._remaining_time
             percent = (elapsed / max_value) * 100 if max_value > 0 else 0
             self.progress_widget.set_value(percent)
-
+            self.progress_widget.set_icon(label_options["{icon}"])
+            self.progress_widget.set_class(class_name)
+            
         for part in label_parts:
             part = part.strip()
             if part:

--- a/src/core/widgets/yasb/volume.py
+++ b/src/core/widgets/yasb/volume.py
@@ -912,6 +912,7 @@ class VolumeWidget(BaseWidget):
                 )
             numeric_value = int(re.search(r"\d+", level_volume).group()) if re.search(r"\d+", level_volume) else 0
             self.progress_widget.set_value(numeric_value)
+            self.progress_widget.set_icon(icon_volume)
 
         for part in label_parts:
             part = part.strip()


### PR DESCRIPTION
This PR adds support for a new center_label option in the progress_bar config:
```
progress_bar:
  enabled: true
  center_label: "\uf4bc"
```
- Accepts available {icon} from widgets (`center_label: "{icon}"`).
- Label can be styled using .progress-circle, with support for dynamic classes.
```
.pomodoro-widget .progress-circle.work {
    color: red
}
```