### PR TITLE
feat(watcher): implement stylesheet import tracking and refresh logic

### DIFF
--- a/src/core/utils/css_processor.py
+++ b/src/core/utils/css_processor.py
@@ -23,6 +23,7 @@ class CSSProcessor:
         """
         if not self.css_content:
             return ""
+        self.imported_files = set()
         # Remove comments from the CSS content
         css = self._remove_comments(self.css_content)
         # Process @import statements and CSS variables

--- a/src/core/watcher.py
+++ b/src/core/watcher.py
@@ -1,12 +1,14 @@
 import hashlib
 import logging
+import os
 from os.path import basename
 
 from watchdog.events import FileModifiedEvent, PatternMatchingEventHandler
 from watchdog.observers import Observer
 
 from core.bar_manager import BarManager
-from core.config import get_config_dir
+from core.config import get_config_dir, get_stylesheet_path
+from core.utils.css_processor import CSSProcessor
 from settings import DEFAULT_CONFIG_FILENAME, DEFAULT_STYLES_FILENAME
 
 
@@ -23,6 +25,44 @@ class FileModifiedEventHandler(PatternMatchingEventHandler):
         self._case_sensitive = False
         self._last_styles_hash = None
         self._last_config_hash = None
+        self._stylesheet_path = self._normalize_path(get_stylesheet_path())
+        self._imported_stylesheets = set()
+        self._imported_hashes = {}
+        self._observer = None
+        self._watched_dirs = set()
+        self._refresh_imported_stylesheets()
+
+    def _normalize_path(self, path: str) -> str:
+        return os.path.normcase(os.path.normpath(path))
+
+    def _refresh_imported_stylesheets(self) -> None:
+        try:
+            processor = CSSProcessor(self._stylesheet_path)
+            processor.process()
+            self._imported_stylesheets = {self._normalize_path(path) for path in processor.imported_files}
+            if self._stylesheet_path:
+                self._imported_stylesheets.add(self._stylesheet_path)
+            self._patterns = [self.styles_file, self.config_file, *self._imported_stylesheets]
+            self._ensure_watch_paths()
+        except Exception:
+            logging.exception("Failed to refresh imported stylesheets list")
+
+    def set_observer(self, observer) -> None:
+        self._observer = observer
+        self._ensure_watch_paths()
+
+    def _ensure_watch_paths(self) -> None:
+        if not self._observer:
+            return
+        paths = {get_config_dir()}
+        for css_path in self._imported_stylesheets:
+            if css_path:
+                paths.add(os.path.dirname(css_path))
+        for path in {self._normalize_path(path) for path in paths}:
+            if path and path not in self._watched_dirs and os.path.isdir(path):
+                self._observer.schedule(self, path=path, recursive=False)
+                self._watched_dirs.add(path)
+                logging.info(f"Watching directory: {path}")
 
     def _file_hash(self, path):
         try:
@@ -33,23 +73,33 @@ class FileModifiedEventHandler(PatternMatchingEventHandler):
 
     def on_modified(self, event: FileModifiedEvent):
         modified_file = basename(event.src_path)
+        normalized_path = self._normalize_path(event.src_path)
 
         if modified_file == self.styles_file and self.bar_manager.config["watch_stylesheet"]:
             new_hash = self._file_hash(event.src_path)
             if new_hash and new_hash != self._last_styles_hash:
                 self._last_styles_hash = new_hash
+                self._refresh_imported_stylesheets()
                 self.bar_manager.styles_modified.emit()
+                logging.debug(f"Stylesheet modified: {event.src_path}")
         elif modified_file == self.config_file and self.bar_manager.config["watch_config"]:
             new_hash = self._file_hash(event.src_path)
             if new_hash and new_hash != self._last_config_hash:
                 self._last_config_hash = new_hash
                 self.bar_manager.config_modified.emit()
+                logging.debug(f"Config file modified: {event.src_path}")
+        elif normalized_path in self._imported_stylesheets and self.bar_manager.config["watch_stylesheet"]:
+            new_hash = self._file_hash(event.src_path)
+            if new_hash and self._imported_hashes.get(normalized_path) != new_hash:
+                self._imported_hashes[normalized_path] = new_hash
+                self._refresh_imported_stylesheets()
+                self.bar_manager.styles_modified.emit()
+                logging.debug(f"Imported stylesheet modified: {event.src_path}")
 
 
 def create_observer(bar_manager: BarManager):
     event_handler = FileModifiedEventHandler(bar_manager)
-    config_path = get_config_dir()
     observer = Observer()
-    observer.schedule(event_handler, path=config_path, recursive=False)
-    logging.info(f"Created file watcher for path {config_path}")
+    event_handler.set_observer(observer)
+    logging.info("Created file watcher")
     return observer


### PR DESCRIPTION
Watches for changes of all imported stylesheets. Handles imported styles being in different folders as well.

Sample output:
```
23:07:03,698     INFO: Watching directory: c:\users\rejdukien\.config\yasb
23:07:03,699     INFO: Watching directory: c:\users\rejdukien\.config\yasb\backup
23:07:03,699     INFO: Watching directory: c:\users\rejdukien\.config\someotherfolder
23:07:03,699     INFO: Created file watcher
23:07:27,581    DEBUG: Imported stylesheet modified: c:\users\rejdukien\.config\someotherfolder\someStylesheet.css
23:07:30,990    DEBUG: Stylesheet modified: c:\users\rejdukien\.config\yasb\styles.css
23:07:41,595    DEBUG: Imported stylesheet modified: c:\users\rejdukien\.config\yasb\backup\widget-copilot.css
```