### PR TITLE
refactor(wifi): move wifi fetch into a thread

### DIFF
--- a/docs/widgets/(Widget)-WiFi.md
+++ b/docs/widgets/(Widget)-WiFi.md
@@ -108,7 +108,6 @@ wifi:
 ```css
 .wifi-menu {}
 .wifi-menu .progress-bar {}
-.wifi-menu .progress-bar::chunk {}
 .wifi-menu .header {}
 .wifi-menu .error-message {}
 .wifi-menu .wifi-list {}
@@ -144,10 +143,7 @@ wifi:
 
 .wifi-menu .progress-bar {
     max-height: 2px;
-}
-
-.wifi-menu .progress-bar::chunk {
-    background-color: #4cc2ff;
+    color: #4cc2ff;
 }
 
 .wifi-menu .header {

--- a/src/core/utils/widgets/wifi/wifi_widgets.py
+++ b/src/core/utils/widgets/wifi/wifi_widgets.py
@@ -21,7 +21,6 @@ from PyQt6.QtWidgets import (
     QLabel,
     QLineEdit,
     QMenu,
-    QProgressBar,
     QPushButton,
     QScrollArea,
     QSizePolicy,
@@ -31,7 +30,7 @@ from PyQt6.QtWidgets import (
 )
 from winrt.windows.devices.wifi import WiFiConnectionStatus
 
-from core.utils.utilities import PopupWidget, is_valid_qobject, refresh_widget_style
+from core.utils.utilities import LoaderLine, PopupWidget, is_valid_qobject, refresh_widget_style
 from core.utils.widgets.wifi.wifi_managers import (
     NetworkInfo,
     ScanResultStatus,
@@ -455,12 +454,10 @@ class WifiMenu(QObject):
         header_label = QLabel("WiFi Networks")
         header_label.setProperty("class", "header")
 
-        self.menu_progress_bar = QProgressBar(self.popup_window)
-        self.menu_progress_bar.setRange(0, 0)  # Undetermined progress bar
-        self.menu_progress_bar.setTextVisible(False)
-        self.menu_progress_bar.setContentsMargins(0, 0, 0, 0)
-        self.menu_progress_bar.setProperty("class", "progress-bar")
+        self.menu_progress_bar = LoaderLine(self.popup_window)
+        self.menu_progress_bar.configure(class_name="progress-bar", segment_ratio=0.40)
         self.menu_progress_bar.setHidden(True)
+        self.menu_progress_bar.start()
 
         self.error_message = ClickableLabel(self.popup_window)
         self.error_message.setAlignment(Qt.AlignmentFlag.AlignCenter)

--- a/src/core/utils/widgets/wifi/wifi_widgets.py
+++ b/src/core/utils/widgets/wifi/wifi_widgets.py
@@ -2,7 +2,7 @@ import logging
 import os
 from dataclasses import replace
 from functools import partial
-from typing import Any, override
+from typing import override
 
 from PyQt6.QtCore import (
     QEvent,
@@ -40,7 +40,8 @@ from core.utils.widgets.wifi.wifi_managers import (
     WiFiManager,
     WifiState,
 )
-from core.utils.win32.utilities import apply_qmenu_style  # type: ignore
+from core.utils.win32.utilities import apply_qmenu_style
+from core.validation.widgets.yasb.wifi import WifiMenuConfig  # type: ignore
 
 logger = logging.getLogger("wifi_widget")
 
@@ -418,7 +419,7 @@ class WifiMenu(QObject):
     def __init__(
         self,
         parent: QWidget,
-        menu_config: dict[str, Any],
+        menu_config: WifiMenuConfig,
     ):
         super().__init__(parent)
         self._parent = parent
@@ -441,10 +442,10 @@ class WifiMenu(QObject):
     def show_menu(self):
         self.popup_window = PopupWidget(
             self._parent,
-            self.menu_config["blur"],
-            self.menu_config["round_corners"],
-            self.menu_config["round_corners_type"],
-            self.menu_config["border_color"],
+            self.menu_config.blur,
+            self.menu_config.round_corners,
+            self.menu_config.round_corners_type,
+            self.menu_config.border_color,
         )
         self.popup_window.setProperty("class", "wifi-menu")
         main_layout = QVBoxLayout(self.popup_window)
@@ -503,10 +504,10 @@ class WifiMenu(QObject):
 
         self.popup_window.adjustSize()
         self.popup_window.setPosition(
-            alignment=self.menu_config["alignment"],
-            direction=self.menu_config["direction"],
-            offset_left=self.menu_config["offset_left"],
-            offset_top=self.menu_config["offset_top"],
+            alignment=self.menu_config.alignment,
+            direction=self.menu_config.direction,
+            offset_left=self.menu_config.offset_left,
+            offset_top=self.menu_config.offset_top,
         )
 
         self.popup_window.destroyed.connect(self._on_wifi_menu_deleted)  # pyright: ignore[reportUnknownMemberType]
@@ -749,9 +750,9 @@ class WifiMenu(QObject):
         """Get the WiFi icon based on the signal strength"""
         level = min(strength // 25, 3)
         if secured:
-            return self.menu_config["wifi_icons_secured"][level]
+            return self.menu_config.wifi_icons_secured[level]
         else:
-            return self.menu_config["wifi_icons_unsecured"][level]
+            return self.menu_config.wifi_icons_unsecured[level]
 
     def _run_and_hide(self, command: str) -> None:
         """Run a command and hide the popup window if exists"""


### PR DESCRIPTION
- moves winrt wifi bars fetching into a thread
- fixes main thread stutters on wifi bars fetch
- precise wifi quality is also fetched in a the same thread
- `menu_config` is now passed as pydantic model, not a dict
- updated wifi popup to the new LoaderLine progress bar
- updated docs for the new progress bar