### PR TITLE
fix(wallpapers): resolve invisible transition animations

### DIFF
--- a/docs/widgets/(Widget)-Wallpapers.md
+++ b/docs/widgets/(Widget)-Wallpapers.md
@@ -20,16 +20,16 @@ wallpapers:
     # Example path to folder with images. Can be a single string or a list of strings.
     image_path: "C:\\Users\\{Username}\\Images" 
     gallery:
-        enabled: true
-        blur: true
-        image_width: 220
-        image_per_page: 6
-        orientation: "portrait"
-        show_buttons: false
-        image_spacing: 8
-        lazy_load: true
-        lazy_load_fadein: 400
-        image_corner_radius: 12
+      enabled: true
+      blur: true
+      image_width: 220
+      image_per_page: 6
+      orientation: "portrait"
+      show_buttons: false
+      image_spacing: 8
+      lazy_load: true
+      lazy_load_fadein: 400
+      image_corner_radius: 12
 ```
 
 ## Advanced Configuration
@@ -46,24 +46,25 @@ wallpapers:
     change_automatically: false # Automatically change wallpaper
     update_interval: 60 # If change_automatically is true, update interval in seconds
     engine:
-        enabled: true
-        animation: "circle" # circle/slide_top/diamond/split
+      enabled: true
+      animation: "circle" # circle/slide_top/diamond/split
     gallery:
-        enabled: true
-        blur: true
-        image_width: 220
-        image_per_page: 6
-        gallery_columns: 0 # 0 = auto, matches image_per_page for a single row
-        horizontal_position: "center" # left/center/right placement on screen
-        vertical_position: "center" # top/center/bottom placement
-        position_offset: 0 # minimum gap (px) from screen edges - see below for advanced options
-        respect_work_area: true # clamp to OS work area (avoids Windows taskbar)
-        show_buttons: false
-        orientation: "portrait"
-        image_spacing: 8
-        lazy_load: true
-        lazy_load_fadein: 400
-        image_corner_radius: 12
+      enabled: true
+      blur: true
+      image_width: 220
+      image_per_page: 6
+      gallery_columns: 0 # 0 = auto, matches image_per_page for a single row
+      horizontal_position: "center" # left/center/right placement on screen
+      vertical_position: "center" # top/center/bottom placement
+      position_offset: 0 # minimum gap (px) from screen edges - see below for advanced options
+      respect_work_area: true # clamp to OS work area (avoids Windows taskbar)
+      show_buttons: false
+      orientation: "portrait"
+      image_spacing: 8
+      lazy_load: true
+      lazy_load_fadein: 400
+      image_corner_radius: 12
+    # Note: do not use run_after: command if you don't know what it does
     run_after: # List of functions to run after wallpaper is updated
       - "wal -s -t -e -q -n -i {image}" # Example command to run after wallpaper is updated
       - "cmd.exe /c start /min pwsh ./yasb.ps1" # Example command to run after wallpaper is updated
@@ -79,7 +80,7 @@ wallpapers:
 - **tooltip:** Whether to show the tooltip on hover.
 - **change_automatically:** Whether to automatically change the wallpaper.
 - **image_path:** The path(s) to the folder(s) containing images for the wallpaper. Can be a single string or a list of strings. This field is required.
-- **engine:** YASB wallpaper transition engine options. Experimental and subject to change. Supported only onWindows 11.
+- **engine:** YASB wallpaper transition engine options. Experimental and subject to change.
   - **enabled:** Whether to enable the transition engine animations when changing wallpapers.
   - **animation:** The animation style used when transitioning between wallpapers. Supported values: `circle`, `slide_top`, `diamond`, `split`. Default is `circle`.
 - **gallery:** The gallery options for the wallpaper widget.

--- a/src/core/validation/widgets/yasb/wallpapers.py
+++ b/src/core/validation/widgets/yasb/wallpapers.py
@@ -10,7 +10,7 @@ from core.validation.widgets.base_model import (
 
 
 class EngineConfig(CustomBaseModel):
-    enabled: bool = True
+    enabled: bool = False
     animation: Literal["circle", "slide_top", "diamond", "split"] = "circle"
 
 

--- a/src/core/widgets/services/wallpapers/wallpaper_engine.py
+++ b/src/core/widgets/services/wallpapers/wallpaper_engine.py
@@ -3,6 +3,7 @@ YASB Wallpaper engine.
 """
 
 import ctypes
+import logging
 import math
 import os
 import winreg
@@ -22,8 +23,7 @@ from win32con import (
     WS_POPUP,
 )
 
-from core.widgets.services.wallpapers.wallpaper_manager import WallpaperManager
-
+logger = logging.getLogger("wallpaper_engine")
 user32 = ctypes.WinDLL("user32", use_last_error=True)
 
 HWND = wintypes.HWND
@@ -153,6 +153,9 @@ def _read_background_color() -> QColor:
 def _locate_workerw() -> int:
     """Find the WorkerW window that sits behind desktop icons."""
     progman = user32.FindWindowW("Progman", None)
+    if not progman:
+        logger.warning("Could not locate Progman. Wallpaper animation skipped.")
+        return 0
     user32.SendMessageTimeoutW(progman, WM_SPAWN_WORKER, 0, 0, 0, 1000, ctypes.byref(ULONG_PTR()))
     worker = HWND()
 
@@ -187,14 +190,17 @@ def _locate_workerw() -> int:
         user32.EnumWindows(_enum_proc, 0)
 
     if not worker:
-        raise RuntimeError("Could not locate WorkerW")
+        logger.warning("Could not locate WorkerW. Wallpaper animation skipped.")
+        return 0
     user32.ShowWindow(worker, 5)
     return worker
 
 
-def _attach_to_workerw(widget: QWidget) -> None:
+def _attach_to_workerw(widget: QWidget) -> bool:
     """Parent *widget* to WorkerW and compute per-monitor screen areas."""
     worker = _locate_workerw()
+    if not worker:
+        return False
     hwnd = HWND(int(widget.winId()))
 
     exstyle = GetWindowLongPtr(hwnd, GWL_EXSTYLE)
@@ -216,6 +222,7 @@ def _attach_to_workerw(widget: QWidget) -> None:
     widget.set_screen_areas(areas)
 
     user32.SetWindowPos(hwnd, HWND_TOP, 0, 0, ww, wh, SWP_NOACTIVATE | SWP_FRAMECHANGED)
+    return True
 
 
 class _ImageLoader(QThread):
@@ -237,6 +244,8 @@ class _ImageLoader(QThread):
 class WallpaperEngine(QWidget):
     _ANIMATION_MS = 1200
     _FRAME_MS = 16
+
+    finished = pyqtSignal()
 
     def __init__(self, image_path: str, animation: str = "circle") -> None:
         super().__init__()
@@ -277,17 +286,18 @@ class WallpaperEngine(QWidget):
         self._pixmap_new = QPixmap.fromImage(new_img)
         self._pixmap_old = QPixmap.fromImage(old_img)
 
-        # If either image fails to load, skip animation and set wallpaper immediately
+        # If either image fails to load, skip animation and let caller commit immediately
         if self._pixmap_new.isNull() or self._pixmap_old.isNull():
-            try:
-                WallpaperManager().set_wallpaper(self._image_path)
-            except Exception:
-                pass
+            self.finished.emit()
             self.deleteLater()
             return
 
         self.setWindowOpacity(0.0)
-        _attach_to_workerw(self)
+        if not _attach_to_workerw(self):
+            self.finished.emit()
+            self.deleteLater()
+            return
+
         self.show()
         QTimer.singleShot(0, self._start_fade_in)
 
@@ -487,10 +497,7 @@ class WallpaperEngine(QWidget):
         self.update()
         if not self._committed:
             self._committed = True
-            try:
-                WallpaperManager().set_wallpaper(self._image_path)
-            except Exception:
-                pass
+            self.finished.emit()
 
     def _clip_path_for_monitor(self, dx: int, dy: int, dw: int, dh: int, t: float) -> QPainterPath:
         """Reveal shape for the new wallpaper."""

--- a/src/core/widgets/services/wallpapers/wallpaper_engine.py
+++ b/src/core/widgets/services/wallpapers/wallpaper_engine.py
@@ -11,7 +11,16 @@ from ctypes import wintypes
 from PyQt6.QtCore import QEasingCurve, QPointF, QRectF, Qt, QThread, QTimeLine, QTimer, pyqtSignal
 from PyQt6.QtGui import QColor, QImage, QPainter, QPainterPath, QPixmap, QPolygonF
 from PyQt6.QtWidgets import QApplication, QWidget
-from win32con import GWL_STYLE, SWP_FRAMECHANGED, SWP_NOACTIVATE, WM_DESTROY, WS_CHILD, WS_POPUP
+from win32con import (
+    GWL_EXSTYLE,
+    GWL_STYLE,
+    SWP_FRAMECHANGED,
+    SWP_NOACTIVATE,
+    WM_DESTROY,
+    WS_CHILD,
+    WS_EX_LAYERED,
+    WS_POPUP,
+)
 
 from core.widgets.services.wallpapers.wallpaper_manager import WallpaperManager
 
@@ -187,7 +196,12 @@ def _attach_to_workerw(widget: QWidget) -> None:
     """Parent *widget* to WorkerW and compute per-monitor screen areas."""
     worker = _locate_workerw()
     hwnd = HWND(int(widget.winId()))
+
+    exstyle = GetWindowLongPtr(hwnd, GWL_EXSTYLE)
+
+    SetWindowLongPtr(hwnd, GWL_EXSTYLE, LONG_PTR(exstyle & ~WS_EX_LAYERED))
     user32.SetParent(hwnd, worker)
+    SetWindowLongPtr(hwnd, GWL_EXSTYLE, LONG_PTR(exstyle))
 
     style = GetWindowLongPtr(hwnd, GWL_STYLE)
     SetWindowLongPtr(hwnd, GWL_STYLE, LONG_PTR((style | WS_CHILD) & ~WS_POPUP))

--- a/src/core/widgets/services/wallpapers/wallpaper_engine.py
+++ b/src/core/widgets/services/wallpapers/wallpaper_engine.py
@@ -215,10 +215,19 @@ def _attach_to_workerw(widget: QWidget) -> bool:
     wr = wintypes.RECT()
     user32.GetWindowRect(worker, ctypes.byref(wr))
     ww, wh = wr.right - wr.left, wr.bottom - wr.top
+    dpr = widget.devicePixelRatioF() or 1.0
 
     areas = []
     for ml, mt, mr, mb in _enum_physical_monitors():
-        areas.append((ml - wr.left, mt - wr.top, mr - ml, mb - mt, 1.0))
+        areas.append(
+            (
+                int(round((ml - wr.left) / dpr)),
+                int(round((mt - wr.top) / dpr)),
+                int(round((mr - ml) / dpr)),
+                int(round((mb - mt) / dpr)),
+                dpr,
+            )
+        )
     widget.set_screen_areas(areas)
 
     user32.SetWindowPos(hwnd, HWND_TOP, 0, 0, ww, wh, SWP_NOACTIVATE | SWP_FRAMECHANGED)
@@ -354,7 +363,7 @@ class WallpaperEngine(QWidget):
             vw,
             vh,
             Qt.AspectRatioMode.KeepAspectRatioByExpanding,
-            Qt.TransformationMode.FastTransformation,
+            Qt.TransformationMode.SmoothTransformation,
         )
         ox = int((vw - scaled.width()) / 2)
         oy = int((vh - scaled.height()) / 2)
@@ -385,7 +394,7 @@ class WallpaperEngine(QWidget):
                 vw,
                 max_mon_dim,
                 Qt.AspectRatioMode.KeepAspectRatioByExpanding,
-                Qt.TransformationMode.FastTransformation,
+                Qt.TransformationMode.SmoothTransformation,
             )
         else:
             tile_src = px
@@ -414,7 +423,7 @@ class WallpaperEngine(QWidget):
                 max(1, int(iw * scale)),
                 max(1, int(ih * scale)),
                 Qt.AspectRatioMode.IgnoreAspectRatio,
-                Qt.TransformationMode.FastTransformation,
+                Qt.TransformationMode.SmoothTransformation,
             )
         result = []
         for _, _, dw, dh, _ in areas:
@@ -440,7 +449,7 @@ class WallpaperEngine(QWidget):
                     vw,
                     vh,
                     Qt.AspectRatioMode.KeepAspectRatioByExpanding,
-                    Qt.TransformationMode.FastTransformation,
+                    Qt.TransformationMode.SmoothTransformation,
                 )
                 ox = int((vw - scaled.width()) / 2)
                 oy = int((vh - scaled.height()) / 2)
@@ -462,7 +471,7 @@ class WallpaperEngine(QWidget):
                     vw,
                     vh,
                     Qt.AspectRatioMode.KeepAspectRatio,
-                    Qt.TransformationMode.FastTransformation,
+                    Qt.TransformationMode.SmoothTransformation,
                 )
                 ox = int((vw - scaled.width()) / 2)
                 oy = int((vh - scaled.height()) / 2)
@@ -474,12 +483,12 @@ class WallpaperEngine(QWidget):
         mode = self.fit_mode
         if mode == "fill":
             scaled = px.scaled(
-                sw, sh, Qt.AspectRatioMode.KeepAspectRatioByExpanding, Qt.TransformationMode.FastTransformation
+                sw, sh, Qt.AspectRatioMode.KeepAspectRatioByExpanding, Qt.TransformationMode.SmoothTransformation
             )
         elif mode == "fit":
-            scaled = px.scaled(sw, sh, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.FastTransformation)
+            scaled = px.scaled(sw, sh, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
         elif mode == "stretch":
-            scaled = px.scaled(sw, sh, Qt.AspectRatioMode.IgnoreAspectRatio, Qt.TransformationMode.FastTransformation)
+            scaled = px.scaled(sw, sh, Qt.AspectRatioMode.IgnoreAspectRatio, Qt.TransformationMode.SmoothTransformation)
         else:
             scaled = px
         ox = int((sw - scaled.width()) / 2)

--- a/src/core/widgets/services/wallpapers/wallpaper_manager.py
+++ b/src/core/widgets/services/wallpapers/wallpaper_manager.py
@@ -11,6 +11,7 @@ from PyQt6.QtCore import QObject, QTimer, pyqtSignal
 
 from core.events.service import EventService
 from core.utils.win32.bindings.shell32 import IDesktopWallpaper
+from core.widgets.services.wallpapers.wallpaper_engine import WallpaperEngine
 
 
 class WallpaperManager(QObject):
@@ -37,6 +38,8 @@ class WallpaperManager(QObject):
         self._is_running = False
         self._last_image = None
         self._timer_running = False
+        self._engine_config = None
+        self._engine = None
 
         self._event_service = EventService()
 
@@ -45,7 +48,12 @@ class WallpaperManager(QObject):
         self._event_service.register_event("set_wallpaper_signal", self._set_wallpaper_signal)
 
     def configure(
-        self, image_path: str | list[str], update_interval: int, change_automatically: bool, run_after: list[str]
+        self,
+        image_path: str | list[str],
+        update_interval: int,
+        change_automatically: bool,
+        run_after: list[str],
+        engine=None,
     ):
         """
         Configure the manager.
@@ -56,6 +64,7 @@ class WallpaperManager(QObject):
             self._image_paths = image_path
 
         self._run_after = run_after
+        self._engine_config = engine
 
         if change_automatically and not self._timer_running:
             if update_interval and update_interval > 0:
@@ -68,23 +77,27 @@ class WallpaperManager(QObject):
     def _timer_callback(self):
         self.change_background()
 
-    def set_wallpaper(self, image_path: str, monitor_id: str | None = None):
-        """
-        Set the desktop wallpaper using the IDesktopWallpaper COM interface.
-        Args:
-            image_path: Absolute path to the wallpaper image file
-            monitor_id: Monitor device path from GetMonitorDevicePathAt, or None for all monitors
-        """
+    def set_wallpaper(self, image_path: str, monitor_id: str | None = None, animate: bool = True):
+        """Set the desktop wallpaper, using the YASB engine animation when enabled."""
+        eng = self._engine_config
+        if animate and monitor_id is None and eng and eng.enabled:
+            try:
+                self._engine = WallpaperEngine(image_path, eng.animation)
+                self._engine.finished.connect(lambda: self.set_wallpaper(image_path, animate=False))
+                self._engine.start()
+                return
+            except Exception as e:
+                logging.error("Wallpaper engine failed, falling back: %s", e)
+
         pythoncom.CoInitialize()
         try:
-            desktop_wallpaper_clsid = GUID("{C2CF3110-460E-4fc1-B9D0-8A1C0C9CC4BD}")
-            desktop_wallpaper = comtypes.client.CreateObject(desktop_wallpaper_clsid, interface=IDesktopWallpaper)
-            abs_path = os.path.abspath(image_path)
-            desktop_wallpaper.SetWallpaper(monitor_id, abs_path)
-
+            clsid = GUID("{C2CF3110-460E-4fc1-B9D0-8A1C0C9CC4BD}")
+            dwp = comtypes.client.CreateObject(clsid, interface=IDesktopWallpaper)
+            dwp.SetWallpaper(monitor_id, os.path.abspath(image_path))
         except Exception as e:
-            logging.error("Failed to set wallpaper using IDesktopWallpaper: %s", e)
-            raise
+            logging.error("Failed to set wallpaper: %s", e)
+            self._is_running = False
+            return
         self._run_after_thread(image_path)
 
     def get_monitor_ids(self) -> list[str]:
@@ -139,7 +152,7 @@ class WallpaperManager(QObject):
             self._last_image = new_wallpaper
         except Exception as e:
             logging.error("Error setting wallpaper %s: %s", new_wallpaper, e)
-        self._run_after_thread(new_wallpaper)
+            self._is_running = False
 
     def _run_after_thread(self, image_path: str):
         if self._run_after:

--- a/src/core/widgets/services/wallpapers/wallpapers_gallery.py
+++ b/src/core/widgets/services/wallpapers/wallpapers_gallery.py
@@ -34,7 +34,6 @@ from core.utils.utilities import refresh_widget_style
 from core.utils.win32.backdrop import enable_blur
 from core.utils.win32.utils import apply_qmenu_style
 from core.utils.win32.window_actions import force_foreground_focus
-from core.widgets.services.wallpapers.wallpaper_engine import WallpaperEngine
 from core.widgets.services.wallpapers.wallpaper_manager import WallpaperManager
 
 
@@ -159,10 +158,9 @@ class ImageLoader(QRunnable):
 class ImageGallery(QMainWindow):
     """ImageGallery displays a gallery of images with navigation and lazy loading features."""
 
-    def __init__(self, image_paths, gallery, engine=None):
+    def __init__(self, image_paths, gallery):
         super().__init__()
         self.gallery = gallery
-        self.engine = engine  # EngineConfig | None
 
         if isinstance(image_paths, str):
             self.image_paths = [image_paths]
@@ -684,20 +682,13 @@ class ImageGallery(QMainWindow):
     def _apply_wallpaper_on_monitor(self, image_path: str, monitor_id: str) -> None:
         """Set wallpaper on a specific monitor (no animation)."""
         self.fade_out_and_close_gallery()
-        WallpaperManager().set_wallpaper(image_path, monitor_id=monitor_id)
+        WallpaperManager().set_wallpaper(image_path, monitor_id=monitor_id, animate=False)
 
     def _apply_wallpaper(self, image_path: str, monitor_id: str | None) -> None:
-        """Apply wallpaper with engine animation (all screens) or direct per-monitor."""
+        """Apply wallpaper. The manager handles engine animation and fallbacks."""
         if monitor_id is None:
-            animation = self.engine.animation if self.engine else "circle"
-            if self.engine and self.engine.enabled:
-                self.fade_out_and_close_gallery()
-                self._engine = WallpaperEngine(image_path, animation)
-                self._engine.destroyed.connect(lambda: setattr(self, "_engine", None))
-                self._engine.start()
-            else:
-                self.fade_out_and_close_gallery()
-                WallpaperManager().set_wallpaper(image_path)
+            self.fade_out_and_close_gallery()
+            WallpaperManager().set_wallpaper(image_path)
         else:
             self._apply_wallpaper_on_monitor(image_path, monitor_id)
 

--- a/src/core/widgets/services/wallpapers/wallpapers_gallery.py
+++ b/src/core/widgets/services/wallpapers/wallpapers_gallery.py
@@ -30,7 +30,6 @@ from PyQt6.QtWidgets import (
 )
 
 from core.bar_helper import ThemeState
-from core.utils.system import is_windows_10
 from core.utils.utilities import refresh_widget_style
 from core.utils.win32.backdrop import enable_blur
 from core.utils.win32.utils import apply_qmenu_style
@@ -691,7 +690,7 @@ class ImageGallery(QMainWindow):
         """Apply wallpaper with engine animation (all screens) or direct per-monitor."""
         if monitor_id is None:
             animation = self.engine.animation if self.engine else "circle"
-            if self.engine and self.engine.enabled and not is_windows_10():
+            if self.engine and self.engine.enabled:
                 self.fade_out_and_close_gallery()
                 self._engine = WallpaperEngine(image_path, animation)
                 self._engine.destroyed.connect(lambda: setattr(self, "_engine", None))

--- a/src/core/widgets/yasb/wallpapers.py
+++ b/src/core/widgets/yasb/wallpapers.py
@@ -20,6 +20,7 @@ class WallpapersWidget(BaseWidget):
             self.config.update_interval,
             self.config.change_automatically,
             self.config.run_after,
+            self.config.engine,
         )
 
         # Connect signals
@@ -56,6 +57,5 @@ class WallpapersWidget(BaseWidget):
             self._image_gallery = ImageGallery(
                 self.config.image_path,
                 self.config.gallery.model_dump(),
-                self.config.engine,
             )
             self._image_gallery.fade_in_gallery(parent=self)


### PR DESCRIPTION
Fixes #917

Resolves an issue where dynamic wallpaper animations would fail to display (become invisible) on specific Windows versions.

DWM refuses to composite a child window inside the desktop WorkerW layer if the window has the `WS_EX_LAYERED` flag active at the exact moment `SetParent` is called. This PR temporarily strips the `WS_EX_LAYERED` flag during the SetParent transition and immediately restores it. This safely bypasses the DWM bug while keeping Qt's opacity fade-in functionality working perfectly without any black flashes or blinks.

Also I have enabled Windows 10 support to test