### PR TITLE
feat(config): add deprecation system with CLI migration tool

### DIFF
--- a/docs/widgets/(Widget)-Clock.md
+++ b/docs/widgets/(Widget)-Clock.md
@@ -14,7 +14,6 @@
 | `calendar` | dict | `{'blur': True, 'round_corners': True, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0, 'country_code': None, 'subdivision': None, 'show_holidays': False, 'holiday_color': "#FF6464", 'show_week_numbers': False, 'show_years': True, 'extended': False}` | Calendar settings for the widget. |
 | `callbacks`         | dict    | `{'on_left': 'toggle_calendar', 'on_middle': 'next_timezone', 'on_right': 'toggle_label'}` | Callbacks for mouse events on the clock widget.                                                                     |
 | `animation`         | dict    | `{'enabled': True, 'type': 'fadeInOut', 'duration': 200}`                             | Animation settings for the widget.                                                                                  |
-| `container_padding` | dict    | `{'top': 0, 'left': 0, 'bottom': 0, 'right': 0}`                                      | Padding for the widget container.                                                                                    |
 | `container_shadow`   | dict   | `{'enabled': False, 'color': 'black', 'offset': [1, 1], 'radius': 3}`                  | Container shadow options.                       |
 | `label_shadow`         | dict   | `{'enabled': False, 'color': 'black', 'offset': [1, 1], 'radius': 3}`                  | Label shadow options.                 |
 
@@ -69,11 +68,6 @@ clock:
       on_left: "toggle_calendar"
       on_middle: "next_timezone"
       on_right: "toggle_label"
-    container_padding:
-      top: 0
-      left: 0
-      bottom: 0
-      right: 0
     label_shadow:
       enabled: true
       color: "black"
@@ -113,7 +107,6 @@ clock:
   - **extended:** Show extended calendar with alarm/timer controls and upcoming holidays.
 - **callbacks:** A dictionary specifying the callbacks for mouse events. The keys are `on_left`, `on_middle`, and `on_right`, and the values are the names of the callback functions. Available callbacks: `toggle_calendar`, `next_timezone`, `toggle_label`, `context_menu`.
 - **animation:** A dictionary specifying the animation settings for the widget. It contains three keys: `enabled`, `type`, and `duration`. The `type` can be `fadeInOut` and the `duration` is the animation duration in milliseconds.
-- **container_padding:** A dictionary specifying the padding for the widget container with keys: `top`, `left`, `bottom`, `right`.
 - **container_shadow:** Container shadow options with keys: `enabled`, `color`, `offset`, `radius`.
 - **label_shadow:** Label shadow options with keys: `enabled`, `color`, `offset`, `radius`.
 

--- a/docs/widgets/(Widget)-GlazeWM-Workspaces.md
+++ b/docs/widgets/(Widget)-GlazeWM-Workspaces.md
@@ -8,7 +8,6 @@
 | `active_empty_label`     | string  | `'{name}'`                                       | Optional label for the currently active workspace (has no windows opened). |
 | `focused_populated_label`| string  | `'{name}'`                                       | Optional label for the currently focused workspace (has opened windows). Falls back to `active_populated_label` if not set.  |
 | `focused_empty_label`    | string  | `'{name}'`                                       | Optional label for the currently focused workspace (has no windows opened). Falls back to `active_empty_label` if not set. |
-| `hide_empty_workspaces`  | boolean | `true`                                           | Whether to hide empty workspaces.                                           |
 | `hide_if_offline`        | boolean | `false`                                          | Whether to hide workspaces widget if GlazeWM is offline.                    |
 | `monitor_exclusive`      | boolean | `true`                                           | If `true`, show monitor-local workspaces (default). If `false`, aggregate active workspaces from GlazeWM IPC and show them on every bar. |
 | `glazewm_server_uri`     | string  | `'ws://localhost:6123'`                          | Optional GlazeWM server uri.                                                |
@@ -26,7 +25,6 @@ glazewm_workspaces:
   type: "glazewm.workspaces.GlazewmWorkspacesWidget"
   options:
     offline_label: "GlazeWM Offline"
-    hide_empty_workspaces: true
     hide_if_offline: false
     monitor_exclusive: true
     enable_scroll_switching: true
@@ -62,7 +60,6 @@ glazewm_workspaces:
 - **active_empty_label:** Optional label for the currently active workspace (has no windows opened). If not set, name or display_name from GlazeWM will be used.
 - **focused_populated_label:** Optional label for the currently focused workspace (has windows opened). If not set, **active_populated_label** will be used, falling back to name or display_name from GlazeWM.
 - **focused_empty_label:** Optional label for the currently focused workspace (has no windows opened). If not set, **active_empty_label** will be used, falling back to name or display_name from GlazeWM.
-- **hide_empty_workspaces:** Whether to hide empty workspaces.
 - **hide_if_offline:** Whether to hide workspaces widget if GlazeWM is offline.
 - **monitor_exclusive:** If enabled (default), follows monitor-local workspace rendering. If disabled, the widget renders active workspaces from GlazeWM IPC on all bars and highlights the globally focused workspace using IPC focus state.
 - **glazewm_server_uri:** Optional GlazeWM server uri if it ever changes on GlazeWM side.

--- a/docs/widgets/(Widget)-Obs.md
+++ b/docs/widgets/(Widget)-Obs.md
@@ -16,7 +16,6 @@ ObsWidget is a custom widget that integrates with OBS (Open Broadcaster Software
 | `show_scene_name` | boolean | `false` | Show current OBS program scene name |
 | `show_stream_stats` | boolean | `false` | Show stream bitrate (kbps) and dropped frames while streaming |
 | `tooltip` | boolean | `true` | Enable or disable tooltips for buttons |
-| `container_padding` | dict | `{top: 0, left: 0, bottom: 0, right: 0}` | Padding around the widget container |
 
 
 ## Example Configuration

--- a/src/cli.py
+++ b/src/cli.py
@@ -361,6 +361,11 @@ class CLIHandler:
             help="Tail yasb process logs (cancel with Ctrl-C)",
             add_help=False,
         )
+        subparsers.add_parser(
+            "migrate-config",
+            help="Find and fix deprecated options in config",
+            add_help=False,
+        )
         parser.add_argument(
             "-v",
             "--version",
@@ -601,6 +606,60 @@ class CLIHandler:
                 print(f"Failed to open config directory: {e}")
             sys.exit(0)
 
+        elif args.command == "migrate-config":
+            from pathlib import Path
+
+            from core.validation.deprecation import migrate_config
+
+            config_path = Path(DEFAULT_CONFIG_DIRECTORY) / "config.yaml"
+            if not config_path.exists():
+                print(f"Config file not found: {config_path}")
+                sys.exit(1)
+
+            try:
+                raw = config_path.read_text(encoding="utf-8")
+            except Exception as e:
+                print(f"Failed to read config: {e}")
+                sys.exit(1)
+
+            new_text, changes = migrate_config(raw)
+            if not changes:
+                print("No deprecated options found. Your config is up to date.")
+                sys.exit(0)
+
+            print(f"\nFound {len(changes)} deprecated option(s) in your config:\n")
+            for change in changes:
+                if change["action"] == "remove":
+                    print(f"  {Format.yellow}{change['path']}{Format.reset}")
+                    print(f"    Will be removed. {change['message']}")
+                elif change["action"] == "rename":
+                    print(
+                        f"  {Format.yellow}{change['path']}{Format.reset} -> {Format.green}{change['new_name']}{Format.reset}"
+                    )
+                    print(f"    Will be renamed. {change['message']}")
+                print()
+
+            confirm = input("Apply changes? (Y/n): ").strip().lower()
+            if confirm not in ["y", "yes", ""]:
+                print("Migration cancelled.")
+                sys.exit(0)
+
+            backup_path = config_path.with_suffix(".yaml.bak")
+            try:
+                backup_path.write_text(raw, encoding="utf-8")
+                print(f"Backup saved to {backup_path}")
+            except Exception as e:
+                print(f"Failed to create backup: {e}")
+                sys.exit(1)
+
+            try:
+                config_path.write_text(new_text, encoding="utf-8")
+                print(f"Config migrated successfully. {len(changes)} option(s) updated.")
+            except Exception as e:
+                print(f"Failed to write config: {e}")
+                sys.exit(1)
+            sys.exit(0)
+
         elif args.config:
             print(DEFAULT_CONFIG_DIRECTORY)
             sys.exit(0)
@@ -627,6 +686,7 @@ class CLIHandler:
                   log                       Tail yasb process logs (cancel with Ctrl-C)
                   reset                     Restore default config files and clear cache
                   config-dir                Open config directory in file explorer
+                  migrate-config            Find and fix deprecated options in config
                   help                      Print this message
 
                 {Format.underline}Options{Format.reset}:

--- a/src/core/setup/widgets_config.py
+++ b/src/core/setup/widgets_config.py
@@ -164,7 +164,6 @@ GLAZEWM_WIDGET: dict = {
             "glazewm_workspaces": {
                 "type": "glazewm.workspaces.GlazewmWorkspacesWidget",
                 "options": {
-                    "hide_empty_workspaces": False,
                     "hide_if_offline": True,
                     "monitor_exclusive": False,
                 },

--- a/src/core/validation/bar.py
+++ b/src/core/validation/bar.py
@@ -14,7 +14,6 @@ class BarAlignment(CustomBaseModel):
 class BarBlurEffect(CustomBaseModel):
     enabled: bool = False
     dark_mode: bool = False
-    acrylic: bool = False
     round_corners: bool = False
     round_corners_type: Literal["normal", "small"] = "normal"
     border_color: str = "System"

--- a/src/core/validation/bar.py
+++ b/src/core/validation/bar.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import CustomBaseModel
 
 class BarAlignment(CustomBaseModel):
     position: Literal["top", "bottom"] = "top"
-    center: bool = False  # deprecated
     align: Literal["left", "center", "right"] = "center"
 
 

--- a/src/core/validation/config.py
+++ b/src/core/validation/config.py
@@ -20,9 +20,6 @@ class YasbConfig(CustomBaseModel):
     watch_config: bool = True
     watch_stylesheet: bool = True
     debug: bool = False
-    # env_file is deprecated and will be removed in the future
-    # Use load .env file from the config folder instead
-    env_file: str | None = None
     update_check: bool = True
     show_systray: bool = True
     komorebi: KomorebiConfig = KomorebiConfig()

--- a/src/core/validation/deprecation.py
+++ b/src/core/validation/deprecation.py
@@ -85,9 +85,26 @@ SCOPED_DEPRECATED_FIELDS: dict[str, dict[str, str]] = {
     "HomeConfig": {
         "distance": "Use 'offset_top' instead.",
     },
+    "GlazewmWorkspacesConfig": {
+        "hide_empty_workspaces": "No longer supported and can be removed from the config.",
+    },
+    "BrightnessConfig": {
+        "hide_unsupported": "No longer supported and can be removed from the config.",
+    },
+    "YasbConfig": {
+        "env_file": "No longer supported. Place a .env file in the config folder instead.",
+    },
+    "GalleryConfig": {
+        "lazy_load_delay": "No longer supported and can be removed from the config.",
+        "enable_cache": "No longer supported and can be removed from the config.",
+    },
 }
 
-SCOPED_RENAMED_FIELDS: dict[str, dict[str, tuple[str, str]]] = {}
+SCOPED_RENAMED_FIELDS: dict[str, dict[str, tuple[str, str]]] = {
+    "ActiveLayoutIconsConfig": {
+        "maximised": ("maximized", "Use 'maximized' instead."),
+    },
+}
 
 
 def handle_deprecated_fields(cls: type, data: Any) -> Any:

--- a/src/core/validation/deprecation.py
+++ b/src/core/validation/deprecation.py
@@ -1,0 +1,183 @@
+"""Centralized deprecation registry and CLI migration tool.
+
+All deprecated or renamed config fields are registered here - both for
+runtime warnings (handle_deprecated_fields) and CLI migration (migrate_config).
+
+Adding a new deprecation
+------------------------
+
+1. Field removed from ALL widgets/models (global):
+
+    DEPRECATED_FIELDS = {
+        "label_shadow": "Use CSS text-shadow instead.",
+    }
+
+2. Field removed from a SPECIFIC model only (scoped):
+
+    SCOPED_DEPRECATED_FIELDS = {
+        "HomeConfig": {
+            "container_padding": "Use CSS padding instead.",
+        },
+    }
+
+3. Field renamed in a SPECIFIC model (scoped):
+
+    SCOPED_RENAMED_FIELDS = {
+        "MenuLabelsConfig": {
+            "logout": ("log_out", "Use 'log_out' instead."),
+        },
+    }
+
+4. Field renamed in ALL models (global):
+
+    RENAMED_FIELDS = {
+        "old_name": ("new_name", "Use 'new_name' instead."),
+    }
+
+The class name key (e.g. "HomeConfig", "BarBlurEffect") must match
+the Pydantic model's __name__ exactly.
+"""
+
+import logging
+from importlib import import_module
+from typing import Any
+
+from yaml import safe_load
+
+logger = logging.getLogger("deprecation")
+
+# Global - removed from any model that doesn't recognize it
+DEPRECATED_FIELDS: dict[str, str] = {}
+
+RENAMED_FIELDS: dict[str, tuple[str, str]] = {}
+
+# Scoped - keyed by class name (for runtime)
+SCOPED_DEPRECATED_FIELDS: dict[str, dict[str, str]] = {
+    "BarBlurEffect": {
+        "acrylic": "No longer supported and can be removed from the config.",
+    },
+}
+
+SCOPED_RENAMED_FIELDS: dict[str, dict[str, tuple[str, str]]] = {}
+
+
+def handle_deprecated_fields(cls: type, data: Any) -> Any:
+    """Runtime handler - called by model_validator on CustomBaseModel."""
+    if not isinstance(data, dict):
+        return data
+    cls_name = cls.__name__
+    deprecated = {**DEPRECATED_FIELDS, **SCOPED_DEPRECATED_FIELDS.get(cls_name, {})}
+    renamed = {**RENAMED_FIELDS, **SCOPED_RENAMED_FIELDS.get(cls_name, {})}
+    for key in list(data.keys()):
+        if key in cls.model_fields:
+            continue
+        if key in deprecated:
+            logger.warning("%s: '%s' is deprecated. %s", cls_name, key, deprecated[key])
+            del data[key]
+        elif key in renamed:
+            new_name, message = renamed[key]
+            logger.warning("%s: '%s' has been renamed to '%s'. %s", cls_name, key, new_name, message)
+            if new_name not in data:
+                data[new_name] = data[key]
+            del data[key]
+    return data
+
+
+def _check(data: dict, path: str, class_name: str, issues: list[dict]):
+    """Check dict keys against global + scoped deprecated/renamed for *class_name*."""
+    deprecated = {**DEPRECATED_FIELDS, **SCOPED_DEPRECATED_FIELDS.get(class_name, {})}
+    renamed = {**RENAMED_FIELDS, **SCOPED_RENAMED_FIELDS.get(class_name, {})}
+    for key in data:
+        kp = f"{path}.{key}"
+        if key in deprecated:
+            issues.append({"path": kp, "key": key, "action": "remove", "message": deprecated[key]})
+        elif key in renamed:
+            new_name, msg = renamed[key]
+            issues.append({"path": kp, "key": key, "action": "rename", "new_name": new_name, "message": msg})
+
+
+def _check_model(data: dict, path: str, model: type, issues: list[dict]):
+    """Check data against a Pydantic model and recurse into its sub-models."""
+    _check(data, path, model.__name__, issues)
+    for name, field in model.model_fields.items():
+        ann = field.annotation
+        if isinstance(ann, type) and hasattr(ann, "model_fields"):
+            val = data.get(name)
+            if isinstance(val, dict):
+                _check(val, f"{path}.{name}", ann.__name__, issues)
+
+
+def _scan(config: dict) -> list[dict]:
+    """Walk parsed YAML and collect all deprecated/renamed fields."""
+    from core.validation.bar import BarConfig
+
+    issues: list[dict] = []
+
+    for bar_name, bar in (config.get("bars") or {}).items():
+        if isinstance(bar, dict):
+            _check_model(bar, f"bars.{bar_name}", BarConfig, issues)
+
+    for wname, wdata in (config.get("widgets") or {}).items():
+        if not isinstance(wdata, dict):
+            continue
+        try:
+            mod, cls_name = wdata.get("type", "").rsplit(".", 1)
+            schema = getattr(import_module(f"core.widgets.{mod}"), cls_name).validation_schema
+        except Exception:
+            continue
+        opts = wdata.get("options")
+        if isinstance(opts, dict):
+            _check_model(opts, f"widgets.{wname}.options", schema, issues)
+
+    return issues
+
+
+def _patch(raw: str, issues: list[dict]) -> str:
+    """Remove/rename lines in raw text matched by exact YAML path."""
+    issue_paths = {i["path"]: i for i in issues}
+    lines = raw.splitlines(True)
+    result: list[str] = []
+    path_stack: list[tuple[int, str]] = []
+    skip_indent = -1
+
+    for line in lines:
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+
+        if skip_indent >= 0:
+            if not stripped.strip() or indent > skip_indent:
+                continue
+            skip_indent = -1
+
+        if stripped.strip() and ":" in stripped:
+            while path_stack and path_stack[-1][0] >= indent:
+                path_stack.pop()
+            key = stripped.split(":")[0].strip().strip("- ")
+            if key:
+                path_stack.append((indent, key))
+
+        current_path = ".".join(k for _, k in path_stack)
+
+        if current_path in issue_paths:
+            issue = issue_paths[current_path]
+            if issue["action"] == "remove":
+                skip_indent = indent
+                path_stack.pop()
+                continue
+            if issue["action"] == "rename":
+                line = line.replace(issue["key"], issue["new_name"], 1)
+
+        result.append(line)
+
+    return "".join(result)
+
+
+def migrate_config(raw: str) -> tuple[str, list[dict]]:
+    """Find and fix deprecated fields. safe_load to find, text to save."""
+    config = safe_load(raw)
+    if not isinstance(config, dict):
+        return raw, []
+    issues = _scan(config)
+    if not issues:
+        return raw, []
+    return _patch(raw, issues), issues

--- a/src/core/validation/deprecation.py
+++ b/src/core/validation/deprecation.py
@@ -47,7 +47,9 @@ from yaml import safe_load
 logger = logging.getLogger("deprecation")
 
 # Global - removed from any model that doesn't recognize it
-DEPRECATED_FIELDS: dict[str, str] = {}
+DEPRECATED_FIELDS: dict[str, str] = {
+    "container_padding": "Use CSS padding instead.",
+}
 
 RENAMED_FIELDS: dict[str, tuple[str, str]] = {}
 
@@ -55,6 +57,33 @@ RENAMED_FIELDS: dict[str, tuple[str, str]] = {}
 SCOPED_DEPRECATED_FIELDS: dict[str, dict[str, str]] = {
     "BarBlurEffect": {
         "acrylic": "No longer supported and can be removed from the config.",
+    },
+    "BarAlignment": {
+        "center": "Use 'align' instead.",
+    },
+    "VSCodeMenuConfig": {
+        "distance": "Use 'offset_top' instead.",
+    },
+    "BrightnessMenuConfig": {
+        "distance": "Use 'offset_top' instead.",
+    },
+    "ClockCalendarConfig": {
+        "distance": "Use 'offset_top' instead.",
+    },
+    "GroupLabelConfig": {
+        "distance": "Use 'offset_top' instead.",
+    },
+    "MenuConfig": {
+        "distance": "Use 'offset_top' instead.",
+    },
+    "AudioMenuConfig": {
+        "distance": "Use 'offset_top' instead.",
+    },
+    "WeatherCardConfig": {
+        "distance": "Use 'offset_top' instead.",
+    },
+    "HomeConfig": {
+        "distance": "Use 'offset_top' instead.",
     },
 }
 
@@ -72,11 +101,11 @@ def handle_deprecated_fields(cls: type, data: Any) -> Any:
         if key in cls.model_fields:
             continue
         if key in deprecated:
-            logger.warning("%s: '%s' is deprecated. %s", cls_name, key, deprecated[key])
+            logger.warning("[DEPRECATED] %s: '%s' - %s", cls_name, key, deprecated[key])
             del data[key]
         elif key in renamed:
             new_name, message = renamed[key]
-            logger.warning("%s: '%s' has been renamed to '%s'. %s", cls_name, key, new_name, message)
+            logger.warning("[DEPRECATED] %s: '%s' renamed to '%s' - %s", cls_name, key, new_name, message)
             if new_name not in data:
                 data[new_name] = data[key]
             del data[key]
@@ -98,13 +127,21 @@ def _check(data: dict, path: str, class_name: str, issues: list[dict]):
 
 def _check_model(data: dict, path: str, model: type, issues: list[dict]):
     """Check data against a Pydantic model and recurse into its sub-models."""
+    import typing
+
     _check(data, path, model.__name__, issues)
     for name, field in model.model_fields.items():
         ann = field.annotation
+        val = data.get(name)
         if isinstance(ann, type) and hasattr(ann, "model_fields"):
-            val = data.get(name)
             if isinstance(val, dict):
-                _check(val, f"{path}.{name}", ann.__name__, issues)
+                _check_model(val, f"{path}.{name}", ann, issues)
+        elif args := typing.get_args(ann):
+            inner = args[0]
+            if isinstance(inner, type) and hasattr(inner, "model_fields") and isinstance(val, list):
+                for i, item in enumerate(val):
+                    if isinstance(item, dict):
+                        _check_model(item, f"{path}.{name}[{i}]", inner, issues)
 
 
 def _scan(config: dict) -> list[dict]:
@@ -145,7 +182,7 @@ def _patch(raw: str, issues: list[dict]) -> str:
         indent = len(line) - len(stripped)
 
         if skip_indent >= 0:
-            if not stripped.strip() or indent > skip_indent:
+            if not stripped or indent > skip_indent:
                 continue
             skip_indent = -1
 

--- a/src/core/validation/widgets/base_model.py
+++ b/src/core/validation/widgets/base_model.py
@@ -38,10 +38,3 @@ class KeybindingConfig(CustomBaseModel):
     keys: str
     action: str
     screen: Literal["active", "cursor", "primary"] = "active"
-
-
-class PaddingConfig(CustomBaseModel):
-    top: int = 0
-    left: int = 0
-    bottom: int = 0
-    right: int = 0

--- a/src/core/validation/widgets/base_model.py
+++ b/src/core/validation/widgets/base_model.py
@@ -1,11 +1,18 @@
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from core.validation.deprecation import handle_deprecated_fields
 
 
 class CustomBaseModel(BaseModel):
     # This is required to prohibit extra fields in the config
     model_config = ConfigDict(extra="forbid", validate_default=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_deprecations(cls, data: Any) -> Any:
+        return handle_deprecated_fields(cls, data)
 
 
 class ShadowConfig(CustomBaseModel):

--- a/src/core/validation/widgets/glazewm/binding_mode.py
+++ b/src/core/validation/widgets/glazewm/binding_mode.py
@@ -3,7 +3,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -34,6 +33,5 @@ class GlazewmBindingModeConfig(CustomBaseModel):
     container_shadow: ShadowConfig = ShadowConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     keybindings: list[KeybindingConfig] = []
     callbacks: GlazewmBindingModeCallbacksConfig = GlazewmBindingModeCallbacksConfig()

--- a/src/core/validation/widgets/glazewm/workspaces.py
+++ b/src/core/validation/widgets/glazewm/workspaces.py
@@ -20,7 +20,6 @@ class GlazewmWorkspacesConfig(CustomBaseModel):
     active_empty_label: str | None = None
     focused_populated_label: str | None = None
     focused_empty_label: str | None = None
-    hide_empty_workspaces: bool = True  # deprecated
     hide_if_offline: bool = False
     monitor_exclusive: bool = True
     glazewm_server_uri: str = "ws://localhost:6123"

--- a/src/core/validation/widgets/glazewm/workspaces.py
+++ b/src/core/validation/widgets/glazewm/workspaces.py
@@ -1,4 +1,4 @@
-from core.validation.widgets.base_model import CustomBaseModel, PaddingConfig, ShadowConfig
+from core.validation.widgets.base_model import CustomBaseModel, ShadowConfig
 
 
 class AppIconsConfig(CustomBaseModel):
@@ -29,6 +29,5 @@ class GlazewmWorkspacesConfig(CustomBaseModel):
     container_shadow: ShadowConfig = ShadowConfig()
     btn_shadow: ShadowConfig = ShadowConfig()
     label_shadow: ShadowConfig = ShadowConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     app_icons: AppIconsConfig = AppIconsConfig()
     animation: bool = False

--- a/src/core/validation/widgets/komorebi/active_layout.py
+++ b/src/core/validation/widgets/komorebi/active_layout.py
@@ -2,7 +2,6 @@ from core.validation.widgets.base_model import (
     AnimationConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -64,7 +63,6 @@ class ActiveLayoutConfig(CustomBaseModel):
     ]
     layout_icons: ActiveLayoutIconsConfig = ActiveLayoutIconsConfig()
     layout_menu: ActiveLayoutMenuConfig = ActiveLayoutMenuConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     animation: AnimationConfig = AnimationConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()

--- a/src/core/validation/widgets/komorebi/active_layout.py
+++ b/src/core/validation/widgets/komorebi/active_layout.py
@@ -18,7 +18,6 @@ class ActiveLayoutIconsConfig(CustomBaseModel):
     right_main_vertical_stack: str = "=||"
     monocle: str = "[M]"
     maximized: str = "[X]"
-    maximised: str = "[X]"  # deprecated, use "maximized" instead
     floating: str = "><>"
     paused: str = "[P]"
     tiling: str = "[T]"

--- a/src/core/validation/widgets/komorebi/control.py
+++ b/src/core/validation/widgets/komorebi/control.py
@@ -5,7 +5,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -41,7 +40,6 @@ class KomorebiControlWidgetConfig(CustomBaseModel):
     show_version: bool = True
     komorebi_menu: KomorebiMenuConfig = KomorebiMenuConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/komorebi/stack.py
+++ b/src/core/validation/widgets/komorebi/stack.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from core.validation.widgets.base_model import CustomBaseModel, PaddingConfig, ShadowConfig
+from core.validation.widgets.base_model import CustomBaseModel, ShadowConfig
 
 
 class RewriteConfig(CustomBaseModel):
@@ -27,7 +27,6 @@ class StackConfig(CustomBaseModel):
     rewrite: list[RewriteConfig] = []
     enable_scroll_switching: bool = False
     reverse_scroll_direction: bool = False
-    container_padding: PaddingConfig = PaddingConfig()
     btn_shadow: ShadowConfig = ShadowConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()

--- a/src/core/validation/widgets/komorebi/workspaces.py
+++ b/src/core/validation/widgets/komorebi/workspaces.py
@@ -1,4 +1,4 @@
-from core.validation.widgets.base_model import CustomBaseModel, PaddingConfig, ShadowConfig
+from core.validation.widgets.base_model import CustomBaseModel, ShadowConfig
 
 
 class ToggleWorkspaceLayerConfig(CustomBaseModel):
@@ -32,7 +32,6 @@ class KomorebiWorkspacesConfig(CustomBaseModel):
     animation: bool = False
     enable_scroll_switching: bool = False
     reverse_scroll_direction: bool = False
-    container_padding: PaddingConfig = PaddingConfig()
     btn_shadow: ShadowConfig = ShadowConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()

--- a/src/core/validation/widgets/yasb/active_window.py
+++ b/src/core/validation/widgets/yasb/active_window.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -41,7 +40,6 @@ class ActiveWindowConfig(CustomBaseModel):
     rewrite: list[RewriteConfig] = []
     animation: AnimationConfig = AnimationConfig()
     ignore_window: IgnoreWindowConfig = IgnoreWindowConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/ai_chat.py
+++ b/src/core/validation/widgets/yasb/ai_chat.py
@@ -6,7 +6,6 @@ from core.validation.widgets.base_model import (
     AnimationConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -76,7 +75,6 @@ class AiChatConfig(CustomBaseModel):
     notification_dot: NotificationDotConfig = NotificationDotConfig()
     start_floating: bool = True
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     callbacks: AiChatCallbacksConfig = AiChatCallbacksConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()

--- a/src/core/validation/widgets/yasb/applications.py
+++ b/src/core/validation/widgets/yasb/applications.py
@@ -1,4 +1,4 @@
-from core.validation.widgets.base_model import AnimationConfig, CustomBaseModel, PaddingConfig, ShadowConfig
+from core.validation.widgets.base_model import AnimationConfig, CustomBaseModel, ShadowConfig
 
 
 class AppConfig(CustomBaseModel):
@@ -16,4 +16,3 @@ class ApplicationsWidgetConfig(CustomBaseModel):
     tooltip: bool = True
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
-    container_padding: PaddingConfig = PaddingConfig()

--- a/src/core/validation/widgets/yasb/battery.py
+++ b/src/core/validation/widgets/yasb/battery.py
@@ -5,7 +5,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -49,7 +48,6 @@ class BatteryConfig(CustomBaseModel):
     status_thresholds: StatusThresholdsConfig = StatusThresholdsConfig()
     status_icons: StatusIconsConfig = StatusIconsConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/bluetooth.py
+++ b/src/core/validation/widgets/yasb/bluetooth.py
@@ -3,7 +3,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -35,7 +34,6 @@ class BluetoothConfig(CustomBaseModel):
     icons: BluetoothIconsConfig = BluetoothIconsConfig()
     device_aliases: list[BluetoothDeviceAliasConfig] = []
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/brightness.py
+++ b/src/core/validation/widgets/yasb/brightness.py
@@ -50,7 +50,6 @@ class BrightnessConfig(CustomBaseModel):
     ]
     brightness_toggle_level: list[int] = []
     brightness_menu: BrightnessMenuConfig = BrightnessMenuConfig()
-    hide_unsupported: bool = True  # deprecated
     auto_light: bool = False
     auto_light_icon: str = "\udb80\udce1"
     auto_light_night_level: int = 50

--- a/src/core/validation/widgets/yasb/brightness.py
+++ b/src/core/validation/widgets/yasb/brightness.py
@@ -8,7 +8,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -20,7 +19,6 @@ class BrightnessMenuConfig(CustomBaseModel):
     border_color: str = "System"
     alignment: str = "right"
     direction: str = "down"
-    distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
 
@@ -59,7 +57,6 @@ class BrightnessConfig(CustomBaseModel):
     auto_light_night_start_time: Annotated[time, WithJsonSchema({"type": "string"})] = time(20, 0)
     auto_light_night_end_time: Annotated[time, WithJsonSchema({"type": "string"})] = time(6, 30)
     auto_light_day_level: int = 100
-    container_padding: PaddingConfig = PaddingConfig()
     animation: AnimationConfig = AnimationConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()

--- a/src/core/validation/widgets/yasb/cava.py
+++ b/src/core/validation/widgets/yasb/cava.py
@@ -4,7 +4,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
 )
 
 
@@ -42,6 +41,5 @@ class CavaConfig(CustomBaseModel):
     hide_empty: bool = False
     bar_type: Literal["bars", "bars_mirrored", "waves", "waves_mirrored"] = "bars"
     edge_fade: int | list[int] = 0
-    container_padding: PaddingConfig = PaddingConfig()
     keybindings: list[KeybindingConfig] = []
     callbacks: CavaCallbacksConfig = CavaCallbacksConfig()

--- a/src/core/validation/widgets/yasb/clock.py
+++ b/src/core/validation/widgets/yasb/clock.py
@@ -8,7 +8,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -20,7 +19,6 @@ class ClockCalendarConfig(CustomBaseModel):
     border_color: str = "System"
     alignment: str = "right"
     direction: str = "down"
-    distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
     country_code: str | None = None
@@ -65,7 +63,6 @@ class ClockConfig(CustomBaseModel):
     alarm_icons: ClockAlarmIconsConfig = ClockAlarmIconsConfig()
     calendar: ClockCalendarConfig = ClockCalendarConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/cpu.py
+++ b/src/core/validation/widgets/yasb/cpu.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -74,7 +73,6 @@ class CpuConfig(CustomBaseModel):
     hide_decimal: bool = False
     cpu_thresholds: CpuThresholdsConfig = CpuThresholdsConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     progress_bar: ProgressBarConfig = ProgressBarConfig()

--- a/src/core/validation/widgets/yasb/custom.py
+++ b/src/core/validation/widgets/yasb/custom.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -36,7 +35,6 @@ class CustomConfig(CustomBaseModel):
     tooltip_label: str | None = None
     exec_options: ExecOptionsConfig = ExecOptionsConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/disk.py
+++ b/src/core/validation/widgets/yasb/disk.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -27,7 +26,6 @@ class GroupLabelConfig(CustomBaseModel):
     border_color: str = "System"
     alignment: str = "right"
     direction: str = "down"
-    distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
 
@@ -56,7 +54,6 @@ class DiskConfig(CustomBaseModel):
     disk_thresholds: DiskThresholdsConfig = DiskThresholdsConfig()
     group_label: GroupLabelConfig = GroupLabelConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     progress_bar: ProgressBarConfig = ProgressBarConfig()

--- a/src/core/validation/widgets/yasb/github.py
+++ b/src/core/validation/widgets/yasb/github.py
@@ -6,7 +6,6 @@ from core.validation.widgets.base_model import (
     AnimationConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -79,5 +78,4 @@ class GithubConfig(CustomBaseModel):
     animation: AnimationConfig = AnimationConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/gpu.py
+++ b/src/core/validation/widgets/yasb/gpu.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -76,7 +75,6 @@ class GpuConfig(CustomBaseModel):
     units: Literal["metric", "imperial"] = "metric"
     gpu_thresholds: GpuThresholdsConfig = GpuThresholdsConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     progress_bar: ProgressBarConfig = ProgressBarConfig()

--- a/src/core/validation/widgets/yasb/grouper.py
+++ b/src/core/validation/widgets/yasb/grouper.py
@@ -1,7 +1,6 @@
 from core.validation.widgets.base_model import (
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -18,7 +17,6 @@ class GrouperWidgetConfig(CustomBaseModel):
     class_name: str = "grouper"
     widgets: list[str] = []
     hide_empty: bool = False
-    container_padding: PaddingConfig = PaddingConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     collapse_options: GrouperCollapseOptions = GrouperCollapseOptions()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/home.py
+++ b/src/core/validation/widgets/yasb/home.py
@@ -3,7 +3,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -38,7 +37,6 @@ class CallbacksHomeConfig(CallbacksConfig):
 class HomeConfig(CustomBaseModel):
     label: str = "\ue71a"
     menu_list: list[MenuItemConfig] | None = None
-    container_padding: PaddingConfig = PaddingConfig()
     power_menu: bool = True
     system_menu: bool = True
     blur: bool = False
@@ -47,7 +45,6 @@ class HomeConfig(CustomBaseModel):
     border_color: str = "System"
     alignment: str = "left"
     direction: str = "down"
-    distance: int = 6
     offset_top: int = 6
     offset_left: int = 0
     menu_labels: MenuLabelsConfig = MenuLabelsConfig()

--- a/src/core/validation/widgets/yasb/language.py
+++ b/src/core/validation/widgets/yasb/language.py
@@ -5,7 +5,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -33,7 +32,6 @@ class LanguageConfig(CustomBaseModel):
     update_interval: int = Field(default=5, ge=1, le=3600)
     class_name: str = ""
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     language_menu: LanguageMenuConfig = LanguageMenuConfig()

--- a/src/core/validation/widgets/yasb/launchpad.py
+++ b/src/core/validation/widgets/yasb/launchpad.py
@@ -4,7 +4,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -57,7 +56,6 @@ class LaunchpadConfig(CustomBaseModel):
     window_style: WindowStyleConfig = WindowStyleConfig()
     animation: AnimationConfig = AnimationConfig()
     shortcuts: ShortcutsConfig = ShortcutsConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     app_title_shadow: ShadowConfig = ShadowConfig()

--- a/src/core/validation/widgets/yasb/libre_monitor.py
+++ b/src/core/validation/widgets/yasb/libre_monitor.py
@@ -5,7 +5,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -71,6 +70,5 @@ class LibreMonitorConfig(CustomBaseModel):
     libre_menu: LibreMenuConfig = LibreMenuConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     animation: AnimationConfig = AnimationConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/media.py
+++ b/src/core/validation/widgets/yasb/media.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -78,7 +77,6 @@ class MediaWidgetConfig(CustomBaseModel):
     icons: IconsConfig = IconsConfig()
     media_menu: MediaMenuConfig = MediaMenuConfig()
     media_menu_icons: MediaMenuIconsConfig = MediaMenuIconsConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     scrolling_label: ScrollingLabelConfig = ScrollingLabelConfig()
     progress_bar: ProgressBarConfig = ProgressBarConfig()
     max_field_size: MaxFieldSizeConfig = MaxFieldSizeConfig()

--- a/src/core/validation/widgets/yasb/memory.py
+++ b/src/core/validation/widgets/yasb/memory.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -63,7 +62,6 @@ class MemoryConfig(CustomBaseModel):
     hide_decimal: bool = False
     memory_thresholds: MemoryThresholdsConfig = MemoryThresholdsConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     progress_bar: ProgressBarConfig = ProgressBarConfig()

--- a/src/core/validation/widgets/yasb/microphone.py
+++ b/src/core/validation/widgets/yasb/microphone.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -54,7 +53,6 @@ class MicrophoneConfig(CustomBaseModel):
     icons: IconsConfig = IconsConfig()
     mic_menu: MicMenuConfig = MicMenuConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     progress_bar: ProgressBarConfig = ProgressBarConfig()

--- a/src/core/validation/widgets/yasb/notes.py
+++ b/src/core/validation/widgets/yasb/notes.py
@@ -5,7 +5,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -25,7 +24,6 @@ class MenuConfig(CustomBaseModel):
 
 class IconsConfig(CustomBaseModel):
     model_config = ConfigDict(populate_by_name=True)
-
     note: str = "\udb82\udd0c"
     delete: str = "\ueab8"
     copy_icon: str = Field(default="\uebcc", alias="copy")
@@ -48,7 +46,6 @@ class NotesConfig(CustomBaseModel):
     start_floating: bool = False
     paste_plain_text: bool = False
     enter_to_add_note: bool = True
-    container_padding: PaddingConfig = PaddingConfig()
     animation: AnimationConfig = AnimationConfig()
     menu: MenuConfig = MenuConfig()
     icons: IconsConfig = IconsConfig()

--- a/src/core/validation/widgets/yasb/notifications.py
+++ b/src/core/validation/widgets/yasb/notifications.py
@@ -3,7 +3,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -25,7 +24,6 @@ class NotificationsConfig(CustomBaseModel):
     tooltip: bool = True
     icons: NotificationsIconsConfig = NotificationsIconsConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/obs.py
+++ b/src/core/validation/widgets/yasb/obs.py
@@ -1,4 +1,4 @@
-from core.validation.widgets.base_model import CustomBaseModel, KeybindingConfig, PaddingConfig
+from core.validation.widgets.base_model import CustomBaseModel, KeybindingConfig
 
 
 class ObsIconsConfig(CustomBaseModel):
@@ -32,5 +32,4 @@ class ObsConfig(CustomBaseModel):
     show_scene_name: bool = False
     show_stream_stats: bool = False
     tooltip: bool = True
-    container_padding: PaddingConfig = PaddingConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/pomodoro.py
+++ b/src/core/validation/widgets/yasb/pomodoro.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -66,7 +65,6 @@ class PomodoroConfig(CustomBaseModel):
     hide_on_break: bool = False
     icons: IconsConfig = IconsConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     progress_bar: ProgressBarConfig = ProgressBarConfig()

--- a/src/core/validation/widgets/yasb/power_menu.py
+++ b/src/core/validation/widgets/yasb/power_menu.py
@@ -8,7 +8,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -51,7 +50,6 @@ class PowerMenuConfig(CustomBaseModel):
     menu_style: Literal["fullscreen", "popup"] = "fullscreen"
     popup: PowerMenuPopupConfig = PowerMenuPopupConfig()
     profile_image_size: int = Field(default=64, ge=16, le=256)
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     animation: AnimationConfig = AnimationConfig()

--- a/src/core/validation/widgets/yasb/power_plan.py
+++ b/src/core/validation/widgets/yasb/power_plan.py
@@ -6,7 +6,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -33,7 +32,6 @@ class PowerPlanConfig(CustomBaseModel):
     class_name: str = ""
     update_interval: int = Field(default=5000, ge=0)
     menu: PowerPlanMenuConfig = PowerPlanMenuConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     callbacks: PowerPlanCallbacksConfig = PowerPlanCallbacksConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()

--- a/src/core/validation/widgets/yasb/recycle_bin.py
+++ b/src/core/validation/widgets/yasb/recycle_bin.py
@@ -3,7 +3,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -26,7 +25,6 @@ class RecycleBinConfig(CustomBaseModel):
     tooltip: bool = True
     show_confirmation: bool = False
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/server_monitor.py
+++ b/src/core/validation/widgets/yasb/server_monitor.py
@@ -5,7 +5,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -22,7 +21,6 @@ class MenuConfig(CustomBaseModel):
     border_color: str = "System"
     alignment: str = "right"
     direction: str = "down"
-    distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
 
@@ -52,7 +50,6 @@ class ServerMonitorConfig(CustomBaseModel):
     menu: MenuConfig = MenuConfig()
     icons: IconsConfig = IconsConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/systray.py
+++ b/src/core/validation/widgets/yasb/systray.py
@@ -1,6 +1,6 @@
 from pydantic import Field
 
-from core.validation.widgets.base_model import CustomBaseModel, PaddingConfig, ShadowConfig
+from core.validation.widgets.base_model import CustomBaseModel, ShadowConfig
 
 
 class SystrayPopupConfig(CustomBaseModel):
@@ -32,7 +32,6 @@ class SystrayWidgetConfig(CustomBaseModel):
     hide_icons: list[str] = []
     tooltip: bool = True
     use_hook: bool = False
-    container_padding: PaddingConfig = PaddingConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     unpinned_shadow: ShadowConfig = ShadowConfig()
     pinned_shadow: ShadowConfig = ShadowConfig()

--- a/src/core/validation/widgets/yasb/taskbar.py
+++ b/src/core/validation/widgets/yasb/taskbar.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -48,7 +47,6 @@ class TaskbarConfig(CustomBaseModel):
     animation: AnimationConfig | bool = AnimationConfig()
     title_label: TitleLabelConfig = TitleLabelConfig()
     hide_empty: bool = False
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     preview: PreviewConfig = PreviewConfig()

--- a/src/core/validation/widgets/yasb/todo.py
+++ b/src/core/validation/widgets/yasb/todo.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -49,7 +48,6 @@ class TodoConfig(CustomBaseModel):
     label: str = "\uf4a0 {count}/{completed}"
     label_alt: str = "\uf4a0 Tasks: {count}"
     data_path: str = ""
-    container_padding: PaddingConfig = PaddingConfig()
     animation: AnimationConfig = AnimationConfig()
     menu: MenuConfig = MenuConfig()
     icons: IconsConfig = IconsConfig()

--- a/src/core/validation/widgets/yasb/traffic.py
+++ b/src/core/validation/widgets/yasb/traffic.py
@@ -5,7 +5,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -48,7 +47,6 @@ class TrafficWidgetConfig(CustomBaseModel):
     speed_threshold: SpeedThresholdConfig = SpeedThresholdConfig()
     menu: MenuConfig = MenuConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/volume.py
+++ b/src/core/validation/widgets/yasb/volume.py
@@ -5,7 +5,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -22,7 +21,6 @@ class AudioMenuConfig(CustomBaseModel):
     border_color: str = "System"
     alignment: str = "right"
     direction: str = "down"
-    distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
     show_apps: bool = False
@@ -64,7 +62,6 @@ class VolumeConfig(CustomBaseModel):
     ]
     audio_menu: AudioMenuConfig = AudioMenuConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     progress_bar: ProgressBarConfig = ProgressBarConfig()

--- a/src/core/validation/widgets/yasb/vscode.py
+++ b/src/core/validation/widgets/yasb/vscode.py
@@ -5,7 +5,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -17,7 +16,6 @@ class VSCodeMenuConfig(CustomBaseModel):
     border_color: str = "System"
     alignment: str = "right"
     direction: str = "down"
-    distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
 
@@ -45,7 +43,6 @@ class VSCodeConfig(CustomBaseModel):
     cli_command: str = "code"
     menu: VSCodeMenuConfig = VSCodeMenuConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/wallpapers.py
+++ b/src/core/validation/widgets/yasb/wallpapers.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -62,7 +61,6 @@ class WallpapersConfig(CustomBaseModel):
     run_after: list[str] = []
     gallery: GalleryConfig = GalleryConfig()
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/wallpapers.py
+++ b/src/core/validation/widgets/yasb/wallpapers.py
@@ -42,8 +42,6 @@ class GalleryConfig(CustomBaseModel):
     image_spacing: int = Field(default=5, ge=0, le=100)
     lazy_load: bool = True
     lazy_load_fadein: int = Field(default=200, ge=0, le=1000)
-    lazy_load_delay: int = Field(default=0, ge=0, le=1000)  # Deprecated
-    enable_cache: bool = False  # Deprecated
 
 
 class CallbacksWallpapersConfig(CallbacksConfig):

--- a/src/core/validation/widgets/yasb/weather.py
+++ b/src/core/validation/widgets/yasb/weather.py
@@ -7,7 +7,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -61,7 +60,6 @@ class WeatherCardConfig(CustomBaseModel):
     border_color: str = "System"
     alignment: str = "right"
     direction: str = "down"
-    distance: int = 6  # deprecated
     offset_top: int = 6
     offset_left: int = 0
     icon_size: int = 64
@@ -94,7 +92,6 @@ class WeatherWidgetConfig(CustomBaseModel):
     weather_card: WeatherCardConfig = WeatherCardConfig()
     # Note: reusing AnimationConfig from base_model which matches the structure
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/whkd.py
+++ b/src/core/validation/widgets/yasb/whkd.py
@@ -2,7 +2,6 @@ from core.validation.widgets.base_model import (
     AnimationConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -18,5 +17,4 @@ class WhkdConfig(CustomBaseModel):
     special_keys: list[WhkdSpecialKeyConfig] = []
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/wifi.py
+++ b/src/core/validation/widgets/yasb/wifi.py
@@ -5,7 +5,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -55,7 +54,6 @@ class WifiConfig(CustomBaseModel):
     get_exact_wifi_strength: bool = False
     hide_if_ethernet: bool = False
     animation: AnimationConfig = AnimationConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     label_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/validation/widgets/yasb/windows_desktops.py
+++ b/src/core/validation/widgets/yasb/windows_desktops.py
@@ -2,7 +2,6 @@ from core.validation.widgets.base_model import (
     CallbacksConfig,
     CustomBaseModel,
     KeybindingConfig,
-    PaddingConfig,
     ShadowConfig,
 )
 
@@ -20,6 +19,5 @@ class WindowsDesktopsConfig(CustomBaseModel):
     animation: bool = False
     btn_shadow: ShadowConfig = ShadowConfig()
     container_shadow: ShadowConfig = ShadowConfig()
-    container_padding: PaddingConfig = PaddingConfig()
     callbacks: WindowsDesktopsCallbacksConfig = WindowsDesktopsCallbacksConfig()
     keybindings: list[KeybindingConfig] = []

--- a/src/core/widgets/yasb/launchpad.py
+++ b/src/core/widgets/yasb/launchpad.py
@@ -590,7 +590,6 @@ class LaunchpadWidget(BaseWidget):
         self._window_animation = config.window_animation.model_dump()
         self._animation = config.animation.model_dump()
         self._shortcuts = config.shortcuts.model_dump()
-        self._padding = config.container_padding.model_dump()
         self._group_apps = config.group_apps
         self._label_shadow = config.label_shadow.model_dump()
         self._container_shadow = config.container_shadow.model_dump()

--- a/src/settings.py
+++ b/src/settings.py
@@ -3,7 +3,7 @@ import sys
 
 # Application Metadata
 BUILD_VERSION = "1.9.1"
-CLI_VERSION = "1.1.6"
+CLI_VERSION = "1.1.7"
 RELEASE_CHANNEL = "stable"
 # Application Settings
 APP_NAME = "YASB"


### PR DESCRIPTION
- Centralized deprecation registry in deprecation.py for deprecated and renamed fields (global and scoped per model)
- Runtime handler strips deprecated fields before Pydantic validation to prevent extra field errors
- CLI command `yasbc migrate-config` scans config, reports issues, and patches the file preserving formatting
- Supports scoped deprecations (e.g. container_padding only in HomeConfig, acrylic only in BarBlurEffect)
- Supports field renames (e.g. logout → log_out in MenuLabelsConfig)