### PR TITLE
feat(ai-chat): Add auto-resizing for input field

### DIFF
--- a/docs/widgets/(Widget)-Ai-Chat.md
+++ b/docs/widgets/(Widget)-Ai-Chat.md
@@ -431,7 +431,7 @@ If you want to use different styles for the context menu, you can target the `.a
     background-color: rgba(37, 37, 37, 0.4);
     border: 1px solid #3f3f3f;
     border-radius: 8px;
-    max-height: 32px;
+    max-height: 64px;
     min-height: 32px;
     padding: 5px 8px 3px 8px;
 }
@@ -440,8 +440,8 @@ If you want to use different styles for the context menu, you can target the `.a
     font-family: "Segoe UI Variable","Segoe UI";
     font-size: 14px;
     color: #ffffff;
-
 }
+
 .ai-chat-popup .chat-footer .chat-input-wrapper.focused {
     border-color: #0078d7;
 }

--- a/src/core/utils/widgets/ai_chat/ui_components.py
+++ b/src/core/utils/widgets/ai_chat/ui_components.py
@@ -191,10 +191,12 @@ class ChatInputEdit(ContextMenuMixin, QTextEdit):
         super().__init__(parent)
         self._is_streaming = False
         self.setProperty("class", "chat-input")
-        self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         self.setFrameShape(QTextEdit.Shape.NoFrame)
         self._init_context_menu(is_input_widget=True)
         self.textChanged.connect(self.text_changed.emit)
+        self.document().contentsChanged.connect(self.updateGeometry)
 
     def focusInEvent(self, event):
         super().focusInEvent(event)
@@ -227,6 +229,16 @@ class ChatInputEdit(ContextMenuMixin, QTextEdit):
             except Exception:
                 pass
         self.insertPlainText(source.text())
+
+    def sizeHint(self):
+        """Return size hint based on document content height"""
+        doc = self.document()
+        doc_height = int(doc.size().height())
+        return QSize(super().sizeHint().width(), doc_height)
+
+    def minimumSizeHint(self):
+        """Return minimum size hint based on document content height"""
+        return self.sizeHint()
 
 
 class ChatMessageBrowser(ContextMenuMixin, QTextBrowser):


### PR DESCRIPTION
Adds autosizing of the text input field, implemented by reusing the same approach used for the ChatMessageBrowser component. Allows it to grow/shrink based on min and max height set in the stylesheet.

Should be a small UX/QoL improvement.