### PR TITLE
refactor(widgets) add support for python 3.14

### DIFF
--- a/.github/workflows/windows-dev.yaml
+++ b/.github/workflows/windows-dev.yaml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
 
 jobs:
   build:
@@ -74,7 +74,7 @@ jobs:
         .\venv\Scripts\Activate
         python -m pip install --upgrade pip
         pip install --force --no-cache .
-        pip install --force --no-cache --upgrade cx_Freeze==7.2.10
+        pip install --extra-index-url https://test.pypi.org/simple/ cx_Freeze --pre --no-cache
       shell: pwsh
 
     - name: Build EXE

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
 
 jobs:
   build:
@@ -36,7 +36,7 @@ jobs:
         .\venv\Scripts\Activate
         python -m pip install --upgrade pip
         pip install --force --no-cache .
-        pip install --force --no-cache --upgrade cx_Freeze==7.2.10
+        pip install --force --no-cache --upgrade cx_Freeze
       shell: pwsh
 
     - name: Build EXE

--- a/docs/widgets/(Widget)-Power-Menu.md
+++ b/docs/widgets/(Widget)-Power-Menu.md
@@ -89,8 +89,8 @@ power_menu:
     margin: 0px;
 }
 .power-menu-popup .button.hover {
-    background-color: #191919;
-    border: 4px solid #191919;
+    background-color: #1d1d1d;
+    border: 4px solid #1d1d1d;
 }
 .power-menu-popup .button .label {
     margin-bottom: 8px;
@@ -110,13 +110,14 @@ power_menu:
 .power-menu-popup .button.cancel .icon {
     padding: 0;
     margin: 0;
+    max-height: 0;
 }
 .power-menu-popup .button.cancel .label {
     color:  #f38ba8;
     margin: 0;
 }
 .power-menu-popup .button.cancel {
-    height: 32px;
+    height: 40px;
     border-radius: 4px;
 }
 .power-menu-popup .button.cancel.hover .label {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,9 @@ authors = [
 ]
 license = { file = "LICENSE" }
 readme = "README.md"
-requires-python = "==3.12.*"
+requires-python = ">= 3.13"
 dependencies = [
-    "PyQt6==6.9.1",
-    "PyQt6-Qt6==6.9.1",
-    "PyQt6_sip",
+    "pyqt6>=6.9.1",
     "cerberus",
     "humanize",
     "psutil",
@@ -26,7 +24,7 @@ dependencies = [
     "holidays",
     "watchdog",
     "pycaw",
-    "pillow==11.1",
+    "pillow",
     "icoextract",
     "qasync",
     "obs-websocket-py",
@@ -56,7 +54,9 @@ dependencies = [
 dev = [
     "pre-commit",
     "ruff",
-    "cx_Freeze==7.2.10"
+    "cx_freeze",
+    "pyqt6-stubs",
+    "types-pillow",
 ]
 
 [tool.hatch.metadata]

--- a/src/build.py
+++ b/src/build.py
@@ -58,7 +58,7 @@ build_options = {
     "silent_level": 1,
     "silent": True,
     "excludes": ["PySide6", "pydoc_data", "email", "tkinter", "PyQt5", "PySide2", "unittest"],
-    "bin_excludes": ["Qt6Pdf.dll", "Qt6PdfWidgets.dll"],
+    "bin_excludes": ["Qt6Pdf.dll", "_avif.cp314-win_amd64.pyd"],
     "zip_exclude_packages": ["*"],
     "build_exe": "dist",
     "include_msvcr": True,

--- a/src/core/bar_helper.py
+++ b/src/core/bar_helper.py
@@ -22,6 +22,7 @@ from PyQt6.QtWidgets import (
 )
 
 from core.utils.controller import exit_application, reload_application
+from core.utils.utilities import refresh_widget_style
 from core.utils.win32.bindings import DwmGetWindowAttribute
 from core.utils.win32.constants import DWMWA_CLOAKED, S_OK
 from core.utils.win32.utilities import get_monitor_hwnd, get_window_rect, qmenu_rounded_corners
@@ -437,11 +438,9 @@ class OsThemeManager(QObject):
 
     def _update_styles(self, widget):
         """Update styles for widget and its children by unpolishing and re-polishing"""
-        widget.style().unpolish(widget)
-        widget.style().polish(widget)
+        refresh_widget_style(widget)
         for child in widget.findChildren(QWidget):
-            child.style().unpolish(child)
-            child.style().polish(child)
+            refresh_widget_style(child)
 
 
 class BarContextMenu:

--- a/src/core/tray.py
+++ b/src/core/tray.py
@@ -86,10 +86,10 @@ class SystemTrayManager(QSystemTrayIcon):
         QMenu {
             background-color: #202020;
             color: #ffffff;
-            border:1px solid #373b3e;
+            border:1px solid #303030;
             padding:5px 0;
             margin:0;
-            border-radius:4px
+            border-radius:8px
         }
         QMenu::item {
             margin:0 4px;

--- a/src/core/ui/windows/about.py
+++ b/src/core/ui/windows/about.py
@@ -20,7 +20,7 @@ from winmica import BackdropType, EnableMica, is_mica_supported
 from core.ui.style import apply_button_style, apply_link_button_style
 from core.ui.windows.update_dialog import ReleaseFetcher, ReleaseInfo, UpdateDialog
 from core.utils.tooltip import set_tooltip
-from core.utils.utilities import get_app_identifier, is_valid_qobject
+from core.utils.utilities import get_app_identifier, is_valid_qobject, refresh_widget_style
 from settings import (
     APP_ID,
     APP_NAME,
@@ -209,8 +209,7 @@ class AboutDialog(QDialog):
         state = self._update_button.property("updateState") or "idle"
         variant = "primary" if state == "available" else "secondary"
         apply_button_style(self._update_button, variant)
-        self._update_button.style().unpolish(self._update_button)
-        self._update_button.style().polish(self._update_button)
+        refresh_widget_style(self._update_button)
 
     def _apply_state(
         self,
@@ -332,8 +331,7 @@ class AboutDialog(QDialog):
         set_tooltip(self._update_button, config["tooltip"], 0, position="top")
 
         apply_button_style(self._update_button, "secondary")
-        self._update_button.style().unpolish(self._update_button)
-        self._update_button.style().polish(self._update_button)
+        refresh_widget_style(self._update_button)
 
     def showEvent(self, event) -> None:
         self._apply_palette()

--- a/src/core/ui/windows/update_dialog.py
+++ b/src/core/ui/windows/update_dialog.py
@@ -30,7 +30,7 @@ from winmica import BackdropType, EnableMica, is_mica_supported
 
 from core.ui.style import apply_button_style
 from core.utils.controller import exit_application
-from core.utils.utilities import is_process_running, is_valid_qobject
+from core.utils.utilities import is_process_running, is_valid_qobject, refresh_widget_style
 from settings import APP_NAME, SCRIPT_PATH
 
 GITHUB_LATEST_RELEASE_URL = "https://api.github.com/repos/amnweb/yasb/releases/latest"
@@ -487,8 +487,7 @@ class UpdateDialog(QDialog):
     def event(self, event) -> bool:
         if event.type() == QEvent.Type.PaletteChange:
             self._apply_button_styles()
-            self.changelog_view.style().unpolish(self.changelog_view)
-            self.changelog_view.style().polish(self.changelog_view)
+            refresh_widget_style(self.changelog_view)
         return super().event(event)
 
     def present(self) -> None:

--- a/src/core/utils/alert_dialog.py
+++ b/src/core/utils/alert_dialog.py
@@ -4,8 +4,10 @@ import traceback
 
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import QIcon
-from PyQt6.QtWidgets import QMessageBox, QSizePolicy, QTextEdit
+from PyQt6.QtWidgets import QMessageBox, QPushButton, QSizePolicy, QTextEdit
+from winmica import BackdropType, EnableMica, is_mica_supported
 
+from core.ui.style import apply_button_style
 from settings import SCRIPT_PATH
 
 
@@ -24,10 +26,13 @@ class AlertDialog(QMessageBox):
         super().__init__(parent)
 
         self.setWindowTitle(title)
+        if is_mica_supported():
+            self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+            hwnd = int(self.winId())
+            EnableMica(hwnd, BackdropType.MICA)
+
         self.setTextInteractionFlags(Qt.TextInteractionFlag.LinksAccessibleByMouse)
-        self.setWindowFlags(
-            Qt.WindowType.WindowStaysOnTopHint | Qt.WindowType.WindowCloseButtonHint | Qt.WindowType.WindowTitleHint
-        )
+        self.setWindowFlags(Qt.WindowType.WindowStaysOnTopHint | Qt.WindowType.WindowCloseButtonHint)
         self.setIcon(icon)
         self.setText(message)
         self.icon_path = os.path.join(SCRIPT_PATH, "assets", "images", "app_icon.png")
@@ -53,8 +58,10 @@ class AlertDialog(QMessageBox):
         self.adjustSize()
 
     def showEvent(self, event):
+        self._style_dialog_buttons()
         text_edit = self.findChild(QTextEdit)
         if text_edit:
+            text_edit.setStyleSheet("background-color: rgba(0,0,0,0.2); border: none;")
             text_edit.setMinimumHeight(60)
             text_edit.setMaximumHeight(150)
             text_edit.setMinimumWidth(420)
@@ -80,6 +87,10 @@ class AlertDialog(QMessageBox):
             text_edit.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
 
         return result
+
+    def _style_dialog_buttons(self):
+        for button in self.findChildren(QPushButton):
+            apply_button_style(button, "secondary")
 
 
 _persistent_dialogs = []

--- a/src/core/utils/css_processor.py
+++ b/src/core/utils/css_processor.py
@@ -3,20 +3,12 @@ import os
 import re
 from typing import Dict, Set
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QFontDatabase, QIcon
-from PyQt6.QtWidgets import QCheckBox, QMessageBox
-
-from core.utils.utilities import app_data_path
-from settings import DEBUG, SCRIPT_PATH
-
 
 class CSSProcessor:
     """
     Processes CSS files: handles @import, CSS variables, and removes comments.
     """
 
-    SKIP_FONT_CHECK = app_data_path("skip_font_check")
     _localdata_initialized = False
 
     def __init__(self, css_path: str):
@@ -39,8 +31,6 @@ class CSSProcessor:
         css = self._remove_comments(css)
         # Extract and replace CSS variables
         css = self._extract_and_replace_variables(css)
-        # Check for missing fonts and warn the user
-        self._check_font_families(css)
         return css
 
     def _read_css_file(self, file_path: str) -> str:
@@ -141,96 +131,3 @@ class CSSProcessor:
 
         # Match hex colors with # followed by exactly 8 hex digits
         return re.sub(r"#([0-9a-fA-F]{8})\b", hex_alpha_replacer, css)
-
-    def _check_font_families(self, css: str):
-        """
-        Checks for missing font families in the CSS and optionally warns the user.
-        Uses case-insensitive comparison for font names.
-        """
-        if not self._should_check_fonts():
-            return set(), {}
-
-        # Generic font families that should be ignored in the check
-        generic_families = {
-            "sans-serif",
-            "serif",
-            "monospace",
-            "cursive",
-            "fantasy",
-            "system-ui",
-            "ui-serif",
-            "ui-sans-serif",
-            "ui-monospace",
-            "ui-rounded",
-            "emoji",
-            "math",
-            "fangsong",
-            "initial",
-            "inherit",
-            "default",
-        }
-
-        # Check for available fonts (converted to lowercase for case-insensitive comparison)
-        available_fonts = {font.lower() for font in QFontDatabase.families()}
-
-        font_families = set()
-        font_status = {}
-
-        matches = re.findall(r"font-family\s*:\s*([^;}\n]+)\s*[;}]+", css, flags=re.IGNORECASE)
-        for match in matches:
-            fonts = [f.strip(" '\"\t\r\n") for f in match.split(",")]
-            for font in fonts:
-                if font:
-                    font_families.add(font)
-                    font_status[font] = font.lower() in generic_families or font.lower() in available_fonts
-
-        missing_fonts = [font for font, installed in font_status.items() if not installed]
-        if missing_fonts:
-            details = [
-                f'<a href="https://www.nerdfonts.com/font-downloads">{font}</a>'
-                if ("nerd font" in font.lower() or font.lower().endswith(" nf") or font.lower().endswith(" nfp"))
-                else font
-                for font in missing_fonts
-            ]
-            if self._show_font_warning(details):
-                self._set_skip_font_check()
-        if DEBUG:
-            logging.debug(f"Missing fonts: {missing_fonts}")
-        return font_families, font_status
-
-    def _set_skip_font_check(self):
-        try:
-            self.SKIP_FONT_CHECK.touch(exist_ok=True)
-        except OSError as e:
-            logging.error(f"Error writing skip_font_check.flag: {e}")
-        except Exception as e:
-            logging.error(f"Unexpected error writing skip_font_check.flag: {e}")
-
-    def _should_check_fonts(self) -> bool:
-        return not self.SKIP_FONT_CHECK.exists()
-
-    def _show_font_warning(self, details: list) -> bool:
-        """
-        Show a warning message box with the missing fonts and an option to not show it again.
-        """
-        msg_box = QMessageBox()
-        msg_box.setWindowFlag(Qt.WindowType.WindowStaysOnTopHint, True)
-        icon_path = os.path.join(SCRIPT_PATH, "assets", "images", "app_icon.png")
-        msg_box.setIcon(QMessageBox.Icon.Warning)
-        msg_box.setWindowIcon(QIcon(icon_path))
-        msg_box.setWindowTitle("Missing font(s) detected in CSS")
-        msg_box.setText(
-            "Some fonts specified in your stylesheet are not installed on your system, "
-            "some icons or symbols may not be visible or may not display correctly."
-        )
-        msg_box.setInformativeText(
-            "Please install the missing fonts.<br>" + "<br>".join(f"<strong>{font}</strong>" for font in details)
-        )
-        msg_box.setStandardButtons(QMessageBox.StandardButton.Ok)
-        msg_box.setTextFormat(Qt.TextFormat.RichText)
-
-        checkbox = QCheckBox("Don't show this warning again")
-        msg_box.setCheckBox(checkbox)
-
-        msg_box.exec()
-        return checkbox.isChecked()

--- a/src/core/utils/tooltip.py
+++ b/src/core/utils/tooltip.py
@@ -396,6 +396,8 @@ class TooltipEventFilter(QObject):
             self._mouse_inside = False
 
     def eventFilter(self, obj, event):
+        if not isinstance(obj, QObject):
+            return False
         if obj is self.widget:
             if event.type() == QEvent.Type.Enter:
                 self._mouse_inside = True

--- a/src/core/utils/utilities.py
+++ b/src/core/utils/utilities.py
@@ -97,6 +97,21 @@ def add_shadow(el: QWidget, options: dict[str, Any]) -> None:
     el.setGraphicsEffect(shadow_effect)
 
 
+def refresh_widget_style(*widgets: QWidget) -> None:
+    """Refresh the style of the given widgets."""
+    for widget in widgets:
+        if widget is None or not is_valid_qobject(widget):
+            continue
+        style = widget.style()
+        if not style:
+            continue
+        try:
+            style.unpolish(widget)
+            style.polish(widget)
+        except Exception:
+            pass
+
+
 def build_widget_label(self, content: str, content_alt: str = None, content_shadow: dict = None):
     def process_content(content, is_alt=False):
         label_parts = re.split("(<span.*?>.*?</span>)", content)
@@ -374,6 +389,8 @@ class PopupWidget(QWidget):
         self._fade_animation.start()
 
     def eventFilter(self, obj, event):
+        if not isinstance(obj, QObject):
+            return False
         if event.type() == QEvent.Type.MouseButtonPress:
             global_pos = event.globalPosition().toPoint()
 

--- a/src/core/utils/widgets/media/aumid_process.py
+++ b/src/core/utils/widgets/media/aumid_process.py
@@ -195,10 +195,3 @@ def _aumid_heuristic_fallback(aumid: str) -> str | None:
             return res
 
     return None
-
-
-# if __name__ == "__main__":
-#     # Usage: aumid_process.py <AUMID>
-#     import sys
-
-#     print(get_process_name_for_aumid(sys.argv[1]))

--- a/src/core/utils/widgets/systray/systray_widget.py
+++ b/src/core/utils/widgets/systray/systray_widget.py
@@ -39,6 +39,7 @@ from win32con import (
 
 import core.utils.widgets.systray.utils as utils
 from core.utils.tooltip import set_tooltip
+from core.utils.utilities import refresh_widget_style
 from core.utils.widgets.systray.tray_monitor import IconData
 from core.utils.widgets.systray.utils import pack_i32
 from core.utils.win32.bindings import (
@@ -413,10 +414,4 @@ class DropWidget(QFrame):
         """
         Refresh styles for the widget and dragged button.
         """
-        if style := self.style():
-            style.unpolish(self)
-            style.polish(self)
-
-        if self.dragged_button and (style := self.dragged_button.style()):
-            style.unpolish(self.dragged_button)
-            style.polish(self.dragged_button)
+        refresh_widget_style(self, self.dragged_button)

--- a/src/core/utils/widgets/taskbar/app_menu.py
+++ b/src/core/utils/widgets/taskbar/app_menu.py
@@ -206,7 +206,7 @@ def show_context_menu(taskbar_widget, hwnd: int, pos) -> QMenu | None:
                     }
                 unique_id, _ = PinManager.get_app_identifier(hwnd, window_data, resolve_shortcut=False)
 
-        menu = QMenu(taskbar_widget)
+        menu = QMenu(taskbar_widget.window())
         menu.setProperty("class", "context-menu")
         qmenu_rounded_corners(menu)
 

--- a/src/core/utils/widgets/taskbar/thumbnail.py
+++ b/src/core/utils/widgets/taskbar/thumbnail.py
@@ -6,6 +6,7 @@ from PyQt6.QtCore import QEasingCurve, QPoint, QPropertyAnimation, QRect, Qt
 from PyQt6.QtGui import QFontMetrics, QPixmap, QRegion
 from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QWidget
 
+from core.utils.utilities import refresh_widget_style
 from core.utils.win32.bindings.dwmapi import (
     DwmQueryThumbnailSourceSize,
     DwmRegisterThumbnail,
@@ -474,8 +475,7 @@ class TaskbarThumbnailManager:
             if is_flashing and hasattr(self._preview_popup, "_content"):
                 try:
                     self._preview_popup._content.setProperty("class", "taskbar-preview flashing")
-                    self._preview_popup._content.style().unpolish(self._preview_popup._content)
-                    self._preview_popup._content.style().polish(self._preview_popup._content)
+                    refresh_widget_style(self._preview_popup._content)
                 except Exception:
                     pass
 

--- a/src/core/utils/widgets/wallpapers/wallpapers_gallery.py
+++ b/src/core/utils/widgets/wallpapers/wallpapers_gallery.py
@@ -30,7 +30,7 @@ from PyQt6.QtWidgets import (
 
 from core.config import get_stylesheet
 from core.event_service import EventService
-from core.utils.utilities import is_windows_10
+from core.utils.utilities import is_windows_10, refresh_widget_style
 from core.utils.win32.win32_accent import Blur
 
 
@@ -394,8 +394,7 @@ class ImageGallery(QMainWindow, BaseStyledWidget):
             else:
                 label.set_focus(False)
                 label.setProperty("class", "wallpapers-gallery-image")
-            label.style().unpolish(label)
-            label.style().polish(label)
+            refresh_widget_style(label)
 
     # Navigation methods
     def load_next_images(self):

--- a/src/core/utils/widgets/weather/widgets.py
+++ b/src/core/utils/widgets/weather/widgets.py
@@ -7,6 +7,7 @@ from PyQt6.QtCore import QPoint, QPointF, QSize, Qt, pyqtSignal
 from PyQt6.QtGui import QColor, QImage, QMouseEvent, QPainter, QPainterPath, QPaintEvent, QPen, QPixmap, QWheelEvent
 from PyQt6.QtWidgets import QFrame, QHBoxLayout, QScrollArea, QWidget
 
+from core.utils.utilities import refresh_widget_style
 from core.utils.widgets.weather.api import IconFetcher
 
 
@@ -64,9 +65,8 @@ class ClickableWidget(QFrame):
     @override
     def setProperty(self, name: str | None, value: Any) -> bool:
         super().setProperty(name, value)
-        if name == "class" and (s := self.style()):
-            s.unpolish(self)
-            s.polish(self)
+        if name == "class":
+            refresh_widget_style(self)
             self.update()
             return True
         return False

--- a/src/core/utils/widgets/wifi/wifi_widgets.py
+++ b/src/core/utils/widgets/wifi/wifi_widgets.py
@@ -31,7 +31,7 @@ from PyQt6.QtWidgets import (
 )
 from winrt.windows.devices.wifi import WiFiConnectionStatus
 
-from core.utils.utilities import PopupWidget, is_valid_qobject
+from core.utils.utilities import PopupWidget, is_valid_qobject, refresh_widget_style
 from core.utils.widgets.wifi.wifi_managers import (
     NetworkInfo,
     ScanResultStatus,
@@ -289,8 +289,7 @@ class WifiItem(QFrame):
         # Update the style
         style = self.style()
         if style is not None:
-            style.unpolish(self)
-            style.polish(self)
+            refresh_widget_style(self)
 
     @override
     def mousePressEvent(self, a0: QMouseEvent | None):

--- a/src/core/widgets/glazewm/binding_mode.py
+++ b/src/core/widgets/glazewm/binding_mode.py
@@ -1,11 +1,11 @@
 import logging
 import re
-from typing import Any, cast
+from typing import Any
 
 from PyQt6.QtCore import pyqtSlot
-from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QStyle
+from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel
 
-from core.utils.utilities import add_shadow, build_widget_label
+from core.utils.utilities import add_shadow, build_widget_label, refresh_widget_style
 from core.utils.widgets.animation_manager import AnimationManager
 from core.utils.widgets.glazewm.client import BindingMode, GlazewmClient
 from core.validation.widgets.glazewm.binding_mode import VALIDATION_SCHEMA
@@ -101,9 +101,7 @@ class GlazewmBindingModeWidget(BaseWidget):
         self._update_label()
 
     def _reload_css(self, label: QLabel):
-        style = cast(QStyle, label.style())
-        style.unpolish(label)
-        style.polish(label)
+        refresh_widget_style(label)
         label.update()
 
     def _update_label(self):

--- a/src/core/widgets/glazewm/workspaces.py
+++ b/src/core/widgets/glazewm/workspaces.py
@@ -12,7 +12,7 @@ from PyQt6.QtCore import (
 from PyQt6.QtGui import QCursor, QImage, QMouseEvent, QPixmap, QShowEvent, QWheelEvent
 from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QWidget
 
-from core.utils.utilities import add_shadow
+from core.utils.utilities import add_shadow, refresh_widget_style
 from core.utils.widgets.glazewm.client import GlazewmClient, Monitor, Window
 from core.utils.win32.app_icons import get_window_icon
 from core.utils.win32.utilities import get_monitor_hwnd, get_process_info
@@ -71,7 +71,7 @@ class GlazewmWorkspaceButton(QPushButton):
         self._update_status()
         self._update_label()
         self.setProperty("class", f"ws-btn {self.status.value}")
-        self.setStyleSheet("")
+        refresh_widget_style(self)
 
     @pyqtSlot()
     def _activate_workspace(self):
@@ -166,7 +166,7 @@ class GlazewmWorkspaceButtonWithIcons(QFrame):
         self._update_label()
         self._update_icons()
         self.setProperty("class", f"ws-btn {self.status.value}")
-        self.setStyleSheet("")
+        refresh_widget_style(self)
 
     def _update_label(self):
         replacements = {

--- a/src/core/widgets/komorebi/control.py
+++ b/src/core/widgets/komorebi/control.py
@@ -8,7 +8,7 @@ from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QSizePolicy, QVBoxLayou
 
 from core.event_enums import KomorebiEvent
 from core.event_service import EventService
-from core.utils.utilities import PopupWidget, add_shadow, build_widget_label
+from core.utils.utilities import PopupWidget, add_shadow, build_widget_label, refresh_widget_style
 from core.utils.widgets.animation_manager import AnimationManager
 from core.utils.widgets.komorebi.client import KomorebiClient
 from core.validation.widgets.komorebi.control import VALIDATION_SCHEMA
@@ -282,8 +282,7 @@ class KomorebiControlWidget(BaseWidget):
 
         # Force style refresh on each button
         for btn in (self.start_btn, self.stop_btn, self.reload_btn):
-            btn.style().unpolish(btn)
-            btn.style().polish(btn)
+            refresh_widget_style(btn)
 
     def _run_komorebi_command(self, command: str):
         """Runs a Komorebi command with locked UI and error handling."""

--- a/src/core/widgets/komorebi/workspaces.py
+++ b/src/core/widgets/komorebi/workspaces.py
@@ -9,7 +9,7 @@ from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QWidget
 
 from core.event_enums import KomorebiEvent
 from core.event_service import EventService
-from core.utils.utilities import add_shadow
+from core.utils.utilities import add_shadow, refresh_widget_style
 from core.utils.widgets.komorebi.animation import KomorebiAnimation
 from core.utils.widgets.komorebi.client import KomorebiClient
 from core.utils.win32.app_icons import get_window_icon
@@ -63,7 +63,7 @@ class WorkspaceButton(QPushButton):
             new_class = " ".join([cls for cls in current_class.split() if not cls.startswith("button-")])
             new_class = f"{new_class} button-{index + 1}"
             button.setProperty("class", new_class)
-            button.setStyleSheet("")
+            refresh_widget_style(button)
 
     def update_and_redraw(self, status: WorkspaceStatus, lock_width: bool = False):
         # Lock current visual width so style/class changes don't cause a jump
@@ -76,7 +76,7 @@ class WorkspaceButton(QPushButton):
             self.setText(self.populated_label)
         else:
             self.setText(self.default_label)
-        self.setStyleSheet("")
+        refresh_widget_style(self)
         if lock_width and prev_width is not None:
             self.setFixedWidth(prev_width)
 
@@ -136,7 +136,7 @@ class WorkspaceButtonWithIcons(QFrame):
             new_class = " ".join([cls for cls in current_class.split() if not cls.startswith("button-")])
             new_class = f"{new_class} button-{index + 1}"
             button.setProperty("class", new_class)
-            button.setStyleSheet("")
+            refresh_widget_style(button)
 
     def update_and_redraw(self, status: WorkspaceStatus, lock_width: bool = False):
         prev_width = self.width() if lock_width else None
@@ -148,7 +148,7 @@ class WorkspaceButtonWithIcons(QFrame):
             self.text_label.setText(self.populated_label)
         else:
             self.text_label.setText(self.default_label)
-        self.setStyleSheet("")
+        refresh_widget_style(self)
         if lock_width and prev_width is not None:
             self.setFixedWidth(prev_width)
 
@@ -515,13 +515,11 @@ class WorkspaceWidget(BaseWidget):
                     self.workspace_layer_label.setText(self._toggle_workspace_layer["tiling_label"])
                 elif workspace["layer"] == "Floating":
                     self.workspace_layer_label.setText(self._toggle_workspace_layer["floating_label"])
-                self.workspace_layer_label.style().unpolish(self.workspace_layer_label)
-                self.workspace_layer_label.style().polish(self.workspace_layer_label)
+                refresh_widget_style(self.workspace_layer_label)
             else:
                 self.workspace_layer_label.setProperty("class", "workspace-layer")
                 self.workspace_layer_label.setText("")
-                self.workspace_layer_label.style().unpolish(self.workspace_layer_label)
-                self.workspace_layer_label.style().polish(self.workspace_layer_label)
+                refresh_widget_style(self.workspace_layer_label)
 
     def _update_button(self, workspace_btn: WorkspaceButton) -> None:
         workspace_index = workspace_btn.workspace_index

--- a/src/core/widgets/yasb/clock.py
+++ b/src/core/widgets/yasb/clock.py
@@ -2,16 +2,15 @@ import locale
 import re
 from datetime import date, datetime
 from itertools import cycle
-from typing import cast
 
 import pytz
 from PyQt6.QtCore import QDate, QLocale, Qt, QTimer
 from PyQt6.QtGui import QColor
-from PyQt6.QtWidgets import QCalendarWidget, QFrame, QHBoxLayout, QLabel, QSizePolicy, QStyle, QTableView, QVBoxLayout
+from PyQt6.QtWidgets import QCalendarWidget, QFrame, QHBoxLayout, QLabel, QSizePolicy, QTableView, QVBoxLayout
 from tzlocal import get_localzone_name
 
 from core.utils.tooltip import set_tooltip
-from core.utils.utilities import PopupWidget, add_shadow, build_widget_label
+from core.utils.utilities import PopupWidget, add_shadow, build_widget_label, refresh_widget_style
 from core.utils.widgets.animation_manager import AnimationManager
 from core.validation.widgets.yasb.clock import VALIDATION_SCHEMA
 from core.widgets.base import BaseWidget
@@ -231,9 +230,7 @@ class ClockWidget(BaseWidget):
         return icon or ""
 
     def _reload_css(self, label: QLabel):
-        style = cast(QStyle, label.style())
-        style.unpolish(label)
-        style.polish(label)
+        refresh_widget_style(label)
         label.update()
 
     def _update_label(self):

--- a/src/core/widgets/yasb/github.py
+++ b/src/core/widgets/yasb/github.py
@@ -14,7 +14,7 @@ from PyQt6.QtGui import QColor, QCursor, QDesktopServices, QPainter, QPaintEvent
 from PyQt6.QtWidgets import QFrame, QGraphicsOpacityEffect, QHBoxLayout, QLabel, QScrollArea, QVBoxLayout, QWidget
 
 from core.utils.tooltip import set_tooltip
-from core.utils.utilities import PopupWidget, add_shadow
+from core.utils.utilities import PopupWidget, add_shadow, refresh_widget_style
 from core.utils.widgets.animation_manager import AnimationManager
 from core.validation.widgets.yasb.github import VALIDATION_SCHEMA
 from core.widgets.base import BaseWidget
@@ -255,7 +255,7 @@ class GithubWidget(BaseWidget):
             else:
                 formatted_text = part.format(data=notification_count)
                 current_widget.setText(formatted_text)
-            current_widget.style().unpolish(current_widget)
+            refresh_widget_style(current_widget)
 
     def mark_as_read(self, notification_id, container_label):
         for notification in self._github_data:

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -13,7 +13,7 @@ from PyQt6.QtGui import QPixmap, QWheelEvent
 from PyQt6.QtWidgets import QFrame, QGridLayout, QHBoxLayout, QLabel, QSizePolicy, QSlider, QVBoxLayout
 from winrt.windows.media.control import GlobalSystemMediaTransportControlsSessionPlaybackInfo
 
-from core.utils.utilities import PopupWidget, ScrollingLabel, add_shadow
+from core.utils.utilities import PopupWidget, ScrollingLabel, add_shadow, refresh_widget_style
 from core.utils.widgets.animation_manager import AnimationManager
 from core.utils.widgets.media.aumid_process import get_process_name_for_aumid
 from core.utils.widgets.media.media import WindowsMedia
@@ -543,23 +543,23 @@ class MediaWidget(BaseWidget):
                 self._popup_play_button.setText(play_icon)
                 self._popup_play_button.setProperty("class", f"btn play {'disabled' if not is_play_enabled else ''}")
                 self._popup_play_button.setCursor(
-                    Qt.CursorShape.PointingHandCursor if is_play_enabled else Qt.CursorShape.PointingHandCursor
+                    Qt.CursorShape.PointingHandCursor if is_play_enabled else Qt.CursorShape.ArrowCursor
                 )
-                self._popup_play_button.setStyleSheet("")
+                refresh_widget_style(self._popup_play_button)
 
             if self._popup_prev_label:
                 self._popup_prev_label.setProperty("class", f"btn prev {'disabled' if not is_prev_enabled else ''}")
                 self._popup_prev_label.setCursor(
-                    Qt.CursorShape.PointingHandCursor if is_prev_enabled else Qt.CursorShape.PointingHandCursor
+                    Qt.CursorShape.PointingHandCursor if is_prev_enabled else Qt.CursorShape.ArrowCursor
                 )
-                self._popup_prev_label.setStyleSheet("")
+                refresh_widget_style(self._popup_prev_label)
 
             if self._popup_next_label:
                 self._popup_next_label.setProperty("class", f"btn next {'disabled' if not is_next_enabled else ''}")
                 self._popup_next_label.setCursor(
-                    Qt.CursorShape.PointingHandCursor if is_next_enabled else Qt.CursorShape.PointingHandCursor
+                    Qt.CursorShape.PointingHandCursor if is_next_enabled else Qt.CursorShape.ArrowCursor
                 )
-                self._popup_next_label.setStyleSheet("")
+                refresh_widget_style(self._popup_next_label)
         except Exception as e:
             logging.error(f"MediaWidget: Error initializing popup buttons: {e}")
 
@@ -679,15 +679,15 @@ class MediaWidget(BaseWidget):
                 if self._play_label is not None:
                     self._play_label.setText(self._media_button_icons["play"])
                     self._play_label.setProperty("class", "btn play disabled")
-                    self._play_label.setStyleSheet("")
+                    refresh_widget_style(self._play_label)
 
                 if self._prev_label is not None:
                     self._prev_label.setProperty("class", "btn prev disabled")
-                    self._prev_label.setStyleSheet("")
+                    refresh_widget_style(self._prev_label)
 
                 if self._next_label is not None:
                     self._next_label.setProperty("class", "btn next disabled")
-                    self._next_label.setStyleSheet("")
+                    refresh_widget_style(self._next_label)
 
             # If we want to hide the widget when no music is playing, hide it!
             if self._hide_empty:
@@ -709,22 +709,20 @@ class MediaWidget(BaseWidget):
 
             self._prev_label.setProperty("class", f"btn prev {'disabled' if not is_prev_enabled else ''}")
             self._prev_label.setCursor(
-                Qt.CursorShape.PointingHandCursor if is_prev_enabled else Qt.CursorShape.PointingHandCursor
+                Qt.CursorShape.PointingHandCursor if is_prev_enabled else Qt.CursorShape.ArrowCursor
             )
 
             self._play_label.setProperty("class", f"btn play {'disabled' if not is_play_enabled else ''}")
             self._play_label.setCursor(
-                Qt.CursorShape.PointingHandCursor if is_play_enabled else Qt.CursorShape.PointingHandCursor
+                Qt.CursorShape.PointingHandCursor if is_play_enabled else Qt.CursorShape.ArrowCursor
             )
 
             self._next_label.setProperty("class", f"btn next {'disabled' if not is_next_enabled else ''}")
             self._next_label.setCursor(
-                Qt.CursorShape.PointingHandCursor if is_next_enabled else Qt.CursorShape.PointingHandCursor
+                Qt.CursorShape.PointingHandCursor if is_next_enabled else Qt.CursorShape.ArrowCursor
             )
 
-            self._prev_label.setStyleSheet("")
-            self._play_label.setStyleSheet("")
-            self._next_label.setStyleSheet("")
+            refresh_widget_style(self._prev_label, self._play_label, self._next_label)
 
         # Update popup if it's currently open
         try:
@@ -736,23 +734,23 @@ class MediaWidget(BaseWidget):
                         "class", f"btn play {'disabled' if not is_play_enabled else ''}"
                     )
                     self._popup_play_button.setCursor(
-                        Qt.CursorShape.PointingHandCursor if is_play_enabled else Qt.CursorShape.PointingHandCursor
+                        Qt.CursorShape.PointingHandCursor if is_play_enabled else Qt.CursorShape.ArrowCursor
                     )
-                    self._popup_play_button.setStyleSheet("")
+                    refresh_widget_style(self._popup_play_button)
 
                 if self._popup_prev_label is not None:
                     self._popup_prev_label.setProperty("class", f"btn prev {'disabled' if not is_prev_enabled else ''}")
                     self._popup_prev_label.setCursor(
-                        Qt.CursorShape.PointingHandCursor if is_prev_enabled else Qt.CursorShape.PointingHandCursor
+                        Qt.CursorShape.PointingHandCursor if is_prev_enabled else Qt.CursorShape.ArrowCursor
                     )
-                    self._popup_prev_label.setStyleSheet("")
+                    refresh_widget_style(self._popup_prev_label)
 
                 if self._popup_next_label is not None:
                     self._popup_next_label.setProperty("class", f"btn next {'disabled' if not is_next_enabled else ''}")
                     self._popup_next_label.setCursor(
-                        Qt.CursorShape.PointingHandCursor if is_next_enabled else Qt.CursorShape.PointingHandCursor
+                        Qt.CursorShape.PointingHandCursor if is_next_enabled else Qt.CursorShape.ArrowCursor
                     )
-                    self._popup_next_label.setStyleSheet("")
+                    refresh_widget_style(self._popup_next_label)
         except RuntimeError:
             self._popup_play_button = None
             self._popup_prev_label = None
@@ -794,8 +792,8 @@ class MediaWidget(BaseWidget):
                         if source_name is not None:
                             self._popup_source_label.setText(source_name)
                             self._popup_source_label.setProperty("class", f"source {source_class_name}")
-                            self._popup_source_label.style().unpolish(self._popup_source_label)
-                            self._popup_source_label.style().polish(self._popup_source_label)
+
+                            refresh_widget_style(self._popup_source_label)
 
                 except Exception as e:
                     logging.error(f"Error updating popup content: {e}")
@@ -1374,8 +1372,7 @@ class MediaWidget(BaseWidget):
             self._app_mute_button.setText(self._menu_config_icons[icon_key])
             self._app_mute_button.setProperty("class", f"{icon_key}-button")
             self._app_mute_button.setEnabled(True)
-            self._app_mute_button.style().unpolish(self._app_mute_button)
-            self._app_mute_button.style().polish(self._app_mute_button)
+            refresh_widget_style(self._app_mute_button)
 
         except Exception as e:
             logging.error(f"MediaWidget: Failed to update mute button: {e}")

--- a/src/core/widgets/yasb/microphone.py
+++ b/src/core/widgets/yasb/microphone.py
@@ -18,7 +18,13 @@ from PyQt6.QtGui import QWheelEvent
 from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QSlider, QVBoxLayout
 
 from core.utils.tooltip import set_tooltip
-from core.utils.utilities import PopupWidget, add_shadow, build_progress_widget, build_widget_label
+from core.utils.utilities import (
+    PopupWidget,
+    add_shadow,
+    build_progress_widget,
+    build_widget_label,
+    refresh_widget_style,
+)
 from core.utils.widgets.animation_manager import AnimationManager
 from core.validation.widgets.yasb.microphone import VALIDATION_SCHEMA
 from core.widgets.base import BaseWidget
@@ -201,8 +207,7 @@ class MicrophoneWidget(BaseWidget):
         else:
             classes.discard("muted")
         widget.setProperty("class", " ".join(classes))
-        widget.style().unpolish(widget)
-        widget.style().polish(widget)
+        refresh_widget_style(widget)
 
     def _get_mic_icon(self):
         if not self.audio_endpoint:

--- a/src/core/widgets/yasb/notifications.py
+++ b/src/core/widgets/yasb/notifications.py
@@ -5,7 +5,7 @@ from PyQt6.QtCore import pyqtSignal
 from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel
 
 from core.event_service import EventService
-from core.utils.utilities import add_shadow, build_widget_label, is_windows_10
+from core.utils.utilities import add_shadow, build_widget_label, is_windows_10, refresh_widget_style
 from core.utils.widgets.animation_manager import AnimationManager
 from core.utils.win32.system_function import notification_center, quick_settings
 from core.validation.widgets.yasb.notifications import VALIDATION_SCHEMA
@@ -159,5 +159,4 @@ class NotificationsWidget(BaseWidget):
 
                 widget_index += 1
         for widget in active_widgets:
-            widget.style().unpolish(widget)
-            widget.style().polish(widget)
+            refresh_widget_style(widget)

--- a/src/core/widgets/yasb/obs.py
+++ b/src/core/widgets/yasb/obs.py
@@ -5,6 +5,7 @@ from PyQt6.QtCore import Q_ARG, QMetaObject, Qt, QThread, QTimer, pyqtSignal
 from PyQt6.QtGui import QCursor
 from PyQt6.QtWidgets import QFrame, QGraphicsOpacityEffect, QHBoxLayout, QLabel
 
+from core.utils.utilities import refresh_widget_style
 from core.validation.widgets.yasb.obs import VALIDATION_SCHEMA
 from core.widgets.base import BaseWidget
 from settings import DEBUG
@@ -145,8 +146,7 @@ class ObsWidget(BaseWidget):
             self.hide_widget()
             QMetaObject.invokeMethod(self.blink_timer, "stop")
 
-        self.record_button.style().unpolish(self.record_button)
-        self.record_button.style().polish(self.record_button)
+        refresh_widget_style(self.record_button)
         self.record_button.update()
         self.record_button.repaint()
 

--- a/src/core/widgets/yasb/pomodoro.py
+++ b/src/core/widgets/yasb/pomodoro.py
@@ -6,7 +6,14 @@ from PyQt6.QtCore import QPropertyAnimation, QRectF, Qt, QTimer, pyqtProperty
 from PyQt6.QtGui import QColor, QCursor, QPainter, QPen
 from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
 
-from core.utils.utilities import PopupWidget, ToastNotifier, add_shadow, build_progress_widget, build_widget_label
+from core.utils.utilities import (
+    PopupWidget,
+    ToastNotifier,
+    add_shadow,
+    build_progress_widget,
+    build_widget_label,
+    refresh_widget_style,
+)
 from core.utils.widgets.animation_manager import AnimationManager
 from core.validation.widgets.yasb.pomodoro import VALIDATION_SCHEMA
 from core.widgets.base import BaseWidget
@@ -267,8 +274,7 @@ class PomodoroWidget(BaseWidget):
                 if hasattr(inst, "_dialog") and inst._dialog is not None and inst._dialog.isVisible():
                     inst._toggle_button.setText("Pause")
                     inst._toggle_button.setProperty("class", "button pause")
-                    inst._toggle_button.style().unpolish(inst._toggle_button)
-                    inst._toggle_button.style().polish(inst._toggle_button)
+                    refresh_widget_style(inst._toggle_button)
         except RuntimeError:
             pass
 
@@ -282,8 +288,7 @@ class PomodoroWidget(BaseWidget):
                 if hasattr(inst, "_dialog") and inst._dialog is not None and inst._dialog.isVisible():
                     inst._toggle_button.setText("Start")
                     inst._toggle_button.setProperty("class", "button start")
-                    inst._toggle_button.style().unpolish(inst._toggle_button)
-                    inst._toggle_button.style().polish(inst._toggle_button)
+                    refresh_widget_style(inst._toggle_button)
                     inst._progress_gauge.setStatusText(f"Paused\n{inst._format_time(inst._remaining_time)}")
         except RuntimeError:
             pass
@@ -307,8 +312,7 @@ class PomodoroWidget(BaseWidget):
 
                     inst._toggle_button.setText("Start")
                     inst._toggle_button.setProperty("class", "button start")
-                    inst._toggle_button.style().unpolish(inst._toggle_button)
-                    inst._toggle_button.style().polish(inst._toggle_button)
+                    refresh_widget_style(inst._toggle_button)
         except RuntimeError:
             pass
 

--- a/src/core/widgets/yasb/todo.py
+++ b/src/core/widgets/yasb/todo.py
@@ -25,7 +25,7 @@ from PyQt6.QtWidgets import (
 
 from core.config import HOME_CONFIGURATION_DIR
 from core.utils.tooltip import set_tooltip
-from core.utils.utilities import PopupWidget, add_shadow, build_widget_label
+from core.utils.utilities import PopupWidget, add_shadow, build_widget_label, refresh_widget_style
 from core.utils.widgets.animation_manager import AnimationManager
 from core.utils.win32.utilities import qmenu_rounded_corners
 from core.validation.widgets.yasb.todo import VALIDATION_SCHEMA
@@ -634,8 +634,7 @@ class TodoWidget(BaseWidget):
                 cb.setChecked(True)
                 cb.setEnabled(False)
                 container.setProperty("class", f"task-item completed {task.get('category', 'default')}")
-                container.style().unpolish(container)
-                container.style().polish(container)
+                refresh_widget_style(container)
                 checkbox.setText(self._icons["checked"])
 
                 def do_archive():

--- a/src/core/widgets/yasb/volume.py
+++ b/src/core/widgets/yasb/volume.py
@@ -22,7 +22,13 @@ from PyQt6.QtGui import QImage, QPixmap, QWheelEvent
 from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QSlider, QVBoxLayout, QWidget
 
 from core.utils.tooltip import CustomToolTip, set_tooltip
-from core.utils.utilities import PopupWidget, add_shadow, build_progress_widget, build_widget_label
+from core.utils.utilities import (
+    PopupWidget,
+    add_shadow,
+    build_progress_widget,
+    build_widget_label,
+    refresh_widget_style,
+)
 from core.utils.widgets.animation_manager import AnimationManager
 from core.utils.win32.app_icons import get_process_icon
 from core.utils.win32.utilities import get_app_name_from_pid
@@ -414,8 +420,7 @@ class VolumeWidget(BaseWidget):
             if self._tooltip:
                 set_tooltip(self.app_toggle_btn, "Expand application volumes")
 
-        self.app_toggle_btn.style().unpolish(self.app_toggle_btn)
-        self.app_toggle_btn.style().polish(self.app_toggle_btn)
+        refresh_widget_style(self.app_toggle_btn)
 
         # Stop any existing animation
         if (
@@ -624,8 +629,7 @@ class VolumeWidget(BaseWidget):
                 btn.setProperty("class", "device selected")
             else:
                 btn.setProperty("class", "device")
-            btn.style().unpolish(btn)
-            btn.style().polish(btn)
+            refresh_widget_style(btn)
 
     def _set_default_device(self, device_id: str):
         """Set default audio device with error handling and multiple interface attempts"""
@@ -934,8 +938,7 @@ class VolumeWidget(BaseWidget):
         else:
             classes.discard("muted")
         widget.setProperty("class", " ".join(classes))
-        widget.style().unpolish(widget)
-        widget.style().polish(widget)
+        refresh_widget_style(widget)
 
     def _get_volume_icon(self):
         current_mute_status = self.volume.GetMute()

--- a/src/core/widgets/yasb/weather.py
+++ b/src/core/widgets/yasb/weather.py
@@ -5,14 +5,14 @@ import traceback
 import urllib.parse
 from datetime import datetime
 from functools import partial
-from typing import Any, cast
+from typing import Any
 
 from PyQt6.QtCore import Qt, QTimer, QUrl, pyqtSlot
 from PyQt6.QtGui import QPixmap
-from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QStyle, QVBoxLayout, QWidget
+from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QVBoxLayout, QWidget
 
 from core.utils.tooltip import set_tooltip
-from core.utils.utilities import PopupWidget, add_shadow
+from core.utils.utilities import PopupWidget, add_shadow, refresh_widget_style
 from core.utils.widgets.animation_manager import AnimationManager
 from core.utils.widgets.weather.api import IconFetcher, WeatherDataFetcher
 from core.utils.widgets.weather.widgets import (
@@ -358,9 +358,7 @@ class WeatherWidget(BaseWidget):
         self._widgets_alt = process_content(content_alt, is_alt=True)
 
     def _reload_css(self, label: QLabel):
-        style = cast(QStyle, label.style())
-        style.unpolish(label)
-        style.polish(label)
+        refresh_widget_style(label)
         label.update()
 
     @pyqtSlot(bool)

--- a/src/core/widgets/yasb/whkd.py
+++ b/src/core/widgets/yasb/whkd.py
@@ -18,7 +18,7 @@ from PyQt6.QtWidgets import (
 )
 
 from core.utils.alert_dialog import raise_info_alert
-from core.utils.utilities import add_shadow, build_widget_label
+from core.utils.utilities import add_shadow, build_widget_label, refresh_widget_style
 from core.utils.widgets.animation_manager import AnimationManager
 from core.validation.widgets.yasb.whkd import VALIDATION_SCHEMA
 from core.widgets.base import BaseWidget
@@ -204,8 +204,7 @@ class KeybindsDialog(QDialog):
                     btn.setMinimumWidth(28)
                     btn.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
                     buttons_layout.addWidget(btn)
-                    btn.style().unpolish(btn)
-                    btn.style().polish(btn)
+                    refresh_widget_style(btn)
                     return btn
 
                 if " + " in keybind:
@@ -244,8 +243,7 @@ class KeybindsDialog(QDialog):
                 self.row_layout.addWidget(self.command_label)
 
                 self.container_layout.addWidget(self.row)
-                self.row.style().unpolish(self.row)
-                self.row.style().polish(self.row)
+                refresh_widget_style(self.row)
 
     def _friendly_key_text(self, k: str) -> str:
         return self.special_keys.get(k.lower(), k)

--- a/src/core/widgets/yasb/windows_desktops.py
+++ b/src/core/widgets/yasb/windows_desktops.py
@@ -20,7 +20,7 @@ from PyQt6.QtWidgets import (
 from pyvda import VirtualDesktop, get_virtual_desktops, set_wallpaper_for_all_desktops
 
 from core.event_service import EventService
-from core.utils.utilities import add_shadow, is_windows_10
+from core.utils.utilities import add_shadow, is_windows_10, refresh_widget_style
 from core.utils.win32.utilities import qmenu_rounded_corners
 from core.validation.widgets.yasb.windows_desktops import VALIDATION_SCHEMA
 from core.widgets.base import BaseWidget
@@ -52,8 +52,7 @@ class WorkspaceButton(QPushButton):
             new_class = " ".join([cls for cls in current_class.split() if not cls.startswith("button-")])
             new_class = f"{new_class} button-{index + 1}"
             button.setProperty("class", new_class)
-            button.style().unpolish(button)
-            button.style().polish(button)
+            refresh_widget_style(button)
         if self.animation:
             try:
                 parent = self.parent_widget
@@ -380,8 +379,7 @@ class WorkspaceWidget(BaseWidget):
             base = f"{base} {' '.join(tokens)}"
 
         workspace_btn.setProperty("class", base)
-        workspace_btn.style().unpolish(workspace_btn)
-        workspace_btn.style().polish(workspace_btn)
+        refresh_widget_style(workspace_btn)
         if schedule_update:
             QTimer.singleShot(0, workspace_btn.update_visible_buttons)
 


### PR DESCRIPTION
- Introduced a new utility function `refresh_widget_style` to streamline the process of refreshing widget styles across various components.
- Replaced direct calls to `style().unpolish()` and `style().polish()` with `refresh_widget_style()` in multiple widget classes, enhancing code readability and maintainability.
- Updated context menus in taskbar and systray widgets to use the main window as the parent for better behavior.
- Removed unnecessary style refresh calls in several widgets, ensuring that style updates are handled consistently through the new utility function.
- Removed PqQt6 pinning to allow for the latest compatible version to be installed, improving dependency management.
- Add Mica support for Windows 11 in AlertDialog.
- Updated the Python version in both `windows-dev.yaml` and `windows.yaml` to 3.14 for consistency.
- Enhanced `build.py` to exclude additional binaries during the build process.
- Added auto width management in `bar.py` for better layout handling.
- Implemented thread cleanup in `systray.py` on application quit.
- Introduced a startup delay for worker threads in `update_check.py` to improve application responsiveness.