### PR TITLE
feat(quick_launch): Add Custom Web Search Engines and Remove Default Options

### DIFF
--- a/docs/widgets/(Widget)-Quick-Launch.md
+++ b/docs/widgets/(Widget)-Quick-Launch.md
@@ -527,7 +527,8 @@ Opens a web search in the default browser. Type `?` followed by a search query (
 | `prefix`   | string | `"?"`      | Trigger prefix. Use `"*"` to include in default results.                             |
 | `priority` | int    | `0`        | Sort order when multiple providers share the same prefix. Lower values appear first. |
 | `engine`   | string | `"google"` | Preferred (first) search engine. All other engines are shown below it.               |
-| `custom_engines` | list[{key: string, name: string, url: string, description: string, icon: string}] | `None` | List of custom search engines that are not included in the defaults. The icon property should be a stringified SVG. A default icon will be provided if not set in your configuration.
+| `custom_engines` | list[{engine: string, name: string, url: string, description: string, icon: string}] | [] | List of custom search engines that are not included in the defaults. The icon property should be a stringified SVG. A default icon will be provided if not set in your configuration. |
+| `remove_engines` | list[str]  | []  | Default engines you want to remove from the list of results |
 
 Default engines:
 
@@ -541,8 +542,9 @@ Default engines:
 | `"youtube"`       | YouTube video search                |
 | `"reddit"`        | Reddit posts and communities search |
 | `"stackoverflow"` | Stack Overflow programming Q&A      |
+| `"x"`             | Search X (formerly Twitter) post    |
 
-You can add your own engines through the `custom_engines` property like this:
+You can add your own engines through the `custom_engines`, and remove default engines you don't want, like this:
 ```yaml
       web_search:
         enabled: true
@@ -550,11 +552,14 @@ You can add your own engines through the `custom_engines` property like this:
         priority: 19
         engine: "brave"
         custom_engines:
-          - key: "brave"
+          - engine: "brave"
             name: "Brave"
             url: "https://search.brave.com/search?q={}"
             description: "Private Web Search"
             icon: '<svg viewBox="0 0 300 345" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid"><defs><linearGradient x1="0%" y1="50.017894%" x2="100.096998%" y2="50.017894%" id="linearGradient-1"><stop stop-color="#fff" offset="0%"/><stop stop-color="#fff" stop-opacity="0.9576" offset="14.13%"/><stop stop-color="#fff" stop-opacity="0.7" offset="100%"/></linearGradient><linearGradient x1="-0.0390588235%" y1="49.9824538%" x2="100%" y2="49.9824538%" id="linearGradient-2"><stop stop-color="#F1F1F2" offset="0%"/><stop stop-color="#E4E5E6" offset="9.191442%"/><stop stop-color="#D9DADB" offset="23.57%"/><stop stop-color="#D2D4D5" offset="43.8%"/><stop stop-color="#D0D2D3" offset="100%"/></linearGradient></defs><rect width="300" height="345" rx="70" ry="70" fill="#F15A22"/><g transform="translate(22,22)"><path d="M256 97.1 246.7 72l6.4-14.4c.8-1.9.4-4-1-5.5l-17.5-17.7c-7.7-7.7-19.1-10.4-29.4-6.8l-4.9 1.7L173.5.3 128.2 0h-.3L82.3.4 55.6 29.6l-4.8-1.7c-10.4-3.7-21.9-.9-29.6 7L3.4 52.8c-1.2 1.2-1.5 2.9-.9 4.4l6.7 15-9.2 25.1 6 22.7 27.2 103.3c3.1 11.9 10.3 22.3 20.4 29.5 0 0 33 23.3 65.5 44.4 2.9 1.9 5.9 3.2 9.1 3.2s6.2-1.3 9.1-3.2c36.6-24 65.5-44.5 65.5-44.5 10-7.2 17.2-17.6 20.3-29.5l27-103.3 5.9-22.8z" fill="#F15A22" stroke="#fff" stroke-width="8" stroke-linejoin="round"/><path d="M134 184.801c-1.2-.5-2.5-.9-2.9-.9h-1.6-1.6c-.4 0-1.7.4-2.9.9l-13 5.4c-1.2.5-3.2 1.4-4.4 2l-19.6 10.2c-1.2.6-1.3 1.7-.2 2.5l17.3 12.2c1.1.8 2.8 2.1 3.8 3l7.7 6.6c1 1 2.6 2.4 3.6 3.3l7.4 6.6c1 1 2.6 1 3.6 0l7.6-6.6c1-.9 2.6-2.3 3.6-3.3l7.7-6.7c1-.9 2.7-2.2 3.8-3l17.3-12.3c1.1-.8 1-1.9-.2-2.5l-19.6-10c-1.2-.6-3.2-1.5-4.4-2l-13-5.4z" fill="#fff" stroke="#fff" stroke-width="6" stroke-linejoin="round" stroke-linecap="round"/><path d="M227.813 101.557c.4-1.3.4-1.8.4-1.8 0-1.3-.1-3.5-.3-4.8l-1-2.9c-.6-1.2-1.6-3.1-2.4-4.2l-11.3-16.7c-.7-1.1-2-2.8-2.9-3.9l-14.6-18.3c-.8-1-1.6-1.9-1.7-1.8h-.2s-1.1.2-2.4.4l-22.3 4.4c-1.3.3-3.4.7-4.7.9l-.4.1c-1.3.2-3.4.1-4.7-.3l-18.7-6c-1.3-.4-3.4-1-4.6-1.3 0 0-3.8-.9-6.9-.8-3.1 0-6.9.8-6.9.8-1.3.3-3.4.9-4.6 1.3l-18.7 6c-1.3.4-3.4.5-4.7.3l-.4-.1c-1.3-.2-3.4-.7-4.7-.9l-22.5-4.2c-1.3-.3-2.4-.4-2.4-.4h-.2c-.1 0-.9.8-1.7 1.8L47.713 67.457c-.8 1-2.1 2.8-2.9 3.9l-11.3 16.7c-.7 1.1-1.8 3-2.4 4.2l-1 2.9c-.2 1.3-.4 3.5-.3 4.8 0 0 0 .4.4 1.8.7 2.4 2.4 4.6 2.4 4.6.8 1 2.3 2.7 3.2 3.6l33.1 35.2c.9 1 1.2 2.8.7 4l-6.9 16.3c-.5 1.2-.6 3.2-.1 4.5l1.9 5.1c1.6 4.3 4.3 8.1 7.9 11l6.7 5.4c1 .8 2.8 1.1 4 .5l21.2-10.1c1.2-.6 3-1.8 4-2.7l15.2-13.7c2.2-2 2.3-5.4.3-7.6l-31.9-21.5c-1.1-.7-1.5-2.3-.9-3.5l14-26.4c.6-1.2.7-3.1.2-4.3l-1.7-3.9c-.5-1.2-2-2.6-3.2-3.1l-41.1-15.4c-1.2-.5-1.2-1 0-1.1l26.5-2.5c1.3-.1 3.4.1 4.7.4l23.6 6.6c1.3.4 2.1 1.7 1.9 3l-8.2 44.9c-.2 1.3-.2 3.1.1 4.1.3 1 1.6 1.9 2.9 2.2l16.4 3.5c1.3.3 3.4.3 4.7 0l15.3-3.5c1.3-.3 2.6-1.3 2.9-2.2.3-1 .4-2.8.1-4.1l-8.1-44.9c-.2-1.3.6-2.6 1.9-3l23.6-6.6c1.3-.4 3.4-.5 4.7-.4l26.5 2.5c1.2.1 1.3.6 0 1.1l-41.1 15.4c-1.2.5-2.7 1.9-3.2 3.1l-1.7 3.9c-.5 1.2-.5 3.1.2 4.3l14.1 26.4c.6 1.2.2 2.8-.9 3.5l-31.9 21.5c-2.1 2.1-1.9 5.6.3 7.6l15.2 13.7c1 .9 2.8 2.1 4 2.7l21.3 10.1c1.2.6 3 .3 4-.5l6.7-5.4c3.6-2.9 6.3-6.7 7.8-11l1.9-5.1c.5-1.2.4-3.2-.1-4.5l-6.9-16.3c-.5-1.2-.2-3 .7-4l33.1-35.2c.9-.9 2.3-2.6 3.2-3.6-.2-.3 1.6-2.5 2.2-4.9z" fill="#fff" stroke="#fff" stroke-width="6" stroke-linejoin="round" stroke-linecap="round"/></g></svg>'
+        remove_engines:
+          - "google"
+          - "bing"
 ```
 
 ### Window Switcher Provider

--- a/src/core/utils/widgets/quick_launch/providers/web_search.py
+++ b/src/core/utils/widgets/quick_launch/providers/web_search.py
@@ -83,6 +83,17 @@ class WebSearchProvider(BaseProvider):
     input_placeholder = "Search the web..."
     icon = ICON_WEB_SEARCH
 
+    def __init__(self, config=None):
+        super().__init__(config)
+        custom_engines = self.config.get("custom_engines")
+        engines_to_remove = self.config.get("remove_engines")
+        if custom_engines.count is not None:
+            for engine in custom_engines:
+                _ENGINES[engine["engine"]] = engine
+        if engines_to_remove is not None:
+            for engine in engines_to_remove:
+                _ENGINES.pop(engine, None)
+
     def match(self, text: str) -> bool:
         if self.prefix:
             return text.strip().startswith(self.prefix)
@@ -92,10 +103,6 @@ class WebSearchProvider(BaseProvider):
         """Return engines with the preferred one first."""
         preferred = self.config.get("engine", "google")
         ordered: list[tuple[str, dict]] = []
-        custom_engines = self.config.get("custom_engines")
-        if custom_engines is not None:
-            for engine in custom_engines:
-                _ENGINES[engine["key"]] = engine
         for key, info in _ENGINES.items():
             if key == preferred:
                 ordered.insert(0, (key, info))
@@ -120,11 +127,12 @@ class WebSearchProvider(BaseProvider):
 
         results: list[ProviderResult] = []
         for key, info in engines:
+            icon = info["icon"]
             results.append(
                 ProviderResult(
                     title=f'Search {info["name"]} for "{query}"',
                     description=info["description"],
-                    icon_char=info["icon"],
+                    icon_char=ICON_WEB_SEARCH if not icon else icon,
                     provider=self.name,
                     action_data={"query": query, "engine": key},
                 )

--- a/src/core/validation/widgets/yasb/quick_launch.py
+++ b/src/core/validation/widgets/yasb/quick_launch.py
@@ -2,7 +2,6 @@ from typing import Literal
 
 from pydantic import Field
 
-from core.utils.widgets.quick_launch.providers.resources.icons import ICON_WEB_SEARCH
 from core.validation.widgets.base_model import (
     AnimationConfig,
     CallbacksConfig,
@@ -44,10 +43,10 @@ class CalculatorProviderConfig(CustomBaseModel):
 
 
 class WebSearchEngineConfig(CustomBaseModel):
-    key: str
+    engine: str
     name: str
     url: str
-    icon: str = ICON_WEB_SEARCH
+    icon: str = ""
     description: str = "Search the web"
 
 
@@ -57,6 +56,7 @@ class WebSearchProviderConfig(CustomBaseModel):
     priority: int = 0
     engine: str = "google"
     custom_engines: list[WebSearchEngineConfig] = []
+    remove_engines: list[str] = []
 
 
 class SystemCommandsProviderConfig(CustomBaseModel):


### PR DESCRIPTION
Allows the ability to add custom engines to the list of default engines for the web_search provider.  Also allows the user to remove any of the default web search engines they don't need.