### PR TITLE
fix(brightness): correct multi-monitor handling and stale values

### DIFF
--- a/src/core/widgets/services/brightness/service.py
+++ b/src/core/widgets/services/brightness/service.py
@@ -56,6 +56,7 @@ class BrightnessService(QObject):
         self._lcd_handle: HANDLE | None = None
         self._lcd_tested = False
         self._lcd_available = False
+        self._lcd_owner: int | None = None
         self._running = False
         self._thread: threading.Thread | None = None
         self._lock = threading.Lock()
@@ -173,6 +174,10 @@ class BrightnessService(QObject):
                 monitor = self._monitors.get(hmonitor)
                 if not monitor:
                     continue
+                # Skip cache update if a user-initiated "set" event is pending or just applied;
+                # physical reads can lag and would overwrite the newer in‑memory value.
+                if hmonitor in self._pending_set:
+                    continue
                 old_brightness = monitor.brightness
                 was_reported = monitor.reported
                 monitor.brightness = brightness
@@ -204,10 +209,13 @@ class BrightnessService(QObject):
                 self._monitors[hmonitor] = _MonitorInfo(hmonitor)
             monitor = self._monitors[hmonitor]
 
-        # Test capabilities on first access
+        # Test capabilities on first access. LCD is global on the laptop panel
+        # so only assign it to one monitor (and only if DDC failed) to avoid
+        # external-monitor widgets writing to the laptop panel.
         if not monitor.tested:
             monitor.supports_ddc = self._test_ddc(hmonitor)
-            monitor.supports_lcd = self._test_lcd()
+            if not monitor.supports_ddc:
+                monitor.supports_lcd = self._test_lcd(hmonitor)
             monitor.tested = True
             logging.debug("Monitor %s: DDC=%s, LCD=%s", hmonitor, monitor.supports_ddc, monitor.supports_lcd)
 
@@ -346,20 +354,28 @@ class BrightnessService(QObject):
             return False
 
     # LCD operations
-    def _test_lcd(self) -> bool:
-        """Test if LCD brightness control is available."""
-        if self._lcd_tested:
-            return self._lcd_available
+    def _test_lcd(self, hmonitor: int) -> bool:
+        """Test if LCD brightness control is available and claim ownership.
 
-        self._lcd_tested = True
-        try:
-            handle = kernel32.CreateFileW("\\\\.\\LCD", 0xC0000000, 0x03, None, 3, 0, None)
-            if handle and handle != INVALID_HANDLE_VALUE:
-                self._lcd_handle = handle
-                self._lcd_available = True
-                return True
-        except Exception:
-            pass
+        The LCD device is global (laptop panel) so only one monitor may own it.
+        First non-DDC monitor to ask wins; subsequent calls return False.
+        """
+        if self._lcd_owner is not None:
+            return self._lcd_owner == hmonitor
+
+        if not self._lcd_tested:
+            self._lcd_tested = True
+            try:
+                handle = kernel32.CreateFileW("\\\\.\\LCD", 0xC0000000, 0x03, None, 3, 0, None)
+                if handle and handle != INVALID_HANDLE_VALUE:
+                    self._lcd_handle = handle
+                    self._lcd_available = True
+            except Exception:
+                pass
+
+        if self._lcd_available:
+            self._lcd_owner = hmonitor
+            return True
         return False
 
     def _read_lcd(self) -> int | None:

--- a/src/core/widgets/yasb/brightness.py
+++ b/src/core/widgets/yasb/brightness.py
@@ -7,7 +7,6 @@ from PyQt6.QtWidgets import QLabel, QSlider, QVBoxLayout
 
 from core.utils.tooltip import CustomToolTip, set_tooltip
 from core.utils.utilities import PopupWidget, build_progress_widget
-from core.utils.win32.bindings.user32 import MONITOR_DEFAULTTONEAREST, user32
 from core.validation.widgets.yasb.brightness import BrightnessConfig
 from core.widgets.base import BaseWidget
 from core.widgets.services.brightness.service import BrightnessService
@@ -24,7 +23,6 @@ class BrightnessWidget(BaseWidget):
         self._widgets_alt: list[QLabel] = []
 
         # Current state
-        self._hmonitor = None
         self.current_brightness = None
         self._auto_light_timer: QTimer | None = None
         self._initialized = False
@@ -52,34 +50,24 @@ class BrightnessWidget(BaseWidget):
         self.callback_right = config.callbacks.on_right
         self.callback_middle = config.callbacks.on_middle
 
-        self._hmonitor = None
-        self._initialized = False
-        self._auto_light_started = False
-        self._slider_tooltip = None
-
-    def _get_hmonitor(self) -> int | None:
-        """Get the monitor handle for this widget."""
-        try:
-            hwnd = int(self.winId())
-            return user32.MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST)
-        except Exception:
-            return None
+    @property
+    def _hmonitor(self) -> int | None:
+        """Bar-resolved monitor handle (set by Bar after position)."""
+        return self.monitor_hwnd
 
     def showEvent(self, a0: QShowEvent | None):
         """Handle widget show event detect monitor and check support."""
         super().showEvent(a0)
         if not self._initialized:
             self._initialized = True
-            self._hmonitor = self._get_hmonitor()
-            # Check if monitor supports brightness
             if self._hmonitor:
                 brightness = self._service.get_brightness(self._hmonitor)
-                if brightness is None:
-                    # Monitor doesn't support brightness control hide widget
-                    self.hide()
+                if brightness is not None:
+                    self.current_brightness = brightness
+                    self._update_label()
                     return
-                self.current_brightness = brightness
-                self._update_label()
+            # No value yet
+            self.hide()
 
     def _on_brightness_changed(self, hmonitor: int, brightness: int | None):
         """Handle brightness change from service (thread-safe via signal)."""
@@ -97,16 +85,12 @@ class BrightnessWidget(BaseWidget):
 
     def get_brightness(self) -> int | None:
         """Get current brightness (cached)."""
-        if self._hmonitor is None:
-            self._hmonitor = self._get_hmonitor()
         if self._hmonitor:
             return self._service.get_brightness(self._hmonitor)
         return None
 
     def set_brightness(self, value: int):
         """Set brightness."""
-        if self._hmonitor is None:
-            self._hmonitor = self._get_hmonitor()
         if self._hmonitor:
             self._service.set_brightness(self._hmonitor, value)
             self.current_brightness = value


### PR DESCRIPTION
Noticed two issues:
1. Brightness was missing in rare cases (both monitors support it normally).
2. Changing brightness on one monitor used values from another monitor (laptop LCD) essentially changing to the incorrect brightness.

Fixes:
- Use the monitor handle provided by the bar instead of resolving it from winId during showEvent. This avoids a race where widgets were incorrectly assigned to the primary monitor.
- Skip updating the cache in the service poll loop when the user has a pending "set" operation, so old hardware reads can't overwrite the newer in‑memory value.
- Gate LCD ownership to a single non-DDC monitor so external DDC monitors no longer fall through to the laptop panel.