### PR TITLE
feat(update check): Adds optional Windows Update popup menu

### DIFF
--- a/docs/widgets/(Widget)-Update-Check.md
+++ b/docs/widgets/(Widget)-Update-Check.md
@@ -18,6 +18,8 @@ This widget checks for available updates using Windows Update, Winget, and Scoop
 | `tooltip`       | boolean | `true`     | Whether to show the tooltip on hover.                        |
 | `interval`      | integer | `1440`     | Check interval in minutes (30 to 10080).                     |
 | `exclude`       | list    | `[]`       | List of updates to exclude (matched against name).           |
+| `show_popup_menu` | boolean    | `false`  | Whether to show a popup menu on left click. This allows the user to choose between opening Windows Update in Settings or executing a command (with a UAC elevation prompt) to directly update Windows Defender Virus' security intelligence updates. |
+| `popup_menu_padding` | integer | `8`   | Padding (in pixels) around the menu items if `show_popup_menu: true`. (Valid range: 0 - 80) |
 
 ### Winget Update Options
 
@@ -92,6 +94,14 @@ update_check:
 .update-check-widget .widget-container.paired-right {}
 .update-check-widget .label {}
 .update-check-widget .icon {}
+/* Styles for the new optional Windows Update popup menu */
+.widget-container.windows.menu-popup {}
+.widget-container.windows.menu-popup .menu-item {}
+.widget-container.windows.menu-popup .menu-item:hover {}
+.widget-container.windows.menu-popup .menu-item .icon {}
+.widget-container.windows.menu-popup .menu-item .label {}
+.widget-container.windows.menu-popup .menu-item:hover .icon {}
+.widget-container.windows.menu-popup .menu-item:hover .label {}
 ```
 
 ### State Classes
@@ -168,4 +178,36 @@ Example:
     font-weight: 600;
     font-size: 14px;
 } 
+/* Styles for the new optional Windows Update popup menu */
+.widget-container.windows.menu-popup {
+    background-color: var(--surface0);
+    border-radius: 4px;
+}
+
+.widget-container.windows.menu-popup .menu-item {
+    background-color: var(--surface1);
+    border-radius: 4px;
+    padding: 4px;
+}
+
+.widget-container.windows.menu-popup .menu-item:hover {
+    background-color: var(--surface2);
+}
+
+.widget-container.windows.menu-popup .menu-item .icon {
+    color: var(--text);
+    font-size: 16px;
+    min-width: 20px;
+}
+
+.widget-container.windows.menu-popup .menu-item .label {
+    color: var(--text);
+    font-size: 13px;
+    font-weight: 400;
+}
+
+.widget-container.windows.menu-popup .menu-item:hover .icon,
+.widget-container.windows.menu-popup .menu-item:hover .label {
+    color: var(--text);
+}
 ```

--- a/src/core/validation/widgets/yasb/update_check.py
+++ b/src/core/validation/widgets/yasb/update_check.py
@@ -12,6 +12,8 @@ class UpdateConfig(CustomBaseModel):
 
 class WindowsUpdateConfig(UpdateConfig):
     interval: int = Field(default=1440, ge=30, le=10080)
+    show_popup_menu: bool = False
+    popup_menu_padding: int = Field(default=8, ge=0, le=80)
 
 
 class WingetUpdateConfig(UpdateConfig):

--- a/src/core/widgets/yasb/update_check.py
+++ b/src/core/widgets/yasb/update_check.py
@@ -1,13 +1,20 @@
+import logging
+import os
 import re
+from ctypes import windll
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel
+from PyQt6.QtGui import QCursor, QPixmap
+from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QVBoxLayout
 
 from core.utils.tooltip import set_tooltip
-from core.utils.utilities import add_shadow, refresh_widget_style
+from core.utils.utilities import PopupWidget, add_shadow, is_valid_qobject, refresh_widget_style
+from core.utils.widgets.animation_manager import AnimationManager
 from core.utils.widgets.update_check.service import UpdateCheckService
 from core.validation.widgets.yasb.update_check import UpdateCheckWidgetConfig
 from core.widgets.base import BaseWidget
+
+logger = logging.getLogger("UpdateCheckWidget")
 
 # Sources and their config attribute names
 _SOURCES = ("winget", "scoop", "windows")
@@ -24,12 +31,37 @@ class UpdateCheckWidget(BaseWidget):
         self._label_widgets: dict[str, list[QLabel]] = {}
         self._counts: dict[str, int] = {}
 
+        # Create a variable for the popup
+        self._popup = None
+
+        # Variables in the WindowsUpdateConfig that will be populated via "for source in _SOURCES" below
+        self._show_popup_menu = False
+        self._popup_menu_padding = 0  # Default value will be set via the WindowsUpdateConfig
+
+        # These are the two hard-coded menu items to show in the popup - just the metadata - the execution commands happen below
+        self._popup_menu_items = [
+            {"icon": "\ue62a", "launch": "windows_update", "name": "Open Windows Update"},
+            {"icon": "\udb84\udfb6", "launch": "update_virus_defs", "name": "Update Virus Definitions"},
+        ]
+
+        # Set up defaults for all variables that are used for the popup but for which we do not yet have configuration / validation schema
+        self._container_shadow = None
+        self._blur = False
+        self._popup_image_icon_size = 16
+        self._animation = {"enabled": True, "type": "fadeInOut", "duration": 200}
+        self._alignment = "center"
+        self._direction = "down"
+        self._popup_offset = {"top": 8, "left": 0}
+
         for source in _SOURCES:
             cfg = getattr(self.config, f"{source}_update", None)
             if cfg and cfg.enabled:
                 container, widgets = self._create_container(source, cfg.label)
                 self._containers[source] = container
                 self._label_widgets[source] = widgets
+                if source == "windows":
+                    self._show_popup_menu = cfg.show_popup_menu
+                    self._popup_menu_padding = cfg.popup_menu_padding
             else:
                 self._containers[source] = None
                 self._label_widgets[source] = []
@@ -171,8 +203,198 @@ class UpdateCheckWidget(BaseWidget):
 
         def handler(event):
             if event.button() == Qt.MouseButton.LeftButton:
-                self._service.handle_left_click(source)
+                if source == "windows":
+                    if self._show_popup_menu == True:
+                        self._toggle_popup()
+                    else:
+                        self._service.handle_left_click("windows")
+                else:
+                    self._service.handle_left_click(source)
             elif event.button() == Qt.MouseButton.RightButton:
                 self._service.handle_right_click(source)
 
         return handler
+
+    def _toggle_popup(self):
+        """Toggle the menu popup visibility."""
+        try:
+            if self._popup and is_valid_qobject(self._popup) and self._popup.isVisible():
+                self._popup.hide_animated()
+            else:
+                self._show_popup()
+        except RuntimeError:
+            # Popup was deleted, create a new one
+            self._show_popup()
+
+    def _show_popup(self):
+        """Create and show the popup menu."""
+        # Close existing popup if any
+        try:
+            if self._popup and is_valid_qobject(self._popup):
+                self._popup.hide()
+        except RuntimeError:
+            pass
+
+        # Create new popup
+        self._popup = PopupWidget(
+            parent=self, blur=self._blur, round_corners=True, round_corners_type="normal", border_color="None"
+        )
+        self._popup.setProperty("class", "widget-container windows menu-popup")
+
+        # Prevent click-through to windows behind the popup
+        self._popup.setAttribute(Qt.WidgetAttribute.WA_NoMouseReplay)
+
+        # Create popup layout directly on the PopupWidget (like media.py does)
+        popup_layout = QVBoxLayout(self._popup)
+        popup_layout.setSpacing(0)
+        popup_layout.setContentsMargins(
+            self._popup_menu_padding,
+            self._popup_menu_padding,
+            self._popup_menu_padding,
+            self._popup_menu_padding,
+        )
+
+        # Add menu items directly to the popup layout
+        if isinstance(self._popup_menu_items, list):
+            item = self.create_menu_item(
+                item_data=self._popup_menu_items[0],
+                parent=self,
+                icon_size=self._popup_image_icon_size,
+                animation=self._animation,
+                bottom_padding=self._popup_menu_padding,
+            )
+            popup_layout.addWidget(item)
+
+            item = self.create_menu_item(
+                item_data=self._popup_menu_items[1],
+                parent=self,
+                icon_size=self._popup_image_icon_size,
+                animation=self._animation,
+                bottom_padding=0,
+            )
+            popup_layout.addWidget(item)
+
+        # Adjust popup size to content
+        self._popup.adjustSize()
+
+        # Force Qt to apply the stylesheet to the popup and its children (guard against None)
+        popup_style = self._popup.style()
+        if popup_style is not None:
+            popup_style.unpolish(self._popup)
+            popup_style.polish(self._popup)
+
+        popup_content = getattr(self._popup, "_popup_content", None)
+        if popup_content is not None:
+            content_style = popup_content.style()
+            if content_style is not None:
+                content_style.unpolish(popup_content)
+                content_style.polish(popup_content)
+
+        # Position and show popup
+        self._popup.setPosition(
+            alignment=self._alignment,
+            direction=self._direction,
+            offset_left=self._popup_offset["left"],
+            offset_top=self._popup_offset["top"],
+        )
+        self._popup.show()
+
+    def create_menu_item(self, item_data, parent, icon_size, animation, bottom_padding):
+        if "icon" in item_data and "launch" in item_data:
+            # Create menu item
+            item = MenuItemWidget(
+                parent=parent,
+                icon=item_data["icon"],
+                label=item_data.get("name", ""),
+                launch=item_data["launch"],
+                icon_size=icon_size,
+                animation=animation,
+                bottom_padding=bottom_padding,
+            )
+            return item
+
+    def execute_code(self, data):
+        """Execute the command associated with a menu item."""
+        try:
+            try:
+                if data == "windows_update":
+                    self._service.handle_left_click("windows")
+                elif data == "update_virus_defs":
+                    # Execute the Windows Defender command to update signatures
+                    exePath = r"C:\Program Files\Windows Defender\MpCmdRun.exe"
+                    parameters = r"-SignatureUpdate"
+                    windll.shell32.ShellExecuteW(
+                        None,
+                        "runas",
+                        exePath,
+                        parameters,
+                        None,
+                        1,
+                    )
+                    # Run the right-click command too, to tell the service to clear and refresh
+                    self._service.handle_right_click("windows")
+
+            except Exception as e:
+                logger.error(f"Error executing popup menu choice: {str(e)}")
+
+            # Close popup after executing command
+            try:
+                if self._popup and is_valid_qobject(self._popup) and self._popup.isVisible():
+                    self._popup.hide_animated()
+            except RuntimeError:
+                pass
+        except Exception as e:
+            logger.error(f'Exception occurred: {str(e)} "{data}"')
+
+
+class MenuItemWidget(QFrame):
+    """A single menu item in the popup."""
+
+    def __init__(self, parent, icon, label, launch, icon_size, animation, bottom_padding):
+        super().__init__()
+        self.parent_widget = parent
+        self._launch = launch
+        self._animation = animation
+        self._bottom_padding = bottom_padding
+
+        self.setProperty("class", "menu-item")
+        self.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
+
+        self.setStyleSheet(f"QFrame .menu-item {{ margin-bottom: {self._bottom_padding}px; }}")
+
+        # Create layout
+        layout = QHBoxLayout(self)
+        layout.setSpacing(8)
+        layout.setContentsMargins(3, 3, 3, 3)
+
+        # Create icon label
+        self._icon_label = QLabel()
+        self._icon_label.setProperty("class", "icon")
+        self._icon_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
+        if os.path.isfile(icon):
+            pixmap = QPixmap(icon).scaled(
+                icon_size,
+                icon_size,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+            self._icon_label.setPixmap(pixmap)
+        else:
+            self._icon_label.setText(icon)
+
+        layout.addWidget(self._icon_label)
+
+        # Create text label
+        self._text_label = QLabel(label)
+        self._text_label.setProperty("class", "label")
+        layout.addWidget(self._text_label, stretch=1)
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            event.accept()  # Accept the event to prevent propagation
+            if self._animation["enabled"]:
+                AnimationManager.animate(self, self._animation["type"], self._animation["duration"])
+            self.parent_widget.execute_code(self._launch)
+        else:
+            super().mousePressEvent(event)

--- a/src/styles.css
+++ b/src/styles.css
@@ -507,3 +507,37 @@ For more information about configuration options, please visit the Wiki https://
     color: rgb(255, 255, 255);
     margin-top: -20px;
 }
+
+/* Styles for the new optional Windows Update popup menu */
+
+.widget-container.windows.menu-popup {
+    background-color: var(--surface0);
+    border-radius: 4px;
+}
+
+.widget-container.windows.menu-popup .menu-item {
+    background-color: var(--surface1);
+    border-radius: 4px;
+    padding: 4px;
+}
+
+.widget-container.windows.menu-popup .menu-item:hover {
+    background-color: var(--surface2);
+}
+
+.widget-container.windows.menu-popup .menu-item .icon {
+    color: var(--text);
+    font-size: 16px;
+    min-width: 20px;
+}
+
+.widget-container.windows.menu-popup .menu-item .label {
+    color: var(--text);
+    font-size: 13px;
+    font-weight: 400;
+}
+
+.widget-container.windows.menu-popup .menu-item:hover .icon,
+.widget-container.windows.menu-popup .menu-item:hover .label {
+    color: var(--text);
+}


### PR DESCRIPTION
### Summary
Introduces `show_popup_menu` and `popup_menu_padding` configuration options for the Update Check - Windows Update source. This allows users to enable a popup menu on left-click instead of directly opening Windows Update settings.

The popup menu offers two choices:
- Open Windows Update in Settings.
- Directly update Windows Defender Virus' security intelligence, which prompts for UAC elevation.

Includes dedicated styling for the new popup menu and its items.

### Features Implemented
1. Adds a new optional parameter to the `WindowsUpdateConfig` for the Update Check widget.
   1. All changes are backwards compatible with existing config
   1. The popup needs to be explicitly turned on via config in the user's `config.yaml`
   1. Allows for overall padding of the popup to be altered via config in the user's `config.yaml`
   1. Allows more complex styling via css
   1. Implements a UAC elevation prompt as required

### Changes
- Updated the validation config to support the two new options parameters
- Updated the widget to:
   - Import the new config parameters
   - Set up a popup widget to display the 2 menu items
   - Optionally show the popup on left-click if enabled
   - Launch either of the commands if selected
   - Pass through the overall popup menu padding from the config to the controls
   - Include some hard coded visual elements (such as blur, animation etc.)
   - Added some basic logging
- Added some default CSS to `styles.css`
- Updated the wiki documentation:
   - Added the 2 new optional parameters to the 'Windows Update Options' section
   - Added the new styles to the 'Available Styles' section
   - Expanded the 'Example' css section with populated css styles

### Usage Example
```
widgets:
  update:
    type: "yasb.update_check.UpdateCheckWidget"
    options:
      windows_update:
        enabled: true
        show_popup_menu: true
        popup_menu_padding: 15
```

### In Action
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/98002072-7fd4-43fe-a3c0-7f670d26baa8" />

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/068bba95-176a-4bc4-993b-d2ea540b0956" />

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/4640cd05-1ddf-4ec0-aa80-1123a245293d" />

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/a596f550-5702-4b59-9c33-1261eaeeb04a" />

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/68b42129-8b66-4536-b517-557a60d16b42" />

Showing more details on the UAC prompt will indicate what the command will run:
<img width="456" height="490" alt="image" src="https://github.com/user-attachments/assets/d3fbec82-08be-410e-b61e-da907128f704" />


### Related Issues
Only indirectly related, but I note that this feature will need some minor amendments should PR #744 be approved as it consumes the Popup widget and will need to meet the new standard.

### Rationale
I got very confused with this widget when I first started to use YASB. The left-click opens Windows Update but I could get 4 or 5 notifications throughout the day indicating my virus definitions needed updating. Looking at Windows Update it reported no updates available.

Originally I was left scratching my head trying to work out how to remove these 'rogue' notifications that wouldn't go away unless I clicked through multiple items to manually update Windows Defender's security intelligence. I even created a shortcut I could run from my desktop to alleviate the burden, and then I decided to try incorporating it into the widget itself.

I now know what happens under the covers. I'd already started this contribution before I fully realized the relationship between Windows Defender and Windows Update, but I figured I would continue for 2 main reasons:

1. I've never coded in Python and I've already an idea for another new widget, so I wanted to prove to myself I could not only learn some Python but also start to understand the inner workings of YASB and contribute something that would meet code quality standards.
4. I figured there was still some value in the idea, as Windows Update occurs infrequently and the updates for Windows Defender can occur multiple times in a day. I think it minimizes the distraction of opening, running and closing Windows Update.

### Acknowledgements and Thanks
I would like to acknowledge the vast amount that I leant on the work of SavedByGrace251 in his PR #521. I reused a lot of his work and would not have been able to produce this contribution without retrofitting his hard work into this widget. Thank you.

### Caveats and Feedback
This is my first time working on YASB, my first time working with Python and my first time contributing to an open source project. Any mistakes or omissions are of course entirely my own.

Please do provide feedback and constructive criticism where due. I can't do it right in the future if I don't know what I'm doing wrong now. That includes the whole idea of this feature. I won't mind at all should this not be accepted. I really just did it to prove that I could but I hope others might see and extract some value from it.