### PR TITLE
fix(systray): fixed systray popup relayout bug

### DIFF
--- a/src/core/utils/widgets/systray/systray_widget.py
+++ b/src/core/utils/widgets/systray/systray_widget.py
@@ -386,14 +386,17 @@ class DropWidget(QFrame):
         return self.main_layout.count()
 
     def add_icon_to_grid(self, icon: IconWidget):
-        count = len(self._get_all_icons())
-        cols = self._grid_cols
-        self.main_layout.addWidget(icon, count // cols, count % cols)
+        icons = self._get_all_icons()
+        if icon not in icons:
+            icons.append(icon)
+        self.relayout_grid(icons)
 
     def relayout_grid(self, icons: list[IconWidget] | None = None):
         if icons is None:
             icons = self._get_all_icons()
         layout = self.main_layout
+        if not isinstance(layout, QGridLayout):
+            return
         for icon in icons:
             layout.removeWidget(icon)
         for r in range(layout.rowCount()):
@@ -405,9 +408,14 @@ class DropWidget(QFrame):
         cols = self._grid_cols
         visible_idx = 0
         for icon in icons:
+            # Keep hidden icons in the layout to prevent them from being orphaned
             if icon.isHidden():
+                # Placing them at the current visible index cell does not mess up the visible order
+                layout.addWidget(icon, visible_idx // cols, visible_idx % cols)
+                layout.setAlignment(icon, Qt.AlignmentFlag.AlignCenter)
                 continue
             layout.addWidget(icon, visible_idx // cols, visible_idx % cols)
+            layout.setAlignment(icon, Qt.AlignmentFlag.AlignCenter)
             icon.show()
             visible_idx += 1
         layout.invalidate()

--- a/src/core/widgets/yasb/systray.py
+++ b/src/core/widgets/yasb/systray.py
@@ -401,7 +401,10 @@ class SystrayWidget(BaseWidget):
             self.sort_timer.start(1000)
         self.update_icon_data(icon.data, data)
         icon.update_icon()
+        was_hidden = icon.isHidden()
         icon.setHidden(data.uFlags & NIF_STATE != 0 and data.dwState == 1)
+        if self.config.show_in_popup and was_hidden != icon.isHidden():
+            self._relayout_popup_grid()
         self.pinned_vis_check_timer.start(300)
 
     @pyqtSlot(IconData)


### PR DESCRIPTION
- hidden icons were orphaned on relayout (removed from the grid)
- instead they are now retained and hidden under the nearest visible cell
- added additional relayout for `on_icon_modified`