### PR TITLE
feat(vscode): add configurable state storage path for VSCode provider

### DIFF
--- a/docs/widgets/(Widget)-Quick-Launch.md
+++ b/docs/widgets/(Widget)-Quick-Launch.md
@@ -529,6 +529,7 @@ Search and open recently used projects, folders, and files directly in Visual St
 | `enabled`  | bool   | `false` | Enable/disable the VSCode provider.      |
 | `prefix`   | string | `"vsc"` | Prefix to activate the provider.         |
 | `priority` | int    | `0`     | Display priority (higher = shown first). |
+| `state_storage_path` | string | `''` | Absolute path to the folder containing editor data, examples are shown below. |
 
 **Usage examples:**
 
@@ -538,6 +539,7 @@ Search and open recently used projects, folders, and files directly in Visual St
 
 > [!NOTE]
 > The VSCode provider reads directly from VSCode's internal SQLite state database (`state.vscdb`) in read-only mode to prevent lock issues and does not require VSCode to be running.
+> **state_storage_path** is absolute path to the `state.vscdb` file. For example: `C:\Users\user\.vscode-shared\sharedStorage\state.vscdb` for Visual Studio Code, or `C:\Users\user\AppData\Roaming\Windsurf\User\globalStorage\state.vscdb` for Windsurf. If left empty, the default Visual Studio Code path will be used.
 
 ### Web Search Provider
 

--- a/docs/widgets/(Widget)-VSCode.md
+++ b/docs/widgets/(Widget)-VSCode.md
@@ -57,7 +57,7 @@ vscode:
 - **max_number_of_folders:** The maximum number of folders to display in the menu.
 - **max_number_of_files:** The maximum number of files to display in the menu (set to 0 if you only want folders).
 - **max_field_size:** The maximum number of characters in the title before truncation.
-- **state_storage_path:** Absolute path to the folder containing editor data. For example, `C:\Users\user\AppData\Roaming\Code\User\globalStorage\state.vscdb` for Visual Studio Code, `C:\Users\user\AppData\Roaming\Windsurf\User\globalStorage\state.vscdb` for Windsurf, etc. If left empty, it will use the default VSCode path.
+- **state_storage_path:** Absolute path to the folder containing editor data. For example, `C:\Users\user\.vscode-shared\sharedStorage\state.vscdb` for Visual Studio Code, `C:\Users\user\AppData\Roaming\Windsurf\User\globalStorage\state.vscdb` for Windsurf, etc. If left empty, it will use the default VSCode path.
 - **modified_date_format:** The date format for the modified date of the files and folders. It uses Python's `strftime` format. For example, '%Y-%m-%d %H:%M' for `2025-06-01 12:00`.
 - **cli_command:** The cli command to execute when a workspace is clicked, doesn't need to contain folder name. For example, `code`, `windsurf`.
 - **callbacks:** A dictionary specifying the callbacks for mouse events. The keys are `on_left`, `on_middle`, and `on_right`, and the values are the names of the callback functions.

--- a/src/core/validation/widgets/yasb/quick_launch.py
+++ b/src/core/validation/widgets/yasb/quick_launch.py
@@ -179,6 +179,7 @@ class VSCodeProviderConfig(CustomBaseModel):
     enabled: bool = False
     prefix: str = "vsc"
     priority: int = 0
+    state_storage_path: str = ""
 
 
 class WindowSwitcherProviderConfig(CustomBaseModel):

--- a/src/core/widgets/services/quick_launch/providers/vscode.py
+++ b/src/core/widgets/services/quick_launch/providers/vscode.py
@@ -102,14 +102,17 @@ class VSCodeProvider(BaseProvider):
 
     def __init__(self, config: dict | None = None):
         super().__init__(config)
-        self._db_path = get_state_db_path()
+        state_storage_path = self.config.get("state_storage_path", "")
+        if not state_storage_path:
+            state_storage_path = get_state_db_path()
+        self._state_file_path = state_storage_path
 
     def _get_recents(self) -> list[dict]:
-        if not os.path.exists(self._db_path):
+        if not os.path.exists(self._state_file_path):
             return []
 
         try:
-            uri = f"file:{self._db_path}?mode=ro"
+            uri = f"file:{self._state_file_path}?mode=ro"
             conn = sqlite3.connect(uri, uri=True)
             cursor = conn.cursor()
             cursor.execute("SELECT value FROM ItemTable WHERE key = 'history.recentlyOpenedPathsList'")


### PR DESCRIPTION
Add `state_storage_path` configuration option to Quick Launch VSCode provider, allowing users to specify custom paths to editor state databases. This enables support for VSCode-compatible editors like Windsurf and other variants that store their state in different locations.

- Add `state_storage_path` option to VSCodeProviderConfig validation schema
- Update VSCodeProvider to use configured path or fall back to default VSCode path
- Update documentation with examples for VSCode and Windsurf state paths
- Clarify that path should point to the state.vscdb file location