### PR TITLE
feat(power_menu): add profile_image_size property for avatar resizing

### DIFF
--- a/docs/widgets/(Widget)-Power-Menu.md
+++ b/docs/widgets/(Widget)-Power-Menu.md
@@ -11,17 +11,10 @@
 | `button_row`        | integer | `3`         | The number of buttons in a row. Must be between 1 and 6. (fullscreen mode only) |
 | `menu_style`        | string  | `"fullscreen"` | The menu display style: `"fullscreen"` for full-screen overlay or `"popup"` for compact popup anchored to the bar button. |
 | `popup`             | dict    | see below   | Popup appearance/position options. Only used when `menu_style` is `"popup"`. |
-| `profile_size`      | dict    | see below   | Profile avatar size options for fullscreen and menu modes.                   |
+| `profile_image_size`| integer | `64`        | Profile avatar size in pixels. Must be between 16 and 256.                    |
 | `buttons`           | dict    | `{}`        | A dictionary defining the buttons and their properties.                     |
 | `container_shadow`  | dict    | `None`      | Container shadow options.                                                   |
 | `label_shadow`      | dict    | `None`      | Label shadow options.                                                       |
-
-### Profile Size Options
-
-| Option              | Type    | Default     | Description                                                                 |
-|---------------------|---------|-------------|-----------------------------------------------------------------------------|
-| `fullscreen`       | integer | `64`        | Avatar size in fullscreen mode. Must be between 16 and 256.                  |
-| `popup`            | integer | `48`        | Avatar size in popup menu mode. Must be between 16 and 256.                 |
 
 ### Popup Options (when `menu_style: "popup"`)
 
@@ -65,9 +58,7 @@ power_menu:
     blur_background: true
     animation_duration: 120 # Milliseconds
     button_row: 3 # Number of buttons in a row, min 1 max 6
-    profile_size:
-      fullscreen: 80 # Avatar size in fullscreen mode
-      popup: 48 # Avatar size in popup mode
+    profile_image_size: 80 # Avatar size in pixels
     buttons:
       restart: ["\uead2", "Restart"]
       shutdown: ["\uf011", "Shut Down"]
@@ -101,9 +92,7 @@ power_menu:
       direction: "down"
       offset_top: 6
       offset_left: 0
-    profile_size:
-      fullscreen: 64
-      popup: 64 # Larger avatar in popup mode
+    profile_image_size: 64
     buttons:
       lock: ["\uea75", "Lock"]
       signout: ["\udb80\udf43", "Sign out"]
@@ -124,7 +113,7 @@ power_menu:
 - **button_row:** The number of buttons in a row. Must be between 1 and 6. (fullscreen mode only)
 - **menu_style:** The menu display style. `"fullscreen"` shows a centered dialog with full-screen overlay (default behavior). `"popup"` shows a compact dropdown popup anchored to the bar button.
 - **popup:** Popup configuration (blur, round_corners, alignment, direction, offsets). Only used when `menu_style` is `"popup"`.
-- **profile_size:** Profile avatar size options. `fullscreen` sets the avatar size in fullscreen mode, `popup` sets the avatar size in popup mode. Must be between 16 and 256.
+- **profile_image_size:** Profile avatar size in pixels. Must be between 16 and 256.
 - **buttons:** A dictionary defining the buttons and their properties. Possible properties are: `lock`, `signout`, `sleep`, `shutdown`, `restart`, `hibernate`, `cancel`, `force_shutdown`, `force_restart`. Note: `cancel` button is not shown in popup mode since the popup auto-closes on outside click.
 - **container_shadow:** Container shadow options.
 - **label_shadow:** Label shadow options.

--- a/src/core/validation/widgets/yasb/power_menu.py
+++ b/src/core/validation/widgets/yasb/power_menu.py
@@ -34,11 +34,6 @@ class PowerMenuPopupConfig(CustomBaseModel):
     offset_left: int = 0
 
 
-class ProfileSizeConfig(CustomBaseModel):
-    fullscreen: int = Field(default=64, ge=16, le=256)
-    popup: int = Field(default=48, ge=16, le=256)
-
-
 class PowerMenuConfig(CustomBaseModel):
     label: str = "power"
     uptime: bool = True
@@ -49,7 +44,7 @@ class PowerMenuConfig(CustomBaseModel):
     button_row: int = Field(default=3, ge=1, le=6)
     menu_style: Literal["fullscreen", "popup"] = "fullscreen"
     popup: PowerMenuPopupConfig = PowerMenuPopupConfig()
-    profile_size: ProfileSizeConfig = ProfileSizeConfig()
+    profile_image_size: int = Field(default=64, ge=16, le=256)
     container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()

--- a/src/core/widgets/yasb/power_menu.py
+++ b/src/core/widgets/yasb/power_menu.py
@@ -229,7 +229,7 @@ class PowerMenuWidget(BaseWidget):
                 self.config.button_row,
                 self.config.buttons.model_dump(exclude_none=True),
                 self.config.show_user,
-                self.config.profile_size.fullscreen,
+                self.config.profile_image_size,
             )
             self.main_window.overlay.fade_in()
             self.main_window.overlay.show()
@@ -261,7 +261,7 @@ class PowerMenuWidget(BaseWidget):
             avatar_label = QLabel()
             avatar_label.setProperty("class", "profile-avatar")
             avatar_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            avatar_size = self.config.profile_size.popup
+            avatar_size = self.config.profile_image_size
             avatar_label.setFixedSize(avatar_size, avatar_size)
             avatar_path = _get_user_avatar_path()
             if avatar_path:


### PR DESCRIPTION
Add `profile_image_size` property to resize profile avatar size for `power_menu` widget affecting both modes.