### PR TITLE
fix(workspaces): update size policies so only horizontal is fixed

### DIFF
--- a/src/core/widgets/glazewm/workspaces.py
+++ b/src/core/widgets/glazewm/workspaces.py
@@ -52,7 +52,7 @@ class GlazewmWorkspaceButton(QPushButton):
         self.workspace_window_count = 0
         self.status = WorkspaceStatus.EMPTY
         self.clicked.connect(self._activate_workspace)  # type: ignore
-        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.setSizePolicy(QSizePolicy.Policy.Fixed, self.sizePolicy().verticalPolicy())
         self._update_status()
 
     def update_button(self):
@@ -151,7 +151,7 @@ class GlazewmWorkspaceButtonWithIcons(QFrame):
         self.workspace_window_count = 0
         self.windows = windows
 
-        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.setSizePolicy(QSizePolicy.Policy.Fixed, self.sizePolicy().verticalPolicy())
 
         self.button_layout = QHBoxLayout(self)
         self.button_layout.setContentsMargins(0, 0, 0, 0)

--- a/src/core/widgets/komorebi/workspaces.py
+++ b/src/core/widgets/komorebi/workspaces.py
@@ -50,7 +50,7 @@ class WorkspaceButton(QPushButton):
         self.populated_label = populated_label if populated_label else self.default_label
         self.setText(self.default_label)
         self.clicked.connect(self.activate_workspace)
-        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.setSizePolicy(QSizePolicy.Policy.Fixed, self.sizePolicy().verticalPolicy())
         self.hide()
 
     def update_visible_buttons(self):
@@ -100,7 +100,7 @@ class WorkspaceButtonWithIcons(QFrame):
         self.active_label = active_label if active_label else self.default_label
         self.populated_label = populated_label if populated_label else self.default_label
 
-        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.setSizePolicy(QSizePolicy.Policy.Fixed, self.sizePolicy().verticalPolicy())
 
         self.button_layout = QHBoxLayout(self)
         self.button_layout.setContentsMargins(0, 0, 0, 0)

--- a/src/core/widgets/yasb/windows_desktops.py
+++ b/src/core/widgets/yasb/windows_desktops.py
@@ -42,7 +42,7 @@ class WorkspaceButton(QPushButton):
         self.setText(self.default_label)
         self.parent_widget = parent
         self.clicked.connect(self._on_clicked)
-        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        self.setSizePolicy(QSizePolicy.Policy.Fixed, self.sizePolicy().verticalPolicy())
 
     def _on_clicked(self):
         if self.parent_widget:


### PR DESCRIPTION
Horizontal size policies are set to `Fixed`. Vertical are unchanged.
CSS engine compatibility. Not strictly required with the latest engine release, but doesn't hurt.