### PR TITLE
feat(openmeteo): custom svg or png icons 

### DIFF
--- a/docs/widgets/(Widget)-Open-Meteo.md
+++ b/docs/widgets/(Widget)-Open-Meteo.md
@@ -61,6 +61,28 @@ Default icon mapping (using Nerd Font glyphs):
 | `thunderstormNight` | `\ue338`       | Thunderstorm (night)                          |
 | `default`           | `\uebaa`       | Unknown/fallback                              |
 
+## Custom Icons for Popup Menu
+
+You can use custom PNG or SVG icons for the weather card popup and hourly forecast. The widget checks for custom icons in your configuration directory before falling back to the default SVGs.
+
+To use custom icons, place your files in:
+`C:/Users/{username}/.config/yasb/icons/openmeteo/`
+
+The file names must match the following icon keys (with `.png` or `.svg` extension):
+
+*   `sunnyDay`, `clearNight`
+*   `cloudyDay`, `cloudyNight`
+*   `foggyDay`, `foggyNight`
+*   `drizzleDay`, `drizzleNight`
+*   `rainyDay`, `rainyNight`
+*   `snowyDay`, `snowyNight`
+*   `thunderstormDay`, `thunderstormNight`
+*   `default`
+
+For example, `sunnyDay.png` or `sunnyDay.svg` in that folder will override the default icon for clear skies.
+
+> **Note**: Custom icons are cached in memory. If you add or change your custom icon files, you will need to **restart YASB** for the changes to take effect.
+
 ## Minimal Configuration
 
 ```yaml

--- a/src/core/widgets/yasb/open_meteo.py
+++ b/src/core/widgets/yasb/open_meteo.py
@@ -36,7 +36,7 @@ from core.utils.widgets.open_meteo.widgets import (
     HourlyData,
     HourlyDataLineWidget,
     HourlyTemperatureScrollArea,
-    render_svg_to_pixmap,
+    get_weather_icon_pixmap,
 )
 from core.validation.widgets.yasb.open_meteo import OpenMeteoWidgetConfig
 from core.widgets.base import BaseWidget
@@ -498,12 +498,12 @@ class OpenMeteoWidget(BaseWidget):
             layout_day.setAlignment(Qt.AlignmentFlag.AlignCenter)
             frame_day.setLayout(layout_day)
 
-            # 1. SVG icon
+            # 1. Weather icon
             row_day_icon_label = QLabel()
             day_code = self._weather_data.get(f"{{day{i}_weather_code}}", 0)
-            svg_str, _, _ = get_weather_icon(int(day_code), True)
+            _, icon_key, _ = get_weather_icon(int(day_code), True)
             dpr = row_day_icon_label.devicePixelRatioF()
-            pixmap = render_svg_to_pixmap(svg_str, self.config.weather_card.icon_size, dpr)
+            pixmap = get_weather_icon_pixmap(icon_key, self.config.weather_card.icon_size, dpr)
             row_day_icon_label.setPixmap(pixmap)
             row_day_icon_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             layout_day.addWidget(row_day_icon_label)


### PR DESCRIPTION
- search for custom icons in `.config/yasb/icons/openmeteo`
- if icons matching the keys are found, use them
- fixed scaling for svg icons