### PR TITLE
fix(validation): power menu button order fix

### DIFF
--- a/src/core/validation/utilities.py
+++ b/src/core/validation/utilities.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+from pydantic import BaseModel, PrivateAttr, model_validator
+
+
+class PreserveOrderMixin(BaseModel):
+    """Mixin that can be added (first) to a Model to preserve dictionary order from the original data"""
+
+    _input_order: list[str] = PrivateAttr(default_factory=list)
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _preserve_input_order(cls, data: Any, handler: Any) -> Any:
+        detected_order = list(data.keys()) if isinstance(data, dict) else []  # type: ignore
+        instance = handler(data)
+        if detected_order and isinstance(instance, cls):
+            instance._input_order = detected_order
+        return instance
+
+    def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+        result = super().model_dump(**kwargs)
+        if self._input_order:
+            return {k: result[k] for k in self._input_order if k in result}
+        return result

--- a/src/core/validation/widgets/yasb/power_menu.py
+++ b/src/core/validation/widgets/yasb/power_menu.py
@@ -1,5 +1,6 @@
 from pydantic import Field
 
+from core.validation.utilities import PreserveOrderMixin
 from core.validation.widgets.base_model import (
     CustomBaseModel,
     KeybindingConfig,
@@ -8,7 +9,7 @@ from core.validation.widgets.base_model import (
 )
 
 
-class PowerMenuButtonsConfig(CustomBaseModel):
+class PowerMenuButtonsConfig(PreserveOrderMixin, CustomBaseModel):
     lock: list[str] | None = None
     signout: list[str] | None = None
     sleep: list[str] | None = None


### PR DESCRIPTION
- added pydantic mixin to preserve dict order from yaml
- fixed buttons ordering issues for power menu