### PR TITLE
feat(komorebi_workspaces): add `scroll_populated_only` workspace scrolling option

### DIFF
--- a/docs/widgets/(Widget)-Komorebi-Workspaces.md
+++ b/docs/widgets/(Widget)-Komorebi-Workspaces.md
@@ -14,6 +14,7 @@
 | `hide_empty_workspaces`  | boolean | `false`      | Whether to hide empty workspaces.                                           |
 | `enable_scroll_switching` | boolean | `false`      | Enable scroll switching between workspaces.                                 |
 | `reverse_scroll_direction` | boolean | `false`      | Reverse scroll direction.                                                  |
+| `scroll_populated_only` | boolean | `false`      | Scroll through populated workspaces only.                                 |
 | `animation`  | boolean | `false`      | Button animation.                                           |
 | `container_shadow`      | dict    | `None`                  | Container shadow options.                                |
 | `btn_shadow`            | dict    | `None`                  | Workspace button shadow options.                         |

--- a/src/core/validation/widgets/komorebi/workspaces.py
+++ b/src/core/validation/widgets/komorebi/workspaces.py
@@ -21,6 +21,7 @@ DEFAULTS = {
     "animation": False,
     "enable_scroll_switching": False,
     "reverse_scroll_direction": False,
+    "scroll_populated_only": False,
     "container_padding": {"top": 0, "left": 0, "bottom": 0, "right": 0},
 }
 
@@ -59,6 +60,7 @@ VALIDATION_SCHEMA = {
     "animation": {"type": "boolean", "default": DEFAULTS["animation"]},
     "enable_scroll_switching": {"type": "boolean", "default": DEFAULTS["enable_scroll_switching"]},
     "reverse_scroll_direction": {"type": "boolean", "default": DEFAULTS["reverse_scroll_direction"]},
+    "scroll_populated_only": {"type": "boolean", "default": DEFAULTS["scroll_populated_only"]},
     "container_padding": {"type": "dict", "default": DEFAULTS["container_padding"], "required": False},
     "btn_shadow": {
         "type": "dict",

--- a/src/core/widgets/komorebi/workspaces.py
+++ b/src/core/widgets/komorebi/workspaces.py
@@ -241,6 +241,7 @@ class WorkspaceWidget(BaseWidget):
         animation: bool,
         enable_scroll_switching: bool,
         reverse_scroll_direction: bool,
+        scroll_populated_only: bool,
         btn_shadow: dict = None,
         label_shadow: dict = None,
         container_shadow: dict = None,
@@ -333,6 +334,7 @@ class WorkspaceWidget(BaseWidget):
 
         self._enable_scroll_switching = enable_scroll_switching
         self._reverse_scroll_direction = reverse_scroll_direction
+        self._scroll_populated_only = scroll_populated_only
         self._icon_cache = dict()
         self.dpi = None
 
@@ -620,6 +622,10 @@ class WorkspaceWidget(BaseWidget):
         direction = -1 if (delta > 0) != self._reverse_scroll_direction else 1
 
         workspaces = self._komorebic.get_workspaces(self._komorebi_screen)
+
+        if self._scroll_populated_only:
+            workspaces = [ws for ws in workspaces if not self._komorebic.get_num_windows(ws) == 0]
+
         if not workspaces:
             return
 

--- a/src/core/widgets/komorebi/workspaces.py
+++ b/src/core/widgets/komorebi/workspaces.py
@@ -622,16 +622,40 @@ class WorkspaceWidget(BaseWidget):
         direction = -1 if (delta > 0) != self._reverse_scroll_direction else 1
 
         workspaces = self._komorebic.get_workspaces(self._komorebi_screen)
-
-        if self._scroll_populated_only:
-            workspaces = [ws for ws in workspaces if not self._komorebic.get_num_windows(ws) == 0]
-
         if not workspaces:
             return
 
         current_idx = self._curr_workspace_index
-        num_workspaces = len(workspaces)
-        next_idx = (current_idx + direction) % num_workspaces
+
+        if self._scroll_populated_only:
+            populated = [ws["index"] for ws in workspaces if not self._komorebic.get_num_windows(ws) == 0]
+            if not populated:
+                return
+
+            next_idx = None
+
+            if direction > 0:
+                for ws_idx in populated:
+                    if ws_idx > current_idx:
+                        next_idx = ws_idx
+                        break
+
+                # if no next index found, wrap to first populated workspace
+                if next_idx is None:
+                    next_idx = populated[0]
+            else:
+                for ws_idx in reversed(populated):
+                    if ws_idx < current_idx:
+                        next_idx = ws_idx
+                        break
+
+                # if no previous index found, wrap to last populated workspace
+                if next_idx is None:
+                    next_idx = populated[-1]
+        else:
+            num_workspaces = len(workspaces)
+            next_idx = (current_idx + direction) % num_workspaces
+
         try:
             self._komorebic.activate_workspace(self._komorebi_screen["index"], next_idx)
         except Exception:


### PR DESCRIPTION
Enable `scroll_populated_only` option to scroll through only populated workspaces.