### PR TITLE
feat(popup): add animation_duration config for popup/card widgets

### DIFF
--- a/src/core/utils/utilities.py
+++ b/src/core/utils/utilities.py
@@ -556,6 +556,7 @@ class PopupWidget(QWidget):
         round_corners_type: str = "normal",
         border_color: str = "None",
         dark_mode: bool = False,
+        animation_duration: int = 80,
     ):
         super().__init__(parent)
 
@@ -579,7 +580,7 @@ class PopupWidget(QWidget):
         self._popup_content = QFrame(self)
 
         self._fade_animation = QPropertyAnimation(self, b"windowOpacity")
-        self._fade_animation.setDuration(80)
+        self._fade_animation.setDuration(animation_duration)
         self._fade_animation.finished.connect(self._on_animation_finished)
 
         self._is_closing = False

--- a/src/core/validation/widgets/komorebi/active_layout.py
+++ b/src/core/validation/widgets/komorebi/active_layout.py
@@ -34,6 +34,7 @@ class ActiveLayoutMenuConfig(CustomBaseModel):
     direction: str = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     show_layout_icons: bool = True
 
 

--- a/src/core/validation/widgets/komorebi/control.py
+++ b/src/core/validation/widgets/komorebi/control.py
@@ -25,6 +25,7 @@ class KomorebiMenuConfig(CustomBaseModel):
     direction: str = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
 
 
 class KomorebiControlCallbacksConfig(CallbacksConfig):

--- a/src/core/validation/widgets/yasb/brightness.py
+++ b/src/core/validation/widgets/yasb/brightness.py
@@ -23,6 +23,7 @@ class BrightnessMenuConfig(CustomBaseModel):
     distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
 
 
 class ProgressBarConfig(CustomBaseModel):

--- a/src/core/validation/widgets/yasb/clock.py
+++ b/src/core/validation/widgets/yasb/clock.py
@@ -23,6 +23,7 @@ class ClockCalendarConfig(CustomBaseModel):
     distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     country_code: str | None = None
     subdivision: str | None = None
     show_holidays: bool = False

--- a/src/core/validation/widgets/yasb/copilot.py
+++ b/src/core/validation/widgets/yasb/copilot.py
@@ -26,6 +26,7 @@ class CopilotMenuConfig(CustomBaseModel):
     direction: str = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     chart: bool = True
 
 

--- a/src/core/validation/widgets/yasb/disk.py
+++ b/src/core/validation/widgets/yasb/disk.py
@@ -30,6 +30,7 @@ class GroupLabelConfig(CustomBaseModel):
     distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
 
 
 class ProgressBarConfig(CustomBaseModel):

--- a/src/core/validation/widgets/yasb/github.py
+++ b/src/core/validation/widgets/yasb/github.py
@@ -36,6 +36,7 @@ class GithubMenuConfig(CustomBaseModel):
     direction: str = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     show_categories: bool = False
     categories_order: list[str] = [
         "PullRequest",

--- a/src/core/validation/widgets/yasb/home.py
+++ b/src/core/validation/widgets/yasb/home.py
@@ -50,6 +50,7 @@ class HomeConfig(CustomBaseModel):
     distance: int = 6
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     menu_labels: MenuLabelsConfig = MenuLabelsConfig()
     animation: AnimationConfig = AnimationConfig()
     label_shadow: ShadowConfig = ShadowConfig()

--- a/src/core/validation/widgets/yasb/language.py
+++ b/src/core/validation/widgets/yasb/language.py
@@ -19,6 +19,7 @@ class LanguageMenuConfig(CustomBaseModel):
     direction: str = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     layout_icon: str = "\uf11c"
     show_layout_icon: bool = True
 

--- a/src/core/validation/widgets/yasb/libre_monitor.py
+++ b/src/core/validation/widgets/yasb/libre_monitor.py
@@ -24,6 +24,7 @@ class LibreMenuConfig(CustomBaseModel):
     direction: str = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     header_label: str = "YASB HW Monitor"
     precision: int = 2
     columns: int = 1

--- a/src/core/validation/widgets/yasb/media.py
+++ b/src/core/validation/widgets/yasb/media.py
@@ -37,6 +37,7 @@ class MediaMenuConfig(CustomBaseModel):
     direction: Literal["up", "down"] = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     thumbnail_size: int = 100
     thumbnail_corner_radius: int = 8
     max_title_size: int = 150

--- a/src/core/validation/widgets/yasb/microphone.py
+++ b/src/core/validation/widgets/yasb/microphone.py
@@ -26,6 +26,7 @@ class MicMenuConfig(CustomBaseModel):
     direction: str = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
 
 
 class ProgressBarConfig(CustomBaseModel):

--- a/src/core/validation/widgets/yasb/notes.py
+++ b/src/core/validation/widgets/yasb/notes.py
@@ -19,6 +19,7 @@ class MenuConfig(CustomBaseModel):
     direction: str = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     max_title_size: int = 150
     show_date_time: bool = True
 

--- a/src/core/validation/widgets/yasb/open_meteo.py
+++ b/src/core/validation/widgets/yasb/open_meteo.py
@@ -61,6 +61,7 @@ class OpenMeteoCardConfig(CustomBaseModel):
     direction: str = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     icon_size: int = 64
     show_hourly_forecast: bool = False
     time_format: Literal["12h", "24h"] = "24h"

--- a/src/core/validation/widgets/yasb/pomodoro.py
+++ b/src/core/validation/widgets/yasb/pomodoro.py
@@ -27,6 +27,7 @@ class MenuConfig(CustomBaseModel):
     direction: str = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     circle_background_color: str = "#09ffffff"
     circle_work_progress_color: str = "#a6e3a1"
     circle_break_progress_color: str = "#89b4fa"

--- a/src/core/validation/widgets/yasb/power_menu.py
+++ b/src/core/validation/widgets/yasb/power_menu.py
@@ -32,6 +32,7 @@ class PowerMenuPopupConfig(CustomBaseModel):
     direction: str = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
 
 
 class PowerMenuConfig(CustomBaseModel):

--- a/src/core/validation/widgets/yasb/power_plan.py
+++ b/src/core/validation/widgets/yasb/power_plan.py
@@ -20,6 +20,7 @@ class PowerPlanMenuConfig(CustomBaseModel):
     direction: Literal["up", "down"] = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
 
 
 class PowerPlanCallbacksConfig(CallbacksConfig):

--- a/src/core/validation/widgets/yasb/quick_launch.py
+++ b/src/core/validation/widgets/yasb/quick_launch.py
@@ -20,6 +20,7 @@ class QuickLaunchPopupConfig(CustomBaseModel):
     border_color: str = "System"
     dark_mode: bool = True
     screen: Literal["primary", "focus", "cursor"] = "focus"
+    animation_duration: int = 80
 
 
 class QuickLaunchCallbacksConfig(CallbacksConfig):

--- a/src/core/validation/widgets/yasb/server_monitor.py
+++ b/src/core/validation/widgets/yasb/server_monitor.py
@@ -25,6 +25,7 @@ class MenuConfig(CustomBaseModel):
     distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
 
 
 class IconsConfig(CustomBaseModel):

--- a/src/core/validation/widgets/yasb/todo.py
+++ b/src/core/validation/widgets/yasb/todo.py
@@ -37,6 +37,7 @@ class MenuConfig(CustomBaseModel):
     direction: str = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
 
 
 class CallbacksTodoConfig(CallbacksConfig):

--- a/src/core/validation/widgets/yasb/traffic.py
+++ b/src/core/validation/widgets/yasb/traffic.py
@@ -24,6 +24,7 @@ class MenuConfig(CustomBaseModel):
     direction: str = "down"
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     show_interface_name: bool = True
     show_internet_info: bool = True
 

--- a/src/core/validation/widgets/yasb/volume.py
+++ b/src/core/validation/widgets/yasb/volume.py
@@ -25,6 +25,7 @@ class AudioMenuConfig(CustomBaseModel):
     distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     show_apps: bool = False
     show_app_labels: bool = False
     show_app_icons: bool = True

--- a/src/core/validation/widgets/yasb/vscode.py
+++ b/src/core/validation/widgets/yasb/vscode.py
@@ -20,6 +20,7 @@ class VSCodeMenuConfig(CustomBaseModel):
     distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
 
 
 class CallbacksVSCodeConfig(CallbacksConfig):

--- a/src/core/validation/widgets/yasb/weather.py
+++ b/src/core/validation/widgets/yasb/weather.py
@@ -64,6 +64,7 @@ class WeatherCardConfig(CustomBaseModel):
     distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
+    animation_duration: int = 80
     icon_size: int = 64
     show_hourly_forecast: bool = False
     time_format: Literal["12h", "24h"] = "24h"

--- a/src/core/widgets/komorebi/active_layout.py
+++ b/src/core/widgets/komorebi/active_layout.py
@@ -118,6 +118,7 @@ class ActiveLayoutWidget(BaseWidget):
             self.config.layout_menu.round_corners,
             self.config.layout_menu.round_corners_type,
             self.config.layout_menu.border_color,
+            animation_duration=self.config.layout_menu.animation_duration,
         )
         self._menu.setProperty("class", "komorebi-layout-menu")
 

--- a/src/core/widgets/komorebi/control.py
+++ b/src/core/widgets/komorebi/control.py
@@ -131,6 +131,7 @@ class KomorebiControlWidget(BaseWidget):
             self.config.komorebi_menu.round_corners,
             self.config.komorebi_menu.round_corners_type,
             self.config.komorebi_menu.border_color,
+            animation_duration=self.config.komorebi_menu.animation_duration,
         )
         self.dialog.setProperty("class", "komorebi-control-menu")
 

--- a/src/core/widgets/yasb/brightness.py
+++ b/src/core/widgets/yasb/brightness.py
@@ -212,6 +212,7 @@ class BrightnessWidget(BaseWidget):
             self.config.brightness_menu.round_corners,
             self.config.brightness_menu.round_corners_type,
             self.config.brightness_menu.border_color,
+            animation_duration=self.config.brightness_menu.animation_duration,
         )
         self.dialog.setProperty("class", "brightness-menu")
 

--- a/src/core/widgets/yasb/clock.py
+++ b/src/core/widgets/yasb/clock.py
@@ -713,6 +713,7 @@ class ClockWidget(BaseWidget):
             self.config.calendar.round_corners,
             self.config.calendar.round_corners_type,
             self.config.calendar.border_color,
+            animation_duration=self.config.calendar.animation_duration,
         )
         self._yasb_calendar.setProperty("class", "clock-popup calendar")
 
@@ -1020,6 +1021,7 @@ class ClockWidget(BaseWidget):
             self.config.calendar.round_corners,
             self.config.calendar.round_corners_type,
             self.config.calendar.border_color,
+            animation_duration=self.config.calendar.animation_duration,
         )
         popup.setProperty("class", f"clock-popup {class_name}")
         return popup

--- a/src/core/widgets/yasb/copilot.py
+++ b/src/core/widgets/yasb/copilot.py
@@ -424,6 +424,7 @@ class CopilotWidget(BaseWidget):
             round_corners=self.config.menu.round_corners,
             round_corners_type=self.config.menu.round_corners_type,
             border_color=self.config.menu.border_color,
+            animation_duration=self.config.menu.animation_duration,
         )
         self._menu.setProperty("class", "copilot-menu")
 

--- a/src/core/widgets/yasb/disk.py
+++ b/src/core/widgets/yasb/disk.py
@@ -134,6 +134,7 @@ class DiskWidget(BaseWidget):
             self.config.group_label.round_corners,
             self.config.group_label.round_corners_type,
             self.config.group_label.border_color,
+            animation_duration=self.config.group_label.animation_duration,
         )
         self.dialog.setProperty("class", "disk-group")
 

--- a/src/core/widgets/yasb/github.py
+++ b/src/core/widgets/yasb/github.py
@@ -426,6 +426,7 @@ class GithubWidget(BaseWidget):
             self.config.menu.round_corners,
             self.config.menu.round_corners_type,
             self.config.menu.border_color,
+            animation_duration=self.config.menu.animation_duration,
         )
         self._menu.setProperty("class", "github-menu")
 

--- a/src/core/widgets/yasb/home.py
+++ b/src/core/widgets/yasb/home.py
@@ -85,6 +85,7 @@ class HomeWidget(BaseWidget):
             self.config.round_corners,
             self.config.round_corners_type,
             self.config.border_color,
+            animation_duration=self.config.animation_duration,
         )
         self._menu.setProperty("class", "home-menu")
 

--- a/src/core/widgets/yasb/language.py
+++ b/src/core/widgets/yasb/language.py
@@ -147,6 +147,7 @@ class LanguageWidget(BaseWidget):
             self.config.language_menu.round_corners,
             self.config.language_menu.round_corners_type,
             self.config.language_menu.border_color,
+            animation_duration=self.config.language_menu.animation_duration,
         )
         self._menu.setProperty("class", "language-menu")
 

--- a/src/core/widgets/yasb/libre_monitor.py
+++ b/src/core/widgets/yasb/libre_monitor.py
@@ -92,6 +92,7 @@ class LibreHardwareMonitorWidget(BaseWidget):
             self.config.libre_menu.round_corners,
             self.config.libre_menu.round_corners_type,
             self.config.libre_menu.border_color,
+            animation_duration=self.config.libre_menu.animation_duration,
         )
         self._menu.setProperty("class", "libre-menu")
 

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -226,6 +226,7 @@ class MediaWidget(BaseWidget):
             self.config.media_menu.round_corners,
             self.config.media_menu.round_corners_type,
             self.config.media_menu.border_color,
+            animation_duration=self.config.media_menu.animation_duration,
         )
 
         self.dialog.setProperty("class", "media-menu")

--- a/src/core/widgets/yasb/microphone.py
+++ b/src/core/widgets/yasb/microphone.py
@@ -281,6 +281,7 @@ class MicrophoneWidget(BaseWidget):
             self.config.mic_menu.round_corners,
             self.config.mic_menu.round_corners_type,
             self.config.mic_menu.border_color,
+            animation_duration=self.config.mic_menu.animation_duration,
         )
         self.dialog.setProperty("class", "microphone-menu")
 

--- a/src/core/widgets/yasb/notes.py
+++ b/src/core/widgets/yasb/notes.py
@@ -136,6 +136,7 @@ class NotesWidget(BaseWidget):
             self.config.menu.round_corners,
             self.config.menu.round_corners_type,
             self.config.menu.border_color,
+            animation_duration=self.config.menu.animation_duration,
         )
         self._menu.setProperty("class", "notes-menu")
 

--- a/src/core/widgets/yasb/open_meteo.py
+++ b/src/core/widgets/yasb/open_meteo.py
@@ -173,6 +173,7 @@ class OpenMeteoWidget(BaseWidget):
             self.config.weather_card.round_corners,
             self.config.weather_card.round_corners_type,
             self.config.weather_card.border_color,
+            animation_duration=self.config.weather_card.animation_duration,
         )
         self.dialog.setProperty("class", "open-meteo-card")
 

--- a/src/core/widgets/yasb/pomodoro.py
+++ b/src/core/widgets/yasb/pomodoro.py
@@ -385,6 +385,7 @@ class PomodoroWidget(BaseWidget):
             self.config.menu.round_corners,
             self.config.menu.round_corners_type,
             self.config.menu.border_color,
+            animation_duration=self.config.menu.animation_duration,
         )
 
         self._dialog.setProperty("class", "pomodoro-menu")

--- a/src/core/widgets/yasb/power_menu.py
+++ b/src/core/widgets/yasb/power_menu.py
@@ -244,6 +244,7 @@ class PowerMenuWidget(BaseWidget):
             popup_cfg.round_corners,
             popup_cfg.round_corners_type,
             popup_cfg.border_color,
+            animation_duration=popup_cfg.animation_duration,
         )
         self._popup.setProperty("class", "power-menu-compact")
 

--- a/src/core/widgets/yasb/power_plan.py
+++ b/src/core/widgets/yasb/power_plan.py
@@ -150,6 +150,7 @@ class PowerPlanWidget(BaseWidget):
             self.config.menu.round_corners,
             self.config.menu.round_corners_type,
             self.config.menu.border_color,
+            animation_duration=self.config.menu.animation_duration,
         )
         self._popup_menu.setProperty("class", "power-plan-menu")
 

--- a/src/core/widgets/yasb/quick_launch.py
+++ b/src/core/widgets/yasb/quick_launch.py
@@ -494,11 +494,11 @@ class QuickLaunchWidget(BaseWidget):
             round_corners_type=cfg.round_corners_type,
             border_color=cfg.border_color,
             dark_mode=cfg.dark_mode,
+            animation_duration=cfg.animation_duration,
         )
         popup.setProperty("class", "quick-launch-popup")
         popup._popup_content.setProperty("class", "container")
         popup.setFixedSize(cfg.width, cfg.height)
-        popup._fade_animation.setDuration(40)
         popup._fade_animation.finished.connect(self._on_popup_closed)
 
         main_layout = QVBoxLayout(popup._popup_content)

--- a/src/core/widgets/yasb/server_monitor.py
+++ b/src/core/widgets/yasb/server_monitor.py
@@ -219,6 +219,7 @@ class ServerMonitor(BaseWidget):
             self.config.menu.round_corners,
             self.config.menu.round_corners_type,
             self.config.menu.border_color,
+            animation_duration=self.config.menu.animation_duration,
         )
         self.dialog.setProperty("class", "server-menu")
 

--- a/src/core/widgets/yasb/todo.py
+++ b/src/core/widgets/yasb/todo.py
@@ -307,6 +307,7 @@ class TodoWidget(BaseWidget):
             self.config.menu.round_corners,
             self.config.menu.round_corners_type,
             self.config.menu.border_color,
+            animation_duration=self.config.menu.animation_duration,
         )
         self._menu.setProperty("class", "todo-menu")
 

--- a/src/core/widgets/yasb/traffic.py
+++ b/src/core/widgets/yasb/traffic.py
@@ -322,6 +322,7 @@ class TrafficWidget(BaseWidget):
             self.config.menu.round_corners,
             self.config.menu.round_corners_type,
             self.config.menu.border_color,
+            animation_duration=self.config.menu.animation_duration,
         )
         self._menu_widget.setProperty("class", "traffic-menu")
 

--- a/src/core/widgets/yasb/volume.py
+++ b/src/core/widgets/yasb/volume.py
@@ -317,6 +317,7 @@ class VolumeWidget(BaseWidget):
             self.config.audio_menu.round_corners,
             self.config.audio_menu.round_corners_type,
             self.config.audio_menu.border_color,
+            animation_duration=self.config.audio_menu.animation_duration,
         )
         self.dialog.setProperty("class", "audio-menu")
 

--- a/src/core/widgets/yasb/vscode.py
+++ b/src/core/widgets/yasb/vscode.py
@@ -149,6 +149,7 @@ class VSCodeWidget(BaseWidget):
             self.config.menu.round_corners,
             self.config.menu.round_corners_type,
             self.config.menu.border_color,
+            animation_duration=self.config.menu.animation_duration,
         )
         menu.setProperty("class", "vscode-menu")
         return menu

--- a/src/core/widgets/yasb/weather.py
+++ b/src/core/widgets/yasb/weather.py
@@ -115,6 +115,7 @@ class WeatherWidget(BaseWidget):
             self.config.weather_card.round_corners,
             self.config.weather_card.round_corners_type,
             self.config.weather_card.border_color,
+            animation_duration=self.config.weather_card.animation_duration,
         )
         self.dialog.setProperty("class", "weather-card")
 


### PR DESCRIPTION
## Summary
- Add `animation_duration` parameter to `PopupWidget` class (default: 80ms)
- Add `animation_duration` config to 24 widget popup/menu validation configs
- Update all PopupWidget instantiations to use custom animation duration

## Description
This PR implements the feature requested in issue #742 - allowing users to customize the fade animation duration for popup menus and cards across all widgets that support them.

## Changes
- **PopupWidget base class**: Added `animation_duration` parameter (default: 80ms) to control fade in/out animation duration
- **Validation configs**: Added `animation_duration: int = 80` to 24 popup/m **Widget implementations**:enu configs
- Updated all 26 PopupWidget instantiations to pass the animation_duration parameter

## Widgets Updated
clock, weather, open_meteo, volume, brightness, media, todo, notes, microphone, power_menu, disk, language, home, traffic, copilot, server_monitor, pomodoro, vscode, github, libre_monitor, power_plan, quick_launch, komorebi/control, komorebi/active_layout

## Usage Example
```yaml
widgets:
  - type: clock
    calendar:
      animation_duration: 150
  
  - type: weather
    weather_card:
      animation_duration: 200
```

## Related Issue
Fixes #742