### PR TITLE
GPU Widget - Allow the Option to Convert GPU Temp to Fahrenheit

### DIFF
--- a/docs/widgets/(Widget)-GPU.md
+++ b/docs/widgets/(Widget)-GPU.md
@@ -29,6 +29,7 @@ If you see a table with your GPU information, `nvidia-smi` is available. If you 
 | `label_shadow`        | dict    | `{"enabled": False, "color": "black", "offset": [1, 1], "radius": 3}`                                                                  | Label shadow options.                                                       |
 | `progress_bar`        | dict    | `{'enabled': false, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': false}` | Progress bar settings.                                                      |
 | `hide_decimal`        | bool    | `false`                                                                 | Whether to hide decimal places in the GPU widget.                          |
+| `units`               | string  | `"metric"`                                                              | Whether the temperature is converted to Fahrenheit (if set to `"imperial"`) or Celsius (if not set or explicitly set to `"metric"`) |
 
 > **About `index`:** If you have multiple NVIDIA GPUs, you can set the `gpu_index` option to select which GPU to monitor. Create multiple GPU widgets with different `gpu_index` values (e.g., 0, 1, 2, ...) to display stats for each card separately.
 

--- a/src/core/validation/widgets/yasb/gpu.py
+++ b/src/core/validation/widgets/yasb/gpu.py
@@ -11,6 +11,7 @@ DEFAULTS = {
     "callbacks": {"on_left": "toggle_label", "on_middle": "do_nothing", "on_right": "do_nothing"},
     "gpu_thresholds": {"low": 30, "medium": 60, "high": 90},
     "hide_decimal": False,
+    "units": "metric",
 }
 
 VALIDATION_SCHEMA = {
@@ -124,4 +125,5 @@ VALIDATION_SCHEMA = {
         "default": DEFAULTS["gpu_thresholds"],
     },
     "hide_decimal": {"type": "boolean", "default": DEFAULTS["hide_decimal"]},
+    "units": {"type": "string", "default": DEFAULTS["units"], "allowed": ["metric", "imperial"]},
 }

--- a/src/core/widgets/yasb/gpu.py
+++ b/src/core/widgets/yasb/gpu.py
@@ -36,6 +36,7 @@ class GpuWidget(BaseWidget):
         container_padding: dict[str, int],
         callbacks: dict[str, str],
         gpu_thresholds: dict[str, int],
+        units: str,
         label_shadow: dict = None,
         container_shadow: dict = None,
         progress_bar: dict = None,
@@ -54,6 +55,7 @@ class GpuWidget(BaseWidget):
         self._label_shadow = label_shadow
         self._container_shadow = container_shadow
         self._gpu_thresholds = gpu_thresholds
+        self._units = units
         self._progress_bar = progress_bar
         self._hide_decimal = hide_decimal
 
@@ -173,7 +175,8 @@ class GpuWidget(BaseWidget):
         """Update the label with GPU data."""
         self._gpu_util_history.append(gpu_data.utilization)
         self._gpu_mem_history.append(gpu_data.mem_used)
-
+        _temp = gpu_data.temp if self._units == "metric" else (gpu_data.temp * (9 / 5) + 32)
+        _temp = round(_temp) if self._hide_decimal else _temp
         _naturalsize = lambda value: naturalsize(value, True, True, "%.0f" if self._hide_decimal else "%.1f")
         gpu_info = {
             "index": gpu_data.index,
@@ -181,7 +184,7 @@ class GpuWidget(BaseWidget):
             "mem_total": _naturalsize(gpu_data.mem_total * 1024 * 1024),
             "mem_used": _naturalsize(gpu_data.mem_used * 1024 * 1024),
             "mem_free": _naturalsize(gpu_data.mem_free * 1024 * 1024),
-            "temp": gpu_data.temp,
+            "temp": _temp,
             "fan_speed": gpu_data.fan_speed,
             "histograms": {
                 "utilization": "".join([self._get_histogram_bar(val, 0, 100) for val in self._gpu_util_history]),


### PR DESCRIPTION
Adds a `"units"` option for the GPU Widget. If not set or explicitly set to `"metric"`, the temp will be output to Celsius.
If set to `"imperial"`, it will be converted to Fahrenheit.  If `""hide_decimal` is set to `True`, then the temperature will be rounded to the nearest integer. 