### PR TITLE
fix(cava): `noise_reduction` value misplacement on cava config

### DIFF
--- a/src/core/widgets/yasb/cava.py
+++ b/src/core/widgets/yasb/cava.py
@@ -566,7 +566,6 @@ class CavaWidget(BaseWidget):
         lines.append(f"lower_cutoff_freq = {self._lower_cutoff_freq}")
         lines.append(f"higher_cutoff_freq = {self._higher_cutoff_freq}")
         lines.append(f"framerate = {self._framerate}")
-        lines.append(f"noise_reduction = {self._noise_reduction}")
         lines.append("")
         lines.append("[output]")
         lines.append("method = raw")
@@ -590,6 +589,7 @@ class CavaWidget(BaseWidget):
         lines.append("[smoothing]")
         lines.append(f"monstercat = {self._monstercat}")
         lines.append(f"waves = {self._waves}")
+        lines.append(f"noise_reduction = {self._noise_reduction}")
 
         config_template = "\n".join(lines) + "\n"
 


### PR DESCRIPTION
The `noise_reduction` value should be set under the `[smoothing]` section of the Cava config file for the value to register correctly. It was misplaced under the `[general]` section.

Fixes noise reduction not being affected by the `noise_reduction` value on the Cava widget.