### PR TITLE
fix(vscode): vscode state database path detection to support shared storage

### DIFF
--- a/src/core/utils/widgets/vscode/get_vscode_state_db_path.py
+++ b/src/core/utils/widgets/vscode/get_vscode_state_db_path.py
@@ -1,0 +1,48 @@
+import json
+import logging
+import os
+
+
+def get_state_db_path() -> str:
+    product_json_path = find_vscode_product_json()
+    try:
+        if os.path.exists(product_json_path):
+            with open(product_json_path, encoding="utf-8") as f:
+                product = json.load(f)
+
+            shared_folder = product.get("sharedDataFolderName")
+            if shared_folder:
+                shared_path = os.path.join(os.path.expanduser("~"), shared_folder, "sharedStorage", "state.vscdb")
+
+                if os.path.exists(shared_path):
+                    return shared_path
+    except Exception as e:
+        logging.error("Shared storage detection failed: %s", e)
+
+    return os.path.expandvars(r"%APPDATA%\Code\User\globalStorage\state.vscdb")
+
+
+def find_vscode_product_json() -> str | None:
+    base_path = os.path.expandvars(r"%LOCALAPPDATA%\Programs\Microsoft VS Code")
+
+    if not os.path.exists(base_path):
+        return None
+
+    try:
+        candidates = []
+        for name in os.listdir(base_path):
+            full_path = os.path.join(base_path, name)
+            product_path = os.path.join(full_path, "resources", "app", "product.json")
+
+            if os.path.isfile(product_path):
+                candidates.append((os.path.getmtime(full_path), product_path))
+
+        if not candidates:
+            return None
+
+        candidates.sort(reverse=True)
+        return candidates[0][1]
+
+    except Exception as e:
+        logging.error("Failed to locate VSCode product.json: %s", e)
+        return None

--- a/src/core/widgets/services/quick_launch/providers/vscode.py
+++ b/src/core/widgets/services/quick_launch/providers/vscode.py
@@ -6,6 +6,7 @@ import urllib.parse
 from pathlib import Path
 
 from core.utils.shell_utils import shell_open
+from core.utils.widgets.vscode.get_vscode_state_db_path import get_state_db_path
 from core.utils.win32.constants import SW_HIDE
 from core.widgets.services.quick_launch.base_provider import (
     BaseProvider,
@@ -101,7 +102,7 @@ class VSCodeProvider(BaseProvider):
 
     def __init__(self, config: dict | None = None):
         super().__init__(config)
-        self._db_path = os.path.expandvars(r"%APPDATA%\Code\User\globalStorage\state.vscdb")
+        self._db_path = get_state_db_path()
 
     def _get_recents(self) -> list[dict]:
         if not os.path.exists(self._db_path):

--- a/src/core/widgets/yasb/vscode.py
+++ b/src/core/widgets/yasb/vscode.py
@@ -11,6 +11,7 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QHBoxLayout, QLabel, QScrollArea, QVBoxLayout, QWidget
 
 from core.utils.utilities import PopupWidget
+from core.utils.widgets.vscode.get_vscode_state_db_path import get_state_db_path
 from core.validation.widgets.yasb.vscode import VSCodeConfig
 from core.widgets.base import BaseWidget
 
@@ -22,9 +23,10 @@ class VSCodeWidget(BaseWidget):
         super().__init__(class_name="vscode-widget")
         self.config = config
         self._show_alt_label = False
+
         state_storage_path = self.config.state_storage_path
         if not state_storage_path:
-            state_storage_path = os.path.expandvars(r"%APPDATA%\Code\User\globalStorage\state.vscdb")
+            state_storage_path = get_state_db_path()
         self._state_file_path = state_storage_path
 
         self._init_container()
@@ -70,7 +72,7 @@ class VSCodeWidget(BaseWidget):
                     else:
                         logging.error("Unexpected entry type: %s", type(path))
             else:
-                logging.error("No data found in %s", file_path)
+                logging.error("No data found in %s", self._state_file_path)
             conn.close()
             return result_list
         except Exception as e:


### PR DESCRIPTION
Fixes issues caused by VS Code **1.118+** moving `history.recentlyOpenedPathsList` from global storage to shared storage.

This change introduces a new utility to dynamically resolve the correct `state.vscdb` path instead of relying on a hardcoded location.

#### What was done

* Added `get_state_db_path()` helper to determine the correct database path at runtime
* Implemented detection of shared storage by:

  * Locating `product.json` from the latest VS Code installation
  * Reading `sharedDataFolderName` to resolve the shared storage directory
  * Constructing the shared DB path:
    `~/<sharedDataFolderName>/sharedStorage/state.vscdb`
* Added existence checks to ensure the shared DB is actually available before using it
* Implemented fallback to legacy global storage:
  `%APPDATA%\Code\User\globalStorage\state.vscdb`
* Added `find_vscode_product_json()` to safely locate the correct `product.json` from installed versions

#### Refactors

* Replaced all hardcoded global storage paths with `get_state_db_path()` in:

  * `VSCodeProvider`
  * YASB VSCode widget

This approach avoids hardcoding `.vscode-shared` and instead adapts based on the user’s actual environment, making it future-proof and more reliable.