### PR TITLE
Fix taskbar icon clipping on non-integer DPI scaling

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ from sys import argv
 from types import TracebackType
 
 import qasync
+from PyQt6.QtCore import Qt
 
 import settings
 from core.application import YASBApplication
@@ -88,6 +89,7 @@ def single_instance_lock(name: str = "yasb_reborn"):
 
 def main():
     """Main entry point"""
+    YASBApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
     app = YASBApplication(argv)
     asyncio.run(main_async(app), loop_factory=qasync.QEventLoop)
 


### PR DESCRIPTION
## Problem

Taskbar widget app icons are clipped ~20-30% on the right side when Windows display scaling is set to a non-integer value (125%, 150%, 175%). The clipping ratio stays constant regardless of `icon_size` config or CSS padding changes, indicating the issue is in Qt's rendering pipeline rather than the stylesheet layer.

**Environment:** Windows 11, 150% display scaling (AppliedDPI=144), YASB v1.8.9

## Root Cause

Qt6's default `HighDpiScaleFactorRoundingPolicy` rounds non-integer scale factors (e.g. 1.5x), causing a mismatch between:
- The `QLabel.setFixedSize(icon_size, icon_size)` logical dimensions
- The DPI-scaled `QPixmap` render bounds (sized at `int(icon_size * dpi)` with `setDevicePixelRatio(dpi)`)

This results in the pixmap being painted wider than the label's allocated content rect, clipping the right edge.

## Fix

Set `Qt.HighDpiScaleFactorRoundingPolicy.PassThrough` before `QApplication` creation, telling Qt to use the exact scale factor without rounding. This is a 2-line change in `src/main.py`.

## Testing

- Verified on Windows 11 at 150% scaling — icons render fully without clipping
- No visual regression at 100% scaling (PassThrough is a no-op for integer factors)
- Confirmed the env var equivalent (`QT_SCALE_FACTOR_ROUNDING_POLICY=PassThrough`) resolves the issue before applying the code fix

Fixes #431