### PR TITLE
feat(taskbar): enhance visibility policy for cloaked windows

### DIFF
--- a/src/core/utils/widgets/taskbar/application_window.py
+++ b/src/core/utils/widgets/taskbar/application_window.py
@@ -83,6 +83,7 @@ class ApplicationWindow:
             "hwnd": self.hwnd,
             "title": self.title,
             "class_name": self.class_name,
+            "is_cloaked": self._is_cloaked(),
             "is_active": self.is_active,
             "is_flashing": self.is_flashing,
             "monitor_handle": monitor_handle,

--- a/src/core/widgets/yasb/taskbar.py
+++ b/src/core/widgets/yasb/taskbar.py
@@ -1220,6 +1220,10 @@ class TaskbarWidget(BaseWidget):
         if proc is None:
             return False
 
+        # Per-widget visibility policy: hide cloaked windows when show_only_visible is enabled.
+        if self._show_only_visible and bool(window_data.get("is_cloaked", False)):
+            return False
+
         if self.config.monitor_exclusive:
             window_monitor = window_data.get("monitor_handle")
             # If monitor is unknown (transient), keep existing items but do not add new ones


### PR DESCRIPTION
- Implement per-widget visibility policy to hide cloaked windows when show_only_visible is enabled.
- Update ApplicationWindow to include cloaked state in its dictionary representation.
- Refactor TaskbarWindowManager to maintain tracking of cloaked windows for independent visibility management.