### PR TITLE
refactor(ai-chat): replace model references with model_index

### DIFF
--- a/src/core/utils/widgets/ai_chat/chat_render.py
+++ b/src/core/utils/widgets/ai_chat/chat_render.py
@@ -35,7 +35,7 @@ class ChatRender:
                 widget.setParent(None)
                 widget.deleteLater()
 
-        history = self._owner._chat_session.get_history(self._owner._provider, self._owner._model)
+        history = self._owner._chat_session.get_history(self._owner._provider, self._owner._model_index)
 
         streaming_partial = None
         if self._owner._chat_session.stream.in_progress:

--- a/src/core/utils/widgets/ai_chat/input_controller.py
+++ b/src/core/utils/widgets/ai_chat/input_controller.py
@@ -59,7 +59,7 @@ class InputController:
         self._owner._append_message("user", ui_text)
         self._owner._chat_session.add_to_history(
             self._owner._provider,
-            self._owner._model,
+            self._owner._model_index,
             "user",
             payload_text,
             user_text=user_text,
@@ -92,7 +92,7 @@ class InputController:
             stopped_display = f"*{stopped_text}*"
         self._owner._stream_ui.stop_thinking_animation()
         self._owner._chat_session.stream.msg_label = None
-        history = self._owner._chat_session.get_history(self._owner._provider, self._owner._model)
+        history = self._owner._chat_session.get_history(self._owner._provider, self._owner._model_index)
         if not partial_text:
             for entry in reversed(history):
                 if entry.get("role") == "user" and not entry.get("stopped"):
@@ -101,7 +101,7 @@ class InputController:
         if not history or history[-1]["role"] != "assistant":
             entry = self._owner._chat_session.add_to_history(
                 self._owner._provider,
-                self._owner._model,
+                self._owner._model_index,
                 "assistant",
                 stopped_text,
             )

--- a/src/core/widgets/yasb/ai_chat.py
+++ b/src/core/widgets/yasb/ai_chat.py
@@ -51,6 +51,7 @@ class AiChatWidget(BaseWidget):
         self._provider = None
         self._provider_config = None
         self._model = None
+        self._model_index = None
         self._popup_chat = None
         self._animation = config.animation.model_dump()
         self._chat = config.chat.model_dump()
@@ -120,6 +121,8 @@ class AiChatWidget(BaseWidget):
         """Get the configuration for the current model"""
         if not (self._provider_config and self._provider_config.get("models")):
             return None
+        if self._model_index is not None and 0 <= self._model_index < len(self._provider_config["models"]):
+            return self._provider_config["models"][self._model_index]
         return next((m for m in self._provider_config["models"] if m["name"] == self._model), None)
 
     def _toggle_chat(self):
@@ -230,10 +233,7 @@ class AiChatWidget(BaseWidget):
             lambda: (
                 [
                     action.setChecked(
-                        any(
-                            action.data() == model_cfg["name"] and model_cfg["name"] == self._model
-                            for model_cfg in self._provider_config["models"]
-                        )
+                        action.data() == self._model_index
                         if self._provider_config and self._provider_config.get("models")
                         else False
                     )
@@ -485,8 +485,8 @@ class AiChatWidget(BaseWidget):
         self.chat_layout.insertWidget(insert_pos, row)
 
     def _on_clear_chat(self):
-        self._chat_session.clear_history(self._provider, self._model)
-        self._stream_worker_manager.reset_copilot_session(self._provider, self._model)
+        self._chat_session.clear_history(self._provider, self._model_index)
+        self._stream_worker_manager.reset_copilot_session(self._provider, self._model_index)
         self._chat_render.render_chat_history()
         self._attachments = []
         self._attachment_manager.refresh_attachments_ui()


### PR DESCRIPTION
Replaces direct model references with model_index. This allows the user to use the same provider+model multiple times, one such use-case would be to use the same model with different instructions.