### PR TITLE
feat(media): add open_media_source callback option

### DIFF
--- a/docs/widgets/(Widget)-Media.md
+++ b/docs/widgets/(Widget)-Media.md
@@ -169,6 +169,7 @@ media:
 - `toggle_label`: Toggles the visibility of the label.
 - `toggle_play_pause`: Toggles between play and pause states.
 - `toggle_media_menu`: Toggles the visibility of the media menu popup.
+- `open_media_source`: Opens the the source that is playing the media.
 - `do_nothing`: A placeholder callback that does nothing when triggered.
 
 ## Description of Options


### PR DESCRIPTION
### Description
This PR addresses [Discussion #683](https://github.com/amnweb/yasb/discussions/683) to add a callback option to the Media Widget to open/activate the application currently playing media by clicking the widget.

### Changes
* `docs/widgets/(Widget)-Media.md`: Added `open_media_source` to callback documentation.
* `src/core/utils/win32/aumid.py`: Added `activate_app_by_aumid(aumid: str)` utility function. This uses `EnumWindows` to find the window handle (`HWND`) associated with a given App User Model ID (`AUMID`) and brings it to the foreground.
* `src/core/widgets/yasb/media.py`: 
    * Imported `activate_app_by_aumid`.
    * Added `_open_media_source` callback method.
    * Registered `open_media_source` as a valid callback string.

### Configuration
Users can now configure this action in their `config.yaml`:

```yaml
widgets:
  media:
    options:
      callbacks:
        on_left: "toggle_media_menu"
        on_middle: "toggle_play_pause"
        on_right: "open_media_source"
```

### Rationale
While `source_apps.py` exists for mapping AUMIDs to display names, it does not provide window handles. The new `activate_app_by_aumid` function fills this gap by dynamically finding the window owned by the media source's `AUMID`, for activating any media application.

If any tweaks are needed, or if I'm taking the wrong approach, I would love to hear the feedback to help out!