### PR TITLE
fix(calculator): remove commas from queries and use configurable prefix

### DIFF
--- a/src/core/utils/widgets/quick_launch/providers/calculator.py
+++ b/src/core/utils/widgets/quick_launch/providers/calculator.py
@@ -99,7 +99,7 @@ class CalculatorProvider(BaseProvider):
         return has_digit and has_operator
 
     def get_results(self, text: str, **kwargs) -> list[ProviderResult]:
-        query = self.get_query_text(text) if text.startswith("=") else text.strip()
+        query = self.get_query_text(text).replace(",", "") if text.startswith(self.prefix) else text.strip()
         if not query:
             return [
                 ProviderResult(
@@ -128,7 +128,6 @@ class CalculatorProvider(BaseProvider):
                     display = f"{result_val:g}"
             else:
                 display = str(result_val)
-
             return [
                 ProviderResult(
                     title=display,


### PR DESCRIPTION
This update improves the calculator command by automatically removing commas from input queries, ensuring they evaluate correctly, and replaces the previously hardcoded `"="` prefix with the configurable `self.prefix` for more flexible usage