### PR TITLE
feat(notes): floating window and refactoring

### DIFF
--- a/docs/widgets/(Widget)-Notes.md
+++ b/docs/widgets/(Widget)-Notes.md
@@ -1,32 +1,46 @@
 # Notes Widget Configuration
 
-| Option              | Type   | Default Value                           | Description                                                                                                              |
-|---------------------|--------|-----------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| `label`           | String | `<span>\udb82\udd0c</span> {count}`      | Primary label template, supports the `{count}` placeholder which is replaced with the number of notes.                  |
-| `label_alt`       | String | `{count} notes`                         | Alternative label format used when switching widget modes.                                                             |
-| `class_name`      | String | `""`                                    | Additional CSS class name for the widget.                                    |
-| `data_path`       | String | `""`                                    | Custom path to JSON file for storing notes. Leave empty to use default location (`~/.config/yasb/notes.json`). Supports `~` for home directory. |
-| `animation`       | Dict   | `{ enabled: true, type: "fadeInOut", duration: 200 }` | Controls animation settings; `enabled` turns animations on/off, `type` defines style, and `duration` is in ms. |
-| `menu`            | Dict   | See below                               | Popup menu settings. See details below.                                                                                |
-| `icons`           | Dict   | `{ note: "\udb82\udd0c", delete: "\ueab8", copy: "\uebcc" }` | Icons for note, delete action and copy text                                                                  |
-| `callbacks`       | Dict   | `{ on_left: "toggle_menu", on_middle: "do_nothing", on_right: "toggle_label" }` | Maps mouse actions to widget functions (e.g., toggling the menu or label).                                              |
-| `container_shadow`   | dict   | `None`                  | Container shadow options.                       |
-| `label_shadow`         | dict   | `None`                  | Label shadow options.                 |
+| Option                | Type     | Default Value                                                                   | Description                                                                                                                                     |
+| --------------------- | -------- | -----------------------------------------                                       | --------------------------------------------------------------------------------------------------------------------------                      |
+| `label`               | String   | `<span>\udb82\udd0c</span> {count}`                                             | Primary label template, supports the `{count}` placeholder which is replaced with the number of notes.                                          |
+| `label_alt`           | String   | `{count} notes`                                                                 | Alternative label format used when switching widget modes.                                                                                      |
+| `class_name`          | String   | `""`                                                                            | Additional CSS class name for the widget.                                                                                                       |
+| `data_path`           | String   | `""`                                                                            | Custom path to JSON file for storing notes. Leave empty to use default location (`~/.config/yasb/notes.json`). Supports `~` for home directory. |
+| `start_floating`      | Boolean  | `false`                                                                         | Whether the menu should start in floating mode.                                                                                                 |
+| `paste_plain_text`    | Boolean  | `false`                                                                         | If true, the widget will paste plain text from the clipboard by default, while Shift+Ctrl+V will paste rich text.                               |
+| `enter_to_add_note`   | Boolean  | `true`                                                                          | If true, pressing Enter in the input field will add a new note and Shift+Enter will add a new line.                                             |
+| `animation`           | Dict     | `{ enabled: true, type: "fadeInOut", duration: 200 }`                           | Controls animation settings; `enabled` turns animations on/off, `type` defines style, and `duration` is in ms.                                  |
+| `menu`                | Dict     | See below                                                                       | Popup menu settings. See details below.                                                                                                         |
+| `icons`               | Dict     | See below                                                                       | Icons used within the widget. See details below.                                                                                                |
+| `callbacks`           | Dict     | `{ on_left: "toggle_menu", on_middle: "do_nothing", on_right: "toggle_label" }` | Maps mouse actions to widget functions (e.g., toggling the menu or label).                                                                      |
+| `container_shadow`    | dict     | `None`                                                                          | Container shadow options.                                                                                                                       |
+| `label_shadow`        | dict     | `None`                                                                          | Label shadow options.                                                                                                                           |
 
 ### Menu Options
 
-| Option              | Type     | Default Value | Description                                                                                  |
-|---------------------|----------|---------------|----------------------------------------------------------------------------------------------|
-| `blur`            | Boolean  | `true`        | Enables a blur effect in the menu popup.                                                     |
-| `round_corners`   | Boolean  | `true`        | If `true`, the menu has rounded corners.                                                     |
-| `round_corners_type` | String | `"normal"`    | Determines the corner style; allowed values are `normal` and `small`.                          |
-| `border_color`    | String   | `"System"`    | Sets the border color for the menu.                                                          |
-| `alignment`       | String   | `"right"`     | Horizontal alignment of the menu relative to the widget (e.g., left, right, center).           |
-| `direction`       | String   | `"down"`      | Direction in which the menu opens.                                                           |
-| `offset_top`      | Integer  | `6`           | Vertical offset for fine positioning of the menu.                                            |
-| `offset_left`     | Integer  | `0`           | Horizontal offset for fine positioning.                                                      |
-| `max_title_size`  | Integer  | `150`         | Maximum characters for note titles before truncation.                                        |
-| `show_date_time`  | Boolean  | `true`        | Indicates whether to display the note’s timestamp.                                           |
+| Option                | Type       | Default Value   | Description                                                                                    |
+| --------------------- | ---------- | --------------- | ---------------------------------------------------------------------------------------------- |
+| `blur`                | Boolean    | `true`          | Enables a blur effect in the menu popup.                                                       |
+| `round_corners`       | Boolean    | `true`          | If `true`, the menu has rounded corners.                                                       |
+| `round_corners_type`  | String     | `"normal"`      | Determines the corner style; allowed values are `normal` and `small`.                          |
+| `border_color`        | String     | `"System"`      | Sets the border color for the menu.                                                            |
+| `alignment`           | String     | `"right"`       | Horizontal alignment of the menu relative to the widget (e.g., left, right, center).           |
+| `direction`           | String     | `"down"`        | Direction in which the menu opens.                                                             |
+| `offset_top`          | Integer    | `6`             | Vertical offset for fine positioning of the menu.                                              |
+| `offset_left`         | Integer    | `0`             | Horizontal offset for fine positioning.                                                        |
+| `max_title_size`      | Integer    | `150`           | Maximum characters for note titles before truncation.                                          |
+| `show_date_time`      | Boolean    | `true`          | Indicates whether to display the note’s timestamp.                                             |
+
+### Icons Options
+
+| Option                | Type       | Default Value    | Description                                                                                    |
+| --------------------- | ---------- | ---------------  | ---------------------------------------------------------------------------------------------- |
+| `note`                | String     | `"\udb82\udd0c"` | Icon representing a note.                                                                      |
+| `delete`              | String     | `"\ueab8"`       | Icon used for the delete action.                                                               |
+| `copy`                | String     | `"\uebcc"`       | Icon for copying text.                                                                         |
+| `float_on`            | String     | `"\udb84\udcac"` | Icon shown when floating can be enabled.                                                       |
+| `float_off`           | String     | `"\udb84\udca9"` | Icon shown when floating can be disabled.                                                      |
+| `close`               | String     | `"\uf00d"`       | Icon for the close button in the header.                                                       |
 
 > [!IMPORTANT]  
 > This widget will save notes in JSON format in `.config/yasb/notes.json`. You can just backup this file to save your notes and restore them later. 
@@ -71,6 +85,9 @@ notes:
 - **label_alt** Alternative label format used when switching modes.
 - **class_name** Additional CSS class name for the widget. This allows for custom styling.
 - **data_path** Optional custom path to the JSON file where notes are stored. If empty or not specified, uses the default location (`~/.config/yasb/notes.json`). Supports `~` for home directory expansion (e.g., `~/Documents/my-notes.json` or `C:/Users/YourName/my-notes.json`).
+- **enter_to_add_note** If true, pressing Enter in the input field will add a new note and Shift+Enter will add a new line. If false it's reversed.
+- **paste_plain_text** If true, the widget will paste plain text from the clipboard by default, while Shift+Ctrl+V will paste rich text. If false it's reversed
+- **start_floating** If true, the menu will start in floating mode.
 - **animation** A dictionary to control widget animation:
   - **enabled**: Boolean flag to turn animations on or off.
   - **type**: The animation style (e.g., "fadeInOut").
@@ -107,6 +124,16 @@ notes:
 .notes-widget .icon {}
 /* Popup menu */
 .notes-menu {}
+/* Floating popup menu */
+.notes-menu.floating {}
+/* Popup menu header */
+.notes-menu .notes-header {}
+/* Header title */
+.notes-menu .notes-header .header-title {}
+/* Floating toggle button */
+.notes-menu .notes-header .float-button {}
+/* Close button */
+.notes-menu .notes-header .close-button {}
 /* Note items inside the menu */
 .notes-menu .note-item {}
 /* Title text within each note item */
@@ -124,6 +151,10 @@ notes:
 .notes-menu .note-input {}
 /* Focus style for the note input */
 .notes-menu .note-input:focus {}
+/* Copy button inside the input field */
+.notes-menu .input-copy-button {}
+.notes-menu .input-copy-button:hover {}
+.notes-menu .input-copy-button:pressed {}
 /* Button to delete a note */
 .notes-menu .delete-button {}
 /* Button hover effect */
@@ -157,6 +188,37 @@ notes:
     min-width: 400px;
     max-width: 400px;
     background-color: rgba(17, 17, 27, 0.4);
+}
+/* Floating state - can have different size */
+.notes-menu.floating {
+    min-width: 600px;
+    max-width: 600px;
+    min-height: 600px;
+    max-height: 600px;
+}
+/* Notes Widget Menu Header */
+.notes-menu .notes-header {
+    background-color: rgba(0, 0, 0, 0);
+    padding: 4px 16px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+.notes-menu .notes-header .header-title {
+    font-size: 16px;
+    font-weight: 800;
+    color: white;
+}
+.notes-menu .notes-header .float-button,
+.notes-menu .notes-header .close-button {
+    background-color: transparent;
+    border: none;
+    color: #cfcfcf;
+    font-size: 16px;
+    padding: 4px;
+}
+.notes-menu .notes-header .float-button:hover,
+.notes-menu .notes-header .close-button:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
 }
 .notes-menu .note-item {
     background-color:transparent;
@@ -208,9 +270,9 @@ notes:
     color: rgba(255, 255, 255, 0.2);
     font-size: 24px;
     font-weight: 600;
-    padding: 10px 0 20px 0;     
+    padding: 10px 0 20px 0;
 }
-.notes-menu .add-button,  
+.notes-menu .add-button,
 .notes-menu .cancel-button {
     padding: 8px;
     background-color: rgba(255, 255, 255, 0.1);
@@ -242,6 +304,20 @@ notes:
 }
 .note-input:focus {
     border: 1px solid #89b4fa;
+}
+.notes-menu .input-copy-button {
+    color: #babfd3;
+    background: transparent;
+    border: none;
+    font-size: 14px;
+    padding: 2px 4px;
+    border-radius: 3px;
+}
+.notes-menu .input-copy-button:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+.notes-menu .input-copy-button:pressed {
+    color: #ffffff;
 }
 ```
 

--- a/src/core/utils/widgets/notes/utils.py
+++ b/src/core/utils/widgets/notes/utils.py
@@ -1,0 +1,394 @@
+import re
+from typing import TYPE_CHECKING, Any
+
+from PyQt6.QtCore import QEvent, QMimeData, Qt
+from PyQt6.QtGui import QKeyEvent, QMouseEvent, QTextCharFormat, QTextCursor
+from PyQt6.QtWidgets import QApplication, QLabel, QPushButton, QSizePolicy, QTextEdit, QWidget
+
+from core.utils.tooltip import set_tooltip
+from core.utils.utilities import PopupWidget, refresh_widget_style
+
+if TYPE_CHECKING:
+    from core.widgets.yasb.notes import NotesWidget
+
+
+class FloatingWindowController:
+    def __init__(self, widget: NotesWidget) -> None:
+        self._widget: NotesWidget = widget
+
+    def toggle_floating(self) -> None:
+        if not self._widget.is_menu_valid() or self._widget.menu is None:
+            return
+
+        if not self._widget.is_floating:
+            self._widget.original_position = self._widget.menu.pos()
+            self._widget.is_floating = True
+            self._widget.menu.set_floating(True)
+            self._widget.adjust_menu_geometry()
+            screen = self._widget.get_target_screen()
+            if screen:
+                screen_geometry = screen.availableGeometry()
+                popup_size = self._widget.menu.size()
+                center_x = screen_geometry.x() + (screen_geometry.width() - popup_size.width()) // 2
+                center_y = screen_geometry.y() + (screen_geometry.height() - popup_size.height()) // 2
+                self._widget.menu.move(center_x, center_y)
+
+            self._widget.float_btn.setText(self._widget.icons["float_off"])
+            set_tooltip(self._widget.float_btn, "Dock window")
+            self._widget.close_btn.setVisible(True)
+        else:
+            self._widget.is_floating = False
+            self._widget.menu.set_floating(False)
+            self._widget.adjust_menu_geometry()
+
+            self._widget.float_btn.setText(self._widget.icons["float_on"])
+            set_tooltip(self._widget.float_btn, "Float window")
+            self._widget.close_btn.setVisible(False)
+
+    def header_mouse_press(self, event: QMouseEvent | None) -> None:
+        if not event:
+            return
+        if self._widget.is_floating and event.button() == Qt.MouseButton.LeftButton and self._widget.menu:
+            self._widget.drag_position = event.globalPosition().toPoint() - self._widget.menu.frameGeometry().topLeft()
+            event.accept()
+
+    def header_mouse_move(self, event: QMouseEvent | None) -> None:
+        if not event:
+            return
+        if self._widget.is_floating and self._widget.drag_position is not None and self._widget.menu:
+            self._widget.menu.move(event.globalPosition().toPoint() - self._widget.drag_position)
+            event.accept()
+
+    def header_mouse_release(self, event: QMouseEvent | None) -> None:
+        if not event:
+            return
+        if self._widget.is_floating:
+            self._widget.drag_position = None
+            event.accept()
+
+
+class NotesPopup(PopupWidget):
+    """Custom popup widget for Notes with floating and deactivate handling"""
+
+    is_floating: bool
+    _block_deactivate: bool
+    _pos_args: tuple[str, str, int, int] | None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.is_floating = False
+        self._block_deactivate = False
+        self._pos_args = None
+        self.setWindowFlags(
+            Qt.WindowType.Tool
+            | Qt.WindowType.FramelessWindowHint
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.NoDropShadowWindowHint
+        )
+
+    def set_block_deactivate(self, enabled: bool) -> None:
+        self._block_deactivate = enabled
+
+    def set_floating(self, floating: bool) -> None:
+        self.is_floating = floating
+
+        if floating:
+            self.setProperty("class", "notes-menu floating")
+        else:
+            self.setProperty("class", "notes-menu")
+
+        refresh_widget_style(self, *self.findChildren(QWidget))
+
+    def setPosition(
+        self, alignment: str = "left", direction: str = "down", offset_left: int = 0, offset_top: int = 0
+    ) -> None:
+        # Store args for when we might stop floating or for resize events
+        self._pos_args = (alignment, direction, offset_left, offset_top)
+
+        # If floating, don't actually move the window to the docked position
+        if self.is_floating:
+            return
+
+        super().setPosition(alignment, direction, offset_left, offset_top)
+
+    def eventFilter(self, obj: Any, event: Any) -> bool:
+        if self.is_floating or self._block_deactivate:
+            return False
+        if obj is None or event is None:
+            return False
+        return bool(super().eventFilter(obj, event))  # type: ignore
+
+    def event(self, a0: Any) -> bool:
+        if a0 and a0.type() == QEvent.Type.WindowDeactivate:
+            if self.is_floating or self._block_deactivate:
+                a0.accept()
+                return True
+            self.hide_animated()
+            return True
+        return bool(super().event(a0))  # type: ignore
+
+
+class ElidedLabel(QLabel):
+    """A QLabel that automatically elides its text if it doesn't fit the width."""
+
+    def __init__(self, text: str = "", parent: QWidget | None = None) -> None:
+        super().__init__(text, parent)
+        self._full_text = text
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
+
+    def setText(self, a0: str | None) -> None:
+        self._full_text = a0 or ""
+        self._update_elided_text()
+
+    def text(self) -> str:
+        return self._full_text
+
+    def resizeEvent(self, a0: Any) -> None:
+        super().resizeEvent(a0)
+        self._update_elided_text()
+
+    def minimumSizeHint(self) -> Any:
+        from PyQt6.QtCore import QSize
+
+        metrics = self.fontMetrics()
+        return QSize(10, metrics.height())
+
+    def sizeHint(self) -> Any:
+        from PyQt6.QtCore import QSize
+
+        metrics = self.fontMetrics()
+        # Cap the natural size hint so the popup doesn't expand infinitely for huge titles
+        return QSize(min(250, metrics.horizontalAdvance(self._full_text)), metrics.height())
+
+    def _update_elided_text(self) -> None:
+        metrics = self.fontMetrics()
+        elided = metrics.elidedText(self._full_text, Qt.TextElideMode.ElideRight, self.width())
+        if elided != super().text():
+            super().setText(elided)
+
+
+class NoteTextEdit(QTextEdit):
+    """
+    Custom QTextEdit widget for note input that overrides keyPressEvent.
+    Captures Enter/Return key presses to trigger note addition in the parent widget,
+    while allowing multiline input using Shift+Enter.
+    """
+
+    def __init__(self, notes_widget: NotesWidget) -> None:
+        super().__init__()
+        self._notes_widget = notes_widget
+        self._force_rich_paste: bool = False
+
+        self.copy_btn = QPushButton(self._notes_widget.config.icons.copy_icon, self)
+        self.copy_btn.setProperty("class", "input-copy-button")
+        self.copy_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self.copy_btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        self.copy_btn.clicked.connect(self._copy_to_clipboard)
+        set_tooltip(self.copy_btn, "Copy to clipboard")
+
+        self.textChanged.connect(self._update_copy_btn_position)
+
+    def _copy_to_clipboard(self) -> None:
+        clipboard = QApplication.clipboard()
+        if clipboard:
+            clipboard.setText(self.toPlainText())
+
+    def _update_copy_btn_position(self) -> None:
+        margin = 4
+        btn_size = self.copy_btn.sizeHint()
+
+        # Calculate the right offset. If the vertical scrollbar is visible,
+        # we need to shift the button to the left by the scrollbar's width.
+        vbar = self.verticalScrollBar()
+        vbar_width = vbar.width() if vbar and vbar.isVisible() else 0
+
+        self.copy_btn.setGeometry(
+            self.width() - btn_size.width() - margin - vbar_width,
+            margin,
+            btn_size.width(),
+            btn_size.height(),
+        )
+
+    def resizeEvent(self, a0: Any) -> None:
+        super().resizeEvent(a0)
+        self._update_copy_btn_position()
+
+    def insertFromMimeData(self, source: QMimeData | None) -> None:
+        if source is None:
+            return
+
+        # Check if we should enforce plain text paste
+        should_paste_plain = self._notes_widget.config.paste_plain_text
+        if self._force_rich_paste:
+            should_paste_plain = False
+
+        if should_paste_plain:
+            self.insertPlainText(source.text())
+            return
+
+        if source.hasHtml():
+            html = source.html()
+            # Strip background color from inline styles
+            html = re.sub(r'background-color\s*:\s*[^;">\']+;?', "", html, flags=re.IGNORECASE)
+            html = re.sub(r'background\s*:\s*[^;">\']+;?', "", html, flags=re.IGNORECASE)
+            # Strip bgcolor attributes
+            html = re.sub(r'bgcolor\s*=\s*["\'][^"\']+["\']', "", html, flags=re.IGNORECASE)
+
+            new_source = QMimeData()
+            new_source.setHtml(html)
+            if source.hasText():
+                new_source.setText(source.text())
+            super().insertFromMimeData(new_source)
+        else:
+            super().insertFromMimeData(source)
+
+    def _get_indent_string(self) -> str:
+        cursor = self.textCursor()
+        block = cursor.block()
+        text = block.text()
+        if text.startswith("\t"):
+            return "\t"
+        elif text.startswith(" ") or text.startswith("\xa0"):
+            return "    "
+
+        # Check previous lines
+        prev_block = block.previous()
+        while prev_block.isValid():
+            prev_text = prev_block.text()
+            if prev_text.startswith("\t"):
+                return "\t"
+            elif prev_text.startswith(" ") or prev_text.startswith("\xa0"):
+                return "    "
+            prev_block = prev_block.previous()
+
+        return "    "
+
+    def _handle_tab(self) -> None:
+        cursor = self.textCursor()
+        indent_str = self._get_indent_string()
+
+        if not cursor.hasSelection():
+            cursor.insertText(indent_str)
+            return
+
+        doc = self.document()
+        if not doc:
+            return
+
+        start_pos = cursor.selectionStart()
+        end_pos = cursor.selectionEnd()
+
+        cursor.beginEditBlock()
+
+        start_block_obj = doc.findBlock(start_pos)
+        end_block_obj = doc.findBlock(end_pos)
+
+        if start_pos != end_pos and end_pos == end_block_obj.position():
+            end_block_obj = end_block_obj.previous()
+
+        cur_block = start_block_obj
+        while cur_block.isValid() and cur_block.blockNumber() <= end_block_obj.blockNumber():
+            block_cursor = QTextCursor(cur_block)
+            block_cursor.movePosition(QTextCursor.MoveOperation.StartOfBlock)
+            block_cursor.insertText(indent_str)
+            cur_block = cur_block.next()
+
+        cursor.endEditBlock()
+
+    def _handle_backtab(self) -> None:
+        cursor = self.textCursor()
+        doc = self.document()
+
+        if not doc:
+            return
+
+        start_pos = cursor.selectionStart()
+        end_pos = cursor.selectionEnd()
+
+        if not cursor.hasSelection():
+            start_pos = cursor.position()
+            end_pos = cursor.position()
+
+        cursor.beginEditBlock()
+
+        start_block_obj = doc.findBlock(start_pos)
+        end_block_obj = doc.findBlock(end_pos)
+
+        if start_pos != end_pos and end_pos == end_block_obj.position():
+            end_block_obj = end_block_obj.previous()
+
+        cur_block = start_block_obj
+        while cur_block.isValid() and cur_block.blockNumber() <= end_block_obj.blockNumber():
+            block_cursor = QTextCursor(cur_block)
+            block_cursor.movePosition(QTextCursor.MoveOperation.StartOfBlock)
+            block_cursor.movePosition(QTextCursor.MoveOperation.EndOfBlock, QTextCursor.MoveMode.KeepAnchor)
+            text = block_cursor.selectedText()
+
+            if text.startswith("\t"):
+                block_cursor.movePosition(QTextCursor.MoveOperation.StartOfBlock)
+                block_cursor.movePosition(QTextCursor.MoveOperation.Right, QTextCursor.MoveMode.KeepAnchor, 1)
+                block_cursor.removeSelectedText()
+            else:
+                spaces_to_remove = 0
+                for i in range(min(4, len(text))):
+                    if text[i] == " " or text[i] == "\xa0":
+                        spaces_to_remove += 1
+                    else:
+                        break
+                if spaces_to_remove > 0:
+                    block_cursor.movePosition(QTextCursor.MoveOperation.StartOfBlock)
+                    block_cursor.movePosition(
+                        QTextCursor.MoveOperation.Right, QTextCursor.MoveMode.KeepAnchor, spaces_to_remove
+                    )
+                    block_cursor.removeSelectedText()
+
+            cur_block = cur_block.next()
+
+        cursor.endEditBlock()
+
+    def keyPressEvent(self, e: QKeyEvent | None) -> None:
+        if e is None:
+            return
+
+        if (
+            e.key() == Qt.Key.Key_V
+            and (e.modifiers() & Qt.KeyboardModifier.ControlModifier)
+            and (e.modifiers() & Qt.KeyboardModifier.ShiftModifier)
+        ):
+            if self._notes_widget.config.paste_plain_text:
+                # Force rich text
+                self._force_rich_paste = True
+                self.paste()
+                self._force_rich_paste = False
+            else:
+                # Force plain text
+                clipboard = QApplication.clipboard()
+                if clipboard:
+                    self.setCurrentCharFormat(QTextCharFormat())
+                    self.insertPlainText(clipboard.text())
+            e.accept()
+            return
+
+        # Normal Paste (Ctrl+V)
+        if e.key() == Qt.Key.Key_V and (e.modifiers() & Qt.KeyboardModifier.ControlModifier):
+            # insertFromMimeData will handle the logic based on config
+            super().keyPressEvent(e)
+            return
+
+        if e.key() == Qt.Key.Key_Tab:
+            self._handle_tab()
+            e.accept()
+            return
+
+        if e.key() == Qt.Key.Key_Backtab:
+            self._handle_backtab()
+            e.accept()
+            return
+
+        if e.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+            if self._notes_widget.config.enter_to_add_note != bool(e.modifiers() & Qt.KeyboardModifier.ShiftModifier):
+                self._notes_widget.add_note_from_input()
+                e.accept()
+                return
+
+        super().keyPressEvent(e)

--- a/src/core/validation/widgets/yasb/notes.py
+++ b/src/core/validation/widgets/yasb/notes.py
@@ -29,6 +29,9 @@ class IconsConfig(CustomBaseModel):
     note: str = "\udb82\udd0c"
     delete: str = "\ueab8"
     copy_icon: str = Field(default="\uebcc", alias="copy")
+    float_on: str = "\udb84\udcac"
+    float_off: str = "\udb84\udca9"
+    close: str = "\uf00d"
 
 
 class NotesCallbacksConfig(CallbacksConfig):
@@ -42,6 +45,9 @@ class NotesConfig(CustomBaseModel):
     label_alt: str = "{count} notes"
     class_name: str = ""
     data_path: str = ""
+    start_floating: bool = False
+    paste_plain_text: bool = False
+    enter_to_add_note: bool = True
     container_padding: PaddingConfig = PaddingConfig()
     animation: AnimationConfig = AnimationConfig()
     menu: MenuConfig = MenuConfig()

--- a/src/core/widgets/yasb/notes.py
+++ b/src/core/widgets/yasb/notes.py
@@ -3,11 +3,13 @@ import json
 import logging
 import os
 import re
-from typing import Dict, List
+from typing import Any
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtGui import QCursor
+from pydantic import BaseModel
+from PyQt6.QtCore import QPoint, Qt, QTimer
+from PyQt6.QtGui import QCursor, QTextCursor
 from PyQt6.QtWidgets import (
+    QApplication,
     QFrame,
     QHBoxLayout,
     QLabel,
@@ -15,38 +17,65 @@ from PyQt6.QtWidgets import (
     QScrollArea,
     QSizePolicy,
     QSpacerItem,
-    QTextEdit,
     QVBoxLayout,
     QWidget,
 )
 
 from core.config import HOME_CONFIGURATION_DIR
-from core.utils.utilities import PopupWidget, add_shadow, build_widget_label
+from core.utils.tooltip import set_tooltip
+from core.utils.utilities import add_shadow, build_widget_label, sip
 from core.utils.widgets.animation_manager import AnimationManager
+from core.utils.widgets.notes.utils import ElidedLabel, FloatingWindowController, NotesPopup, NoteTextEdit
+from core.utils.win32.utilities import find_focused_screen, get_foreground_hwnd, set_foreground_hwnd  # type: ignore
+from core.utils.win32.window_actions import force_foreground_focus
 from core.validation.widgets.yasb.notes import NotesConfig
 from core.widgets.base import BaseWidget
 from settings import DEBUG
 
 
 class NotesWidget(BaseWidget):
-    validation_schema = NotesConfig
-    _instances: List[NotesWidget] = []
+    validation_schema: dict[str, Any] | type[BaseModel] | None = NotesConfig
+    _instances: list[NotesWidget] = []
 
-    def __init__(self, config: NotesConfig):
+    def __init__(self, config: NotesConfig) -> None:
         super().__init__(class_name=f"notes-widget {config.class_name}")
         self.config = config
         NotesWidget._instances.append(self)
 
-        self._show_alt_label = False
-        self._label_content = self.config.label
-        self._label_alt_content = self.config.label_alt
+        self._show_alt_label: bool = False
+        self._label_content: str = self.config.label
+        self._label_alt_content: str = self.config.label_alt
+        self.icons: dict[str, str] = self.config.icons.model_dump(by_alias=True)
+        self._start_floating: bool = config.start_floating
+        self.is_floating: bool = False
+        self.previous_hwnd: int = 0  # Used for restoring focus
+        self.original_position: Any = None
+        self.drag_position: QPoint | None = None
+        self.menu: NotesPopup | None = None
+        self._widgets: list[QWidget] = []
+        self._widgets_alt: list[QWidget] = []
+        self.scroll_area: QScrollArea | None = None
+        self.scroll_widget: QWidget | None = None
+        self.scroll_layout: QVBoxLayout | None = None
+        self.editing_note: dict[str, str] | None = None
+        self._pending_note_html: str = ""
+        self.notes_file: str = ""
+        self.notes: list[dict[str, str]] = []
+
+        self.note_input: NoteTextEdit
+        self.add_button: QPushButton
+        self.cancel_button: QPushButton
+        self.float_btn: QPushButton
+        self.close_btn: QPushButton
+
+        self._floating_controller = FloatingWindowController(self)
 
         # Use custom data path if provided, otherwise use default
         if config.data_path and config.data_path.strip():
-            self._notes_file = os.path.expanduser(config.data_path)
+            self.notes_file = os.path.expanduser(config.data_path)
         else:
-            self._notes_file = os.path.join(HOME_CONFIGURATION_DIR, "notes.json")
-        self._notes: list[dict[str, str]] = self._load_notes()
+            self.notes_file = os.path.join(HOME_CONFIGURATION_DIR, "notes.json")
+        self.notes = self._load_notes()
 
         # Initialize container layout
         self._widget_container_layout = QHBoxLayout()
@@ -81,13 +110,53 @@ class NotesWidget(BaseWidget):
             pass
 
     @classmethod
-    def update_all(cls):
+    def update_all(cls) -> None:
         """Update all instances of NotesWidget"""
         for instance in cls._instances:
-            instance._notes = instance._load_notes()
+            instance.notes = instance._load_notes()
             instance._update_label()
+            if instance.is_menu_active():
+                instance._refresh_notes_list()
 
-    def _toggle_label(self):
+    def get_target_screen(self) -> Any:
+        screen_mode = "cursor"
+        for kb in self.config.keybindings:
+            if kb.action == "toggle_menu":
+                screen_mode = kb.screen
+                break
+        if screen_mode == "cursor":
+            screen_name = find_focused_screen(follow_mouse=True, follow_window=False)
+        elif screen_mode == "active":
+            screen_name = find_focused_screen(follow_mouse=False, follow_window=True)
+        elif screen_mode == "primary":
+            return QApplication.primaryScreen() or QApplication.screens()[0]
+        else:
+            return self.screen() or QApplication.primaryScreen() or QApplication.screens()[0]
+        if screen_name:
+            for s in QApplication.screens():
+                if s.name() == screen_name:
+                    return s
+        return self.screen() or QApplication.primaryScreen() or QApplication.screens()[0]
+
+    def is_menu_active(self) -> bool:
+        """Check if menu exists and is visible without crashing on deleted objects."""
+        if self.menu is None or sip.isdeleted(self.menu):
+            return False
+        try:
+            return self.menu.isVisible()
+        except RuntimeError:
+            return False
+
+    def is_menu_valid(self) -> bool:
+        if not self.is_menu_active() or self.menu is None:
+            return False
+        try:
+            _ = self.menu.size()
+        except RuntimeError:
+            return False
+        return True
+
+    def _toggle_label(self) -> None:
         if self.config.animation.enabled:
             AnimationManager.animate(self, self.config.animation.type, self.config.animation.duration)
 
@@ -101,10 +170,104 @@ class NotesWidget(BaseWidget):
 
         self._update_label()
 
-    def _toggle_menu(self):
-        if self.config.animation.enabled:
-            AnimationManager.animate(self, self.config.animation.type, self.config.animation.duration)
-        self._show_menu()
+    def _toggle_menu(self) -> None:
+        # If popup is not visible or doesn't exist, open it
+        if not self.is_menu_active():
+            if self.config.animation.enabled:
+                AnimationManager.animate(self, self.config.animation.type, self.config.animation.duration)
+            self._show_menu()
+        else:
+            self._close_menu()
+
+    def _close_menu(self) -> None:
+        if not self.is_menu_active() or self.menu is None:
+            return
+        self.menu.hide_animated()
+
+    def _on_menu_destroyed(self, *_args: Any) -> None:
+        self.menu = None
+        self.scroll_widget = None
+        self.scroll_layout = None
+        self.scroll_area = None
+        self.is_floating = False
+        # Restore focus
+        if self.previous_hwnd:
+            try:
+                set_foreground_hwnd(self.previous_hwnd)
+            finally:
+                self.previous_hwnd = 0
+
+    def _refresh_notes_list(self) -> None:
+        """Refresh the notes list in the scroll area without closing the menu."""
+        if self.menu is None or sip.isdeleted(self.menu):
+            return
+
+        if self.scroll_layout is None or sip.isdeleted(self.scroll_layout):
+            return
+
+        # Clear layout
+        while self.scroll_layout.count():
+            item = self.scroll_layout.takeAt(0)
+            if item:
+                widget = item.widget()
+                if widget:
+                    widget.setParent(None)
+                    widget.deleteLater()
+
+        # Add notes
+        if self.notes:
+            for note in self.notes:
+                self._add_note_to_menu(note, self.scroll_layout)
+        else:
+            # Show empty state
+            empty_label = QLabel(f"{self.config.icons.note}  No notes yet!")
+            empty_label.setProperty("class", "empty-list")
+            empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self.scroll_layout.addWidget(empty_label)
+
+        # Use a short timer to ensure layout is updated before adjusting size
+        # We want this to run even if not visible yet to set initial size hints
+        QTimer.singleShot(50, self.adjust_menu_geometry)
+
+    def adjust_menu_geometry(self):
+        """Adjust menu size and position based on current content."""
+        if self.menu is None or sip.isdeleted(self.menu):
+            return
+
+        # Force scroll widget to update its size hint based on new content
+        if self.scroll_widget:
+            self.scroll_widget.adjustSize()
+
+        # Calculate height for up to 3 notes
+        if self.scroll_layout and self.scroll_area:
+            count = self.scroll_layout.count()
+            if count > 0:
+                # Calculate height of up to 3 items
+                total_h = 0
+                for i in range(min(count, 3)):
+                    item = self.scroll_layout.itemAt(i)
+                    if item:
+                        widget = item.widget()
+                        if widget:
+                            total_h += widget.sizeHint().height()
+
+                self.scroll_area.setFixedHeight(total_h)
+            else:
+                if self.is_floating:
+                    self.scroll_area.setMinimumHeight(0)
+                    self.scroll_area.setMaximumHeight(60)
+                    self.scroll_area.setMinimumHeight(60)
+                else:
+                    self.scroll_area.setFixedHeight(60)  # Fallback for empty state
+
+        self.menu.adjustSize()
+        # setPosition is now overridden in NotesPopup to ignore moves when floating
+        self.menu.setPosition(
+            alignment=self.config.menu.alignment,
+            direction=self.config.menu.direction,
+            offset_left=self.config.menu.offset_left,
+            offset_top=self.config.menu.offset_top,
+        )
 
     def _update_label(self):
         active_widgets = self._widgets_alt if self._show_alt_label else self._widgets
@@ -113,13 +276,15 @@ class NotesWidget(BaseWidget):
         label_parts = re.split("(<span.*?>.*?</span>)", active_label_content)
         label_parts = [part for part in label_parts if part]
 
-        notes_count = len(self._notes)
+        notes_count = len(self.notes)
 
         for widget_index, part in enumerate(label_parts):
-            if widget_index >= len(active_widgets) or not isinstance(active_widgets[widget_index], QLabel):
+            if widget_index >= len(active_widgets):
                 continue
 
             current_widget = active_widgets[widget_index]
+            if not isinstance(current_widget, QLabel):
+                continue
 
             if "<span" in part and "</span>" in part:
                 icon = re.sub(r"<span.*?>|</span>", "", part).strip()
@@ -129,33 +294,111 @@ class NotesWidget(BaseWidget):
                 current_widget.setText(formatted_text)
             widget_index += 1
 
-    def _show_menu(self):
-        self._menu = PopupWidget(
+    def _build_menu_button(
+        self,
+        parent: QWidget,
+        label: str,
+        class_name: str,
+        on_click: Any,
+        visible: bool = True,
+    ) -> QPushButton:
+        btn = QPushButton(label, parent)
+        btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        btn.setProperty("class", class_name)
+        if on_click:
+            btn.clicked.connect(on_click)
+        btn.setVisible(visible)
+        return btn
+
+    def _create_header(self, layout: QVBoxLayout):
+        header_widget = QFrame()
+        header_widget.setProperty("class", "notes-header")
+        header_widget.mousePressEvent = lambda a0: self._floating_controller.header_mouse_press(a0)
+        header_widget.mouseMoveEvent = lambda a0: self._floating_controller.header_mouse_move(a0)
+        header_widget.mouseReleaseEvent = lambda a0: self._floating_controller.header_mouse_release(a0)
+        header_layout = QHBoxLayout(header_widget)
+        header_layout.setSpacing(0)
+        header_layout.setContentsMargins(8, 4, 8, 4)
+
+        header_title = QLabel("Notes")
+        header_title.setProperty("class", "header-title")
+        header_layout.addWidget(header_title)
+
+        header_layout.addStretch()
+
+        self.float_btn = self._build_menu_button(
+            header_widget,
+            self.icons["float_on"],
+            "float-button",
+            self._floating_controller.toggle_floating,
+        )
+        set_tooltip(self.float_btn, "Float window")
+        header_layout.addWidget(self.float_btn)
+
+        self.close_btn = self._build_menu_button(
+            header_widget,
+            self.icons["close"],
+            "close-button",
+            self._close_menu,
+            visible=False,
+        )
+        set_tooltip(self.close_btn, "Close window")
+        header_layout.addWidget(self.close_btn)
+
+        layout.addWidget(header_widget)
+
+    def _show_menu(self) -> None:
+        # Remember the current foreground window so we can restore focus when closing
+        self.previous_hwnd = get_foreground_hwnd()
+
+        # Capture current position to restore after recreation if floating
+        current_pos = self.menu.pos() if self.is_menu_active() and self.menu else None
+
+        self.menu = NotesPopup(
             self,
             self.config.menu.blur,
             self.config.menu.round_corners,
             self.config.menu.round_corners_type,
             self.config.menu.border_color,
         )
-        self._menu.setProperty("class", "notes-menu")
+        self.menu.setProperty("class", "notes-menu")
+        self.menu.destroyed.connect(self._on_menu_destroyed)
 
         # Create main layout
-        main_layout = QVBoxLayout(self._menu)
+        main_layout = QVBoxLayout(self.menu)
         main_layout.setSpacing(0)
         main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
 
-        # Add text input area with button row - MOVED TO TOP
+        # Create Header
+        self._create_header(main_layout)
+
+        # Add text input area with button row
         input_container = QWidget()
         input_layout = QVBoxLayout(input_container)
         input_layout.setContentsMargins(8, 8, 8, 8)
         input_layout.setSpacing(5)
 
         # Text input field
-        self._note_input = NoteTextEdit(self)
-        self._note_input.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
-        self._note_input.setPlaceholderText("Type your note here...")
-        self._note_input.setProperty("class", "note-input")
-        input_layout.addWidget(self._note_input)
+        self.note_input = NoteTextEdit(self)
+        self.note_input.setPlaceholderText("Type your note here...")
+        self.note_input.setProperty("class", "note-input")
+
+        # Restore pending content if any
+        if self._pending_note_html:
+            self.note_input.setHtml(self._pending_note_html)
+            # Move cursor to end
+            cursor = self.note_input.textCursor()
+            cursor.movePosition(QTextCursor.MoveOperation.End)
+            self.note_input.setTextCursor(cursor)
+
+        self.note_input.textChanged.connect(self._save_pending_note)
+
+        # Make actual tabs 4 spaces wide
+        metrics = self.note_input.fontMetrics()
+        self.note_input.setTabStopDistance(float(metrics.horizontalAdvance(" ") * 4))
+
+        input_layout.addWidget(self.note_input)
 
         # Button row
         button_container = QWidget()
@@ -167,7 +410,7 @@ class NotesWidget(BaseWidget):
         self.add_button = QPushButton("Add Note")
         self.add_button.setProperty("class", "add-button")
         self.add_button.setCursor(QCursor(Qt.CursorShape.PointingHandCursor))
-        self.add_button.clicked.connect(self._add_note_from_input)
+        self.add_button.clicked.connect(self.add_note_from_input)
         button_layout.addWidget(self.add_button)
 
         # Cancel button (hidden by default)
@@ -178,18 +421,23 @@ class NotesWidget(BaseWidget):
         self.cancel_button.hide()
         button_layout.addWidget(self.cancel_button)
 
+        # If we are in edit mode, update buttons
+        if self.editing_note:
+            self.add_button.setText("Save Changes")
+            self.cancel_button.show()
+
         input_layout.addWidget(button_container)
         main_layout.addWidget(input_container)
 
         # Create scroll area for notes
-        scroll_area = QScrollArea()
-        scroll_area.setWidgetResizable(True)
-        scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        scroll_area.setProperty("class", "scroll-area")
+        self.scroll_area = QScrollArea()
+        self.scroll_area.setWidgetResizable(True)
+        self.scroll_area.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.scroll_area.setProperty("class", "scroll-area")
 
         # Style the scrollbar
-        scroll_area.setViewportMargins(0, 0, -4, 0)
-        scroll_area.setStyleSheet("""
+        self.scroll_area.setViewportMargins(0, 0, -4, 0)
+        self.scroll_area.setStyleSheet("""
             QScrollBar:vertical { border: none; background:transparent; width: 4px; }
             QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical { background: transparent; }
             QScrollBar::handle:vertical { background: rgba(255, 255, 255, 0.2); min-height: 10px; border-radius: 2px; }
@@ -198,70 +446,81 @@ class NotesWidget(BaseWidget):
         """)
 
         # Create scroll widget and layout
-        scroll_widget = QWidget()
-        scroll_widget.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
-        scroll_layout = QVBoxLayout(scroll_widget)
-        scroll_layout.setContentsMargins(0, 0, 0, 0)
-        scroll_layout.setSpacing(0)
+        self.scroll_widget = QWidget()
+        self.scroll_widget.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.scroll_layout = QVBoxLayout(self.scroll_widget)
+        self.scroll_layout.setContentsMargins(0, 0, 0, 0)
+        self.scroll_layout.setSpacing(0)
+        self.scroll_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
 
-        scroll_area.setWidget(scroll_widget)
+        self.scroll_area.setWidget(self.scroll_widget)
 
         # Add notes to the scroll area
-        if self._notes:
-            for note in self._notes:
-                self._add_note_to_menu(note, scroll_layout)
-        else:
-            # Show empty state
-            empty_label = QLabel(f"{self.config.icons.note}  No notes yet!")
-            empty_label.setProperty("class", "empty-list")
-            empty_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            scroll_layout.addWidget(empty_label)
+        self._refresh_notes_list()
 
-        main_layout.addWidget(scroll_area)
+        main_layout.addWidget(self.scroll_area)
 
-        # Initialize edit mode tracking
-        self._editing_note = None
+        if self.menu:
+            self.menu.adjustSize()
+            self.menu.setPosition(
+                alignment=self.config.menu.alignment,
+                direction=self.config.menu.direction,
+                offset_left=self.config.menu.offset_left,
+                offset_top=self.config.menu.offset_top,
+            )
+            self.menu.show()
 
-        self._menu.adjustSize()
-        self._menu.setPosition(
-            alignment=self.config.menu.alignment,
-            direction=self.config.menu.direction,
-            offset_left=self.config.menu.offset_left,
-            offset_top=self.config.menu.offset_top,
-        )
-        self._menu.show()
-        self._note_input.setFocus()
+            if self.is_floating:
+                self.menu.set_floating(True)
+                if current_pos is not None:
+                    self.menu.move(current_pos)
+                self.float_btn.setText(self.icons["float_off"])
+                set_tooltip(self.float_btn, "Dock window")
+                self.close_btn.setVisible(True)
+            elif self._start_floating:
+                self._floating_controller.toggle_floating()
 
-    def _add_note_from_input(self):
+            force_foreground_focus(int(self.menu.winId()))
+        self.note_input.setFocus()
+
+    def _save_pending_note(self) -> None:
+        """Save the current input content to memory"""
+        if not sip.isdeleted(self.note_input):
+            if self.note_input.toPlainText().strip():
+                self._pending_note_html = self.note_input.toHtml()
+            else:
+                self._pending_note_html = ""
+
+    def add_note_from_input(self) -> None:
         """Add a new note or save changes to an existing note"""
-        note_text = self._note_input.toPlainText().strip()
-        if not note_text:
+        plain_text = self.note_input.toPlainText().strip()
+        if not plain_text:
             return
 
-        note_data = {"title": note_text, "timestamp": datetime.datetime.now().isoformat()}
+        note_data: dict[str, str] = {
+            "title": plain_text,
+            "html": self.note_input.toHtml(),
+            "timestamp": datetime.datetime.now().isoformat(),
+        }
 
-        if self._editing_note:
+        if self.editing_note:
             # Update existing note
-            for i, existing_note in enumerate(self._notes):
-                if existing_note == self._editing_note:
-                    self._notes[i] = note_data
+            for i, existing_note in enumerate(self.notes):
+                if existing_note == self.editing_note:
+                    self.notes[i] = note_data
                     break
-            self._editing_note = None  # Reset edit mode
+            self.editing_note = None  # Reset edit mode
             self.add_button.setText("Add Note")
             self.cancel_button.hide()
         else:
             # Add new note
-            self._notes.insert(0, note_data)
+            self.notes.insert(0, note_data)
 
         self._save_notes()
+        self.note_input.clear()
         NotesWidget.update_all()  # Update all widget instances
-        self._note_input.clear()
 
-        if hasattr(self, "_menu"):
-            self._menu.hide()
-            self._show_menu()
-
-    def _add_note_to_menu(self, note, layout):
+    def _add_note_to_menu(self, note: dict[str, str], layout: QVBoxLayout) -> None:
         container = QWidget()
         container.setProperty("class", "note-item")
         container.setContentsMargins(0, 0, 0, 0)
@@ -279,17 +538,18 @@ class NotesWidget(BaseWidget):
 
         # Vertical layout for title + date
         text_container = QWidget()
+        text_container.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
         text_layout = QVBoxLayout(text_container)
         text_layout.setContentsMargins(0, 0, 0, 0)
         text_layout.setSpacing(6)
 
         # Title
-        display_title = re.sub(r"[\n\t\r]+", "", note["title"])
+        lines = note["title"].splitlines()
+        display_title = lines[0] if lines else ""
         if len(display_title) > self.config.menu.max_title_size:
             display_title = display_title[: (self.config.menu.max_title_size - 3)] + "..."
-        title_label = QLabel(display_title)
+        title_label = ElidedLabel(display_title)
         title_label.setProperty("class", "title")
-        title_label.setWordWrap(True)
         title_label.setAlignment(Qt.AlignmentFlag.AlignVCenter)
         text_layout.addWidget(title_label)
 
@@ -332,89 +592,75 @@ class NotesWidget(BaseWidget):
         container_layout.addWidget(buttons_container)
 
         # Edit on click
-        container.mousePressEvent = lambda e: self._edit_note(note) if e.button() == Qt.MouseButton.LeftButton else None
+        container.mousePressEvent = lambda a0: (
+            self._edit_note(note) if a0 and a0.button() == Qt.MouseButton.LeftButton else None
+        )
 
         # Add container to vertical layout
         layout.addWidget(container)
 
-    def _edit_note(self, note):
+    def _edit_note(self, note: dict[str, str]) -> None:
         """Edit an existing note in the popup menu"""
         # Set editing mode
-        self._editing_note = note
+        self.editing_note = note
 
         # Load note content into the input field
-        self._note_input.setText(note["title"])
-        self._note_input.setFocus()
+        if "html" in note:
+            self.note_input.setHtml(note["html"])
+        else:
+            self.note_input.setText(note["title"])
+        self.note_input.setFocus()
 
         # Update UI to show we're in edit mode
         self.add_button.setText("Save Changes")
         self.cancel_button.show()
 
-    def _delete_note(self, note):
+    def _delete_note(self, note: dict[str, str]) -> None:
         """Delete a note"""
-        if note in self._notes:
-            self._notes.remove(note)
+        if note in self.notes:
+            self.notes.remove(note)
             self._save_notes()
             NotesWidget.update_all()  # Update all widget instances
 
-            if hasattr(self, "_menu"):
-                self._menu.hide()
-                self._show_menu()
+    def _on_clear_chat(self) -> None:
+        """Clear all notes (if such action is needed)"""
+        self.notes = []
+        self._save_notes()
+        NotesWidget.update_all()
 
-    def _cancel_editing(self):
+    def _cancel_editing(self) -> None:
         """Cancel editing mode"""
-        self._editing_note = None
-        self._note_input.clear()
+        self.editing_note = None
+        self.note_input.clear()
         self.add_button.setText("Add Note")
         self.cancel_button.hide()
 
-    def _copy_note(self, note):
+    def _copy_note(self, note: dict[str, str]) -> None:
         """Copy note content to clipboard"""
-        from PyQt6.QtWidgets import QApplication
 
         clipboard = QApplication.clipboard()
-        clipboard.setText(note["title"])
+        if clipboard:
+            clipboard.setText(note["title"])
 
-    def _load_notes(self) -> List[Dict]:
+    def _load_notes(self) -> list[dict[str, str]]:
         """Load notes from JSON file"""
         try:
-            if os.path.exists(self._notes_file):
+            if os.path.exists(self.notes_file):
                 if DEBUG:
-                    logging.debug(f"Loading notes from {self._notes_file}")
-                with open(self._notes_file, "r", encoding="utf-8") as f:
+                    logging.debug(f"Loading notes from {self.notes_file}")
+                with open(self.notes_file, "r", encoding="utf-8") as f:
                     return list(json.load(f))
         except Exception as e:
             logging.error(f"Error loading notes: {e}")
 
         return []
 
-    def _save_notes(self):
+    def _save_notes(self) -> None:
         """Save notes to JSON file"""
         try:
             if DEBUG:
-                logging.debug(f"Saving notes to {self._notes_file}")
-            with open(self._notes_file, "w", encoding="utf-8") as f:
-                json.dump(self._notes, f, indent=2, ensure_ascii=False)
+                logging.debug(f"Saving notes to {self.notes_file}")
+            with open(self.notes_file, "w", encoding="utf-8") as f:
+                json.dump(self.notes, f, indent=2, ensure_ascii=False)
         except Exception as e:
             logging.error(f"Error saving notes: {e}")
-
-
-class NoteTextEdit(QTextEdit):
-    """
-    Custom QTextEdit widget for note input that overrides keyPressEvent.
-    Captures Enter/Return key presses to trigger note addition in the parent widget,
-    while allowing multiline input using Shift+Enter.
-    """
-
-    def keyPressEvent(self, event):
-        if event.key() in (Qt.Key.Key_Return, Qt.Key.Key_Enter) and not (
-            event.modifiers() & Qt.KeyboardModifier.ShiftModifier
-        ):
-            parent = self.parent()
-            while parent and not hasattr(parent, "_add_note_from_input"):
-                parent = parent.parent()
-            if parent:
-                parent._add_note_from_input()
-            event.accept()
-        else:
-            super().keyPressEvent(event)


### PR DESCRIPTION
- added floating window toggle
- added Tab and Shift+Tab indent/unindent for selection
- added option to start in floating mode
- added rich text save/load
- added copy button in the input field and styling
- added option to either paste plain text by default or rich text. Shift+Ctrl+V will invert this behavior
- added window header and styling
- refactored note adding and deleting to be dynamic
- plain text and html rich text are now both saved in json
- added option on enter to add a new note or add a new line
- pending notes will now persist in memory even if the window is closed
- updated the documentation

<img width="1029" height="615" alt="image" src="https://github.com/user-attachments/assets/27a1371d-2ab9-414c-992b-4abb57232c68" />
