### PR TITLE
refactor(UI): consolidate backdrop APIs, rewrite alert dialog, and fix context menu styling

### DIFF
--- a/src/core/bar_helper.py
+++ b/src/core/bar_helper.py
@@ -799,9 +799,9 @@ class BarContextMenu:
 
     def show(self, position):
         self._menu = QMenu(self.parent)
+        apply_qmenu_style(self._menu)
         self._menu.setProperty("class", "context-menu dark" if ThemeState.is_dark() else "context-menu")
         self._menu.aboutToHide.connect(self._on_menu_about_to_hide)
-        apply_qmenu_style(self._menu)
 
         # Bar info
         bar_info = self._menu.addAction(f"Bar: {self._bar_name}")
@@ -809,10 +809,10 @@ class BarContextMenu:
 
         # Widgets menu
         widgets_menu = self._menu.addMenu("Active Widgets")
+        apply_qmenu_style(widgets_menu)
         widgets_menu.setProperty(
             "class", "context-menu submenu dark" if ThemeState.is_dark() else "context-menu submenu"
         )
-        apply_qmenu_style(widgets_menu)
         self._populate_widgets_menu(widgets_menu)
 
         self._menu.addSeparator()

--- a/src/core/ui/views/view_base.py
+++ b/src/core/ui/views/view_base.py
@@ -5,8 +5,8 @@ import os
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QIcon
 
-from core.ui.theme import get_tokens
-from core.utils.win32.backdrop import enable_mica, is_mica_supported
+from core.ui.theme import get_tokens, is_dark
+from core.utils.win32.backdrop import enable_mica, is_mica_supported, set_dark_mode
 from settings import SCRIPT_PATH
 
 
@@ -15,6 +15,7 @@ class ViewBase:
 
     Provides:
       - Mica backdrop setup with base stylesheet
+      - Dark title bar on Windows 10 when in dark mode
       - Application icon
     """
 
@@ -43,6 +44,12 @@ class ViewBase:
             }}
         """)
         if not has_mica:
+            # Apply dark title bar when system is in dark mode
+            if is_dark():
+                try:
+                    set_dark_mode(int(self.winId()))
+                except Exception:
+                    pass
             return False
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
         enable_mica(int(self.winId()))

--- a/src/core/utils/alert_dialog.py
+++ b/src/core/utils/alert_dialog.py
@@ -40,14 +40,13 @@ class AlertDialog(QWidget):
         self._details_visible = False
         self._theme_key = theme_key()
 
-        # ── build UI ──────────────────────────────────────────
         root = QVBoxLayout(self)
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(0)
         # Enforce strict size constraint so window automatically grows/shrinks
         root.setSizeConstraint(QVBoxLayout.SizeConstraint.SetFixedSize)
 
-        # Container card — DWM handles corner radius
+        # Container card - DWM handles corner radius
         self._container = QFrame(self)
         self._container.setObjectName("alert_bg")
         self._container.setFixedWidth(560)
@@ -57,7 +56,7 @@ class AlertDialog(QWidget):
         container_layout.setContentsMargins(0, 0, 0, 0)
         container_layout.setSpacing(0)
 
-        # -- content area (title + body + details) --
+        # Content area (title + body + details)
         self._content = QFrame(self._container)
         self._content.setObjectName("alert_content")
         content_layout = QVBoxLayout(self._content)
@@ -247,7 +246,7 @@ def raise_info_alert(
         title: Dialog title (bold heading).
         msg: Primary message body.
         informative_msg: Secondary hint (e.g. "Click 'Show Details'...").
-        additional_details: If provided, a "Show more info" button
+        additional_details: If provided, a "Show Details" button
             appears that expands an inline details pane.
         rich_text: Treat *msg* as HTML.
         exit_on_close: Call ``sys.exit()`` when the dialog is dismissed.

--- a/src/core/utils/alert_dialog.py
+++ b/src/core/utils/alert_dialog.py
@@ -1,111 +1,236 @@
-import os
+import logging
 import sys
-import traceback
 
-from PyQt6.QtCore import Qt, QTimer
-from PyQt6.QtGui import QIcon
-from PyQt6.QtWidgets import QMessageBox, QPushButton, QSizePolicy, QTextEdit
+from PyQt6.QtCore import QEasingCurve, QParallelAnimationGroup, QPoint, QPropertyAnimation, Qt, QTimer, pyqtSignal
+from PyQt6.QtWidgets import (
+    QApplication,
+    QFrame,
+    QHBoxLayout,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
 
-from core.ui.theme import get_tokens
-from settings import SCRIPT_PATH
+from core.ui.components.button import Button
+from core.ui.components.text_block import TextBlock
+from core.ui.theme import get_tokens, theme_key
+from core.utils.win32.backdrop import enable_dwm_frame
+from core.utils.win32.bindings import user32
+
+_alert_dialogs: list[AlertDialog] = []
 
 
-class AlertDialog(QMessageBox):
+class AlertDialog(QWidget):
+    closed = pyqtSignal()
+
     def __init__(
         self,
-        title: str,
-        message: str,
-        informative_message: str = None,
-        additional_details: str = None,
-        icon: QMessageBox.Icon = QMessageBox.Icon.Information,
-        show_quit: bool = False,
-        show_ok: bool = False,
-        parent=None,
-    ):
-        super().__init__(parent)
+        title: str = "",
+        message: str = "",
+        informative_message: str = "",
+        additional_details: str = "",
+        rich_text: bool = False,
+    ) -> None:
+        super().__init__(
+            None,
+            Qt.WindowType.Tool | Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint,
+        )
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
+        self._has_details = bool(additional_details)
+        self._details_visible = False
+        self._theme_key = theme_key()
 
-        self.setWindowTitle(title)
-        self.setTextInteractionFlags(Qt.TextInteractionFlag.LinksAccessibleByMouse)
-        self.setWindowFlags(Qt.WindowType.WindowStaysOnTopHint | Qt.WindowType.WindowCloseButtonHint)
-        self.setIcon(icon)
-        self.setText(message)
-        self.icon_path = os.path.join(SCRIPT_PATH, "assets", "images", "app_icon.png")
-        if os.path.exists(self.icon_path):
-            self.setWindowIcon(QIcon(self.icon_path))
+        # ── build UI ──────────────────────────────────────────
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+        # Enforce strict size constraint so window automatically grows/shrinks
+        root.setSizeConstraint(QVBoxLayout.SizeConstraint.SetFixedSize)
+
+        # Container card — DWM handles corner radius
+        self._container = QFrame(self)
+        self._container.setObjectName("alert_bg")
+        self._container.setFixedWidth(560)
+        root.addWidget(self._container)
+
+        container_layout = QVBoxLayout(self._container)
+        container_layout.setContentsMargins(0, 0, 0, 0)
+        container_layout.setSpacing(0)
+
+        # -- content area (title + body + details) --
+        self._content = QFrame(self._container)
+        self._content.setObjectName("alert_content")
+        content_layout = QVBoxLayout(self._content)
+        content_layout.setContentsMargins(24, 24, 24, 24)
+        content_layout.setSpacing(4)
+        content_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
+
+        self._title_label = TextBlock(title, variant="subtitle", parent=self._content)
+        self._title_label.setWordWrap(True)
+        self._title_label.setVisible(bool(title))
+        content_layout.addWidget(self._title_label)
+        content_layout.addSpacing(12)
+
+        self._msg_label = TextBlock(message, variant="body", parent=self._content)
+        self._msg_label.setWordWrap(True)
+        if rich_text:
+            self._msg_label.setTextFormat(Qt.TextFormat.RichText)
+        content_layout.addWidget(self._msg_label)
 
         if informative_message:
-            self.setInformativeText(informative_message)
+            self._info_label = TextBlock(informative_message, variant="body-secondary", parent=self._content)
+            self._info_label.setWordWrap(True)
+            content_layout.addWidget(self._info_label)
+        else:
+            self._info_label = None
 
+        self._details_wrapper = QWidget(self._content)
+        details_layout = QVBoxLayout(self._details_wrapper)
+        details_layout.setContentsMargins(0, 8, 0, 0)
+        details_layout.setSpacing(0)
+
+        self._details = QTextEdit(self._details_wrapper)
+        self._details.setReadOnly(True)
+        self._details.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
+        self._details.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self._details.setLineWrapMode(QTextEdit.LineWrapMode.NoWrap)
+        self._details.setMaximumHeight(100)
         if additional_details:
-            self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
-            self.setDetailedText(additional_details)
+            self._details.setPlainText(additional_details)
 
-        self.ok_button = self.addButton("Ok", QMessageBox.ButtonRole.AcceptRole) if show_ok else None
-        self.quit_button = self.addButton("Quit", QMessageBox.ButtonRole.DestructiveRole) if show_quit else None
-        self.setSizeGripEnabled(False)
+        details_layout.addWidget(self._details)
+        self._details_wrapper.setVisible(False)
+        content_layout.addWidget(self._details_wrapper)
+        container_layout.addWidget(self._content, 0)
 
-        self.setMinimumHeight(0)
-        self.setMaximumHeight(260)
-        self.setMinimumWidth(420)
-        self.setMaximumWidth(520)
-        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
+        self._btn_bar = QFrame(self._container)
+        self._btn_bar.setObjectName("alert_btns")
+        button_layout = QHBoxLayout(self._btn_bar)
+        button_layout.setContentsMargins(24, 24, 24, 24)
+
+        self._details_btn: Button | None = None
+        if additional_details:
+            self._details_btn = Button("Show Details", variant="default", parent=self._btn_bar)
+            self._details_btn.clicked.connect(self._toggle_details)
+            button_layout.addWidget(self._details_btn)
+
+        self._close_btn = Button("Close", variant="accent", parent=self._btn_bar)
+        self._close_btn.clicked.connect(self._close)
+        button_layout.addWidget(self._close_btn)
+
+        container_layout.addWidget(self._btn_bar, 0)
+
+        self._apply_styles()
+        QApplication.instance().paletteChanged.connect(self._on_theme_changed)
+
+    def mousePressEvent(self, event) -> None:
+        if event.button() == Qt.MouseButton.LeftButton:
+            if self._btn_bar.geometry().contains(event.pos()):
+                return
+            if wh := self.windowHandle():
+                wh.startSystemMove()
+
+    def show_dialog(self) -> None:
+        self.setWindowOpacity(0.0)
+        self._center_on_screen()
+
+        target_pos = self.pos()
+        start_pos = target_pos + QPoint(0, 20)
+        self.move(start_pos)
+
+        enable_dwm_frame(int(self.winId()))
+
+        self.show()
+        self.activateWindow()
+        try:
+            user32.MessageBeep(3)
+        except Exception as e:
+            logging.debug("Failed to play error sound: %s", e)
+
+        self._fade_anim = QPropertyAnimation(self, b"windowOpacity")
+        self._fade_anim.setDuration(120)
+        self._fade_anim.setStartValue(0.0)
+        self._fade_anim.setEndValue(1.0)
+        self._fade_anim.setEasingCurve(QEasingCurve.Type.Linear)
+
+        self._pos_anim = QPropertyAnimation(self, b"pos")
+        self._pos_anim.setDuration(120)
+        self._pos_anim.setStartValue(start_pos)
+        self._pos_anim.setEndValue(target_pos)
+        self._pos_anim.setEasingCurve(QEasingCurve.Type.Linear)
+
+        self._anim_group = QParallelAnimationGroup(self)
+        self._anim_group.addAnimation(self._fade_anim)
+        self._anim_group.addAnimation(self._pos_anim)
+        self._anim_group.start()
+
+    def _close(self) -> None:
+        self.closed.emit()
+
+        current_pos = self.pos()
+        end_pos = current_pos - QPoint(0, 20)
+
+        self._fade_out_anim = QPropertyAnimation(self, b"windowOpacity")
+        self._fade_out_anim.setDuration(120)
+        self._fade_out_anim.setStartValue(self.windowOpacity())
+        self._fade_out_anim.setEndValue(0.0)
+        self._fade_out_anim.setEasingCurve(QEasingCurve.Type.Linear)
+
+        self._pos_out_anim = QPropertyAnimation(self, b"pos")
+        self._pos_out_anim.setDuration(120)
+        self._pos_out_anim.setStartValue(current_pos)
+        self._pos_out_anim.setEndValue(end_pos)
+        self._pos_out_anim.setEasingCurve(QEasingCurve.Type.Linear)
+
+        self._out_anim_group = QParallelAnimationGroup(self)
+        self._out_anim_group.addAnimation(self._fade_out_anim)
+        self._out_anim_group.addAnimation(self._pos_out_anim)
+        self._out_anim_group.finished.connect(self.close)
+        self._out_anim_group.start()
+
+    def _toggle_details(self) -> None:
+        self._details_visible = not self._details_visible
+        self._details_wrapper.setVisible(self._details_visible)
+        if self._details_btn:
+            self._details_btn.setText("Hide details" if self._details_visible else "Show Details")
+
+    def _center_on_screen(self) -> None:
+        screen = QApplication.screenAt(self.pos()) or QApplication.primaryScreen()
+        if screen is None:
+            return
+
+        self.ensurePolished()
         self.adjustSize()
 
-    def showEvent(self, event):
-        self._style_dialog_buttons()
-        text_edit = self.findChild(QTextEdit)
-        if text_edit:
-            text_edit.setStyleSheet("background-color: rgba(0,0,0,0.2); border: none;")
-            text_edit.setMinimumHeight(60)
-            text_edit.setMaximumHeight(150)
-            text_edit.setMinimumWidth(420)
-            text_edit.setMaximumWidth(520)
-            text_edit.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
-
-        super().showEvent(event)
-
-    def event(self, e):
-        result = QMessageBox.event(self, e)
-        self.setMinimumHeight(0)
-        self.setMaximumHeight(260)
-        self.setMinimumWidth(420)
-        self.setMaximumWidth(520)
-        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
-
-        text_edit = self.findChild(QTextEdit)
-        if text_edit:
-            text_edit.setMinimumHeight(60)
-            text_edit.setMaximumHeight(150)
-            text_edit.setMinimumWidth(420)
-            text_edit.setMaximumWidth(520)
-            text_edit.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
-
-        return result
-
-    def _style_dialog_buttons(self):
-        t = get_tokens()
-        style = (
-            f"QPushButton {{ background-color: {t['control_fill_default']}; color: {t['text_primary']};"
-            f" border: 1px solid {t['control_stroke_default']}; border-radius: 4px;"
-            f" font-weight: 600; font-size: 12px; font-family: 'Segoe UI'; padding: 4px 16px; }}"
-            f"QPushButton:hover {{ background-color: {t['control_fill_secondary']};"
-            f" border: 1px solid {t['control_stroke_secondary']}; }}"
-            f"QPushButton:pressed {{ background-color: {t['control_fill_tertiary']}; }}"
-            f"QPushButton:disabled {{ background-color: {t['control_fill_disabled']};"
-            f" color: {t['text_disabled']}; }}"
+        centre = screen.geometry().center()
+        self.move(
+            centre.x() - self.width() // 2,
+            centre.y() - self.height() // 2,
         )
-        for button in self.findChildren(QPushButton):
-            button.setStyleSheet(style)
 
+    def _on_theme_changed(self) -> None:
+        key = theme_key()
+        if key == self._theme_key:
+            return
+        self._theme_key = key
+        self._apply_styles()
 
-_persistent_dialogs = []
+    def _apply_styles(self) -> None:
+        tokens = get_tokens()
+        bg = tokens["solid_bg_base"]
+        layer_alt = tokens["layer_alt"]
+        stroke = tokens["card_stroke_default"]
+        text_secondary = tokens["text_secondary"]
 
+        self._container.setStyleSheet(f"#alert_bg {{ background: {bg}; }}")
+        self._content.setStyleSheet(f"#alert_content {{ background: {layer_alt}; border-bottom: 1px solid {stroke}; }}")
+        self._btn_bar.setStyleSheet(f"#alert_btns {{ background: {bg}; }}")
 
-def _remove_dialog(dialog):
-    try:
-        _persistent_dialogs.remove(dialog)
-    except ValueError:
-        pass
+        self._details.setStyleSheet(
+            f"QTextEdit {{ background: {bg}; color: {text_secondary};"
+            f"border: none; padding: 2px; border-radius: 4px;"
+            f"font-family: 'Cascadia Code', 'Consolas', monospace; font-size: 12px; }}"
+        )
 
 
 def raise_info_alert(
@@ -115,51 +240,34 @@ def raise_info_alert(
     additional_details: str = None,
     rich_text: bool = False,
     exit_on_close: bool = False,
-    parent=None,
-):
-    alert = AlertDialog(
-        icon=QMessageBox.Icon.Information,
+) -> None:
+    """Show alert dialog.
+
+    Args:
+        title: Dialog title (bold heading).
+        msg: Primary message body.
+        informative_msg: Secondary hint (e.g. "Click 'Show Details'...").
+        additional_details: If provided, a "Show more info" button
+            appears that expands an inline details pane.
+        rich_text: Treat *msg* as HTML.
+        exit_on_close: Call ``sys.exit()`` when the dialog is dismissed.
+    """
+    dlg = AlertDialog(
         title=title,
         message=msg,
         informative_message=informative_msg,
-        additional_details=additional_details,
-        parent=parent,
+        additional_details=additional_details or "",
+        rich_text=rich_text,
     )
-    if rich_text:
-        alert.setTextFormat(Qt.TextFormat.RichText)
-
-    alert.finished.connect(lambda _: _remove_dialog(alert))
+    dlg.closed.connect(lambda: _cleanup(dlg))
     if exit_on_close:
-        alert.finished.connect(lambda _: sys.exit())
+        dlg.closed.connect(lambda: sys.exit())
+    _alert_dialogs.append(dlg)
+    QTimer.singleShot(100, dlg.show_dialog)
 
-    _persistent_dialogs.append(alert)
-    QTimer.singleShot(100, alert.show)
 
-
-def raise_error_alert(
-    title: str,
-    msg: str,
-    informative_msg: str,
-    additional_details: str = None,
-    rich_text: bool = False,
-    exit_on_close: bool = True,
-    parent=None,
-):
-    alert = AlertDialog(
-        icon=QMessageBox.Icon.Critical,
-        title=title,
-        message=msg,
-        informative_message=informative_msg,
-        additional_details=additional_details if additional_details else traceback.format_exc(),
-        show_quit=True,
-        parent=parent,
-    )
-    if rich_text:
-        alert.setTextFormat(Qt.TextFormat.RichText)
-
-    alert.finished.connect(lambda _: _remove_dialog(alert))
-    if exit_on_close:
-        alert.finished.connect(lambda _: sys.exit())
-
-    _persistent_dialogs.append(alert)
-    QTimer.singleShot(100, alert.show)
+def _cleanup(dialog: AlertDialog) -> None:
+    try:
+        _alert_dialogs.remove(dialog)
+    except ValueError:
+        pass

--- a/src/core/utils/win32/backdrop.py
+++ b/src/core/utils/win32/backdrop.py
@@ -49,7 +49,7 @@ def set_accent_policy(hwnd, accent_state, gradient_color=0, accent_flags=0):
         raise ctypes.WinError()
 
 
-def _set_dark_mode(hwnd):
+def set_dark_mode(hwnd):
     value = ctypes.c_int(1)
     result = DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, ctypes.byref(value), ctypes.sizeof(value))
     if result != 0:
@@ -84,7 +84,7 @@ def enable_blur(hwnd, DarkMode=False, RoundCorners=False, RoundCornersType="norm
         if sys.getwindowsversion().build >= 22000:
             set_accent_policy(hwnd, ACCENT_ENABLE_BLURBEHIND, gradient_color=0x01202020)
             if DarkMode:
-                _set_dark_mode(hwnd)
+                set_dark_mode(hwnd)
             if RoundCorners:
                 set_window_corner_preference(
                     hwnd, DWMWCP_ROUND if RoundCornersType == "normal" else DWMWCP_ROUNDSMALL, BorderColor
@@ -115,3 +115,15 @@ def enable_mica(hwnd):
             DwmSetWindowAttribute(hwnd, DWMWA_MICA_EFFECT, ctypes.byref(value), ctypes.sizeof(value))
     except Exception as e:
         logging.debug("Failed to apply mica: %s", e)
+
+
+def enable_dwm_frame(hwnd):
+    """Apply DWM frame effects (shadow + rounded corners) to a frameless window."""
+    hwnd = int(hwnd)
+    try:
+        margins = MARGINS(1, 1, 1, 1)
+        DwmExtendFrameIntoClientArea(hwnd, margins)
+        if sys.getwindowsversion().build >= 22000:
+            set_window_corner_preference(hwnd, DWMWCP_ROUND, "System")
+    except Exception as e:
+        logging.debug("Failed to apply DWM frame: %s", e)

--- a/src/core/utils/win32/utils.py
+++ b/src/core/utils/win32/utils.py
@@ -372,7 +372,7 @@ def apply_qmenu_style(qwidget: QWidget):
         def apply_blur():
             try:
                 hwnd = int(qwidget.winId())
-                enable_blur(hwnd, DarkMode=True, RoundCorners=True, RoundCornersType="normal", BorderColor="None")
+                enable_blur(hwnd, DarkMode=False, RoundCorners=True, RoundCornersType="normal", BorderColor="None")
             except Exception:
                 pass
 

--- a/src/core/widgets/services/ai_chat/context_menu_service.py
+++ b/src/core/widgets/services/ai_chat/context_menu_service.py
@@ -11,6 +11,7 @@ class ContextMenuService:
 
     def show_context_menu(self, widget, pos, is_input=False):
         context_menu = QMenu(widget)
+        apply_qmenu_style(context_menu)
         context_menu.setProperty("class", "context-menu")
 
         if is_input:
@@ -68,7 +69,7 @@ class ContextMenuService:
                     pass
 
             select_all_action.triggered.connect(select_all)
-        apply_qmenu_style(context_menu)
+            select_all_action.triggered.connect(select_all)
 
         global_pos = widget.mapToGlobal(pos)
         if is_input:

--- a/src/core/widgets/services/quick_launch/context_menu.py
+++ b/src/core/widgets/services/quick_launch/context_menu.py
@@ -24,8 +24,8 @@ class QuickLaunchContextMenuService:
             return ProviderMenuActionResult()
 
         menu = QMenu(parent)
-        menu.setProperty("class", "context-menu")
         apply_qmenu_style(menu)
+        menu.setProperty("class", "context-menu")
         menu.setContentsMargins(0, 0, 0, 0)
 
         action_map = {}

--- a/src/core/widgets/services/taskbar/app_menu.py
+++ b/src/core/widgets/services/taskbar/app_menu.py
@@ -240,8 +240,8 @@ def show_context_menu(taskbar_widget, hwnd: int, pos) -> QMenu | None:
                 unique_id, _ = PinManager.get_app_identifier(hwnd, window_data, resolve_shortcut=False)
 
         menu = QMenu(taskbar_widget.window())
-        menu.setProperty("class", "context-menu")
         apply_qmenu_style(menu)
+        menu.setProperty("class", "context-menu")
 
         # Determine app type from unique_id
         is_explorer = False

--- a/src/core/widgets/services/wallpapers/wallpapers_gallery.py
+++ b/src/core/widgets/services/wallpapers/wallpapers_gallery.py
@@ -170,7 +170,7 @@ class ImageGallery(QMainWindow):
             self.image_paths = image_paths
 
         all_files = []
-        file_types = ("png", "jpg", "jpg", "gif", "bmp")
+        file_types = ("png", "jpg", "jpeg", "gif", "bmp", "tif", "tiff")
         # webp support for wallpapers was introduced in Preview Build 26220.7653, and Stable Build 26100.8037 (24H2) / 26200.8037 (25H2)
         # https://windowsforum.com/threads/kb5079473-windows-11-march-2026-update-sysmon-in-box-emoji-16-and-webp-wallpapers.404657/
         if (self._build_and_ubr[0] >= 26220 and self._build_and_ubr[1] >= 7653) or (
@@ -516,6 +516,7 @@ class ImageGallery(QMainWindow):
         self.loaded_images += 1
         if self.loaded_images >= self.expected_images:
             self.is_loading = False
+            self._update_nav_buttons()
 
     def update_image_label(self, image_path, pixmap, index):
         """Update label with loaded image."""
@@ -548,9 +549,20 @@ class ImageGallery(QMainWindow):
     def _navigate_page(self, direction):
         """Navigate pages: direction is 1 for next, -1 for prev."""
         new_index = self.current_index + (direction * self.images_per_page)
-        self.current_index = max(0, min(new_index, len(self.image_files) - self.images_per_page))
+        # Clamp to page-aligned boundaries so the last partial page is reachable
+        # but we never land on an off-grid offset (e.g. showing just 1 image).
+        last_page_start = ((len(self.image_files) - 1) // self.images_per_page) * self.images_per_page
+        self.current_index = max(0, min(new_index, last_page_start))
         self.load_images()
         self.focused_index = self.current_index
+        self._update_nav_buttons()
+
+    def _update_nav_buttons(self):
+        """Enable/disable prev/next buttons based on current page position."""
+        if hasattr(self, "prev_button"):
+            self.prev_button.setEnabled(self.current_index > 0)
+        if hasattr(self, "next_button"):
+            self.next_button.setEnabled(self.current_index + self.images_per_page < len(self.image_files))
 
     def load_next_images(self):
         """Load the next page of images."""
@@ -671,8 +683,8 @@ class ImageGallery(QMainWindow):
         self.update_focus()
 
         menu = QMenu(self)
-        menu.setProperty("class", "context-menu")
         apply_qmenu_style(menu)
+        menu.setProperty("class", "context-menu")
 
         action_all = menu.addAction("Set on all screens")
         action_all.triggered.connect(lambda: self._apply_wallpaper(image_path, None))
@@ -687,6 +699,8 @@ class ImageGallery(QMainWindow):
         self._menu_open = True
         menu.exec(pos)
         self._menu_open = False
+        if not self.is_closing and not self.isActiveWindow():
+            self.fade_out_and_close_gallery()
 
     def _apply_wallpaper_on_monitor(self, image_path: str, monitor_id: str) -> None:
         """Set wallpaper on a specific monitor (no animation)."""

--- a/src/core/widgets/yasb/ai_chat.py
+++ b/src/core/widgets/yasb/ai_chat.py
@@ -195,10 +195,10 @@ class AiChatWidget(BaseWidget):
             """
         )
         self.provider_menu = QMenu(self.provider_btn)
+        apply_qmenu_style(self.provider_menu)
         self.provider_menu.setProperty("class", "context-menu")
         self.provider_menu.setStyleSheet("QMenu::indicator { width: 0px; height: 0px; }")
         self.provider_menu.aboutToHide.connect(lambda: self._on_menu_hide(self.provider_menu))
-        apply_qmenu_style(self.provider_menu)
         self.provider_btn.clicked.connect(lambda: self._open_menu(self.provider_menu, self.provider_btn))
         self._provider_model_manager.populate_provider_menu()
         self.model_btn = QPushButton(self._get_model_label())
@@ -214,10 +214,10 @@ class AiChatWidget(BaseWidget):
         )
         self.model_btn.setEnabled(bool(self._provider_config and self._provider_config.get("models")))
         self.model_menu = QMenu(self.model_btn)
+        apply_qmenu_style(self.model_menu)
         self.model_menu.setProperty("class", "context-menu")
         self.model_menu.setStyleSheet("QMenu::indicator { width: 0px; height: 0px; }")
         self.model_menu.aboutToHide.connect(lambda: self._on_menu_hide(self.model_menu))
-        apply_qmenu_style(self.model_menu)
         self.model_menu.aboutToShow.connect(
             lambda: (
                 [

--- a/src/core/widgets/yasb/clock.py
+++ b/src/core/widgets/yasb/clock.py
@@ -881,12 +881,12 @@ class ClockWidget(BaseWidget):
     def _show_context_menu(self):
         """Build and display the context menu for the clock widget."""
         menu = QMenu(self.window())
-        menu.setProperty("class", "context-menu")
         apply_qmenu_style(menu)
+        menu.setProperty("class", "context-menu")
         if len(self._timezones_list) > 1:
             tz_menu = QMenu("Timezones", menu)
-            tz_menu.setProperty("class", "context-menu submenu")
             apply_qmenu_style(tz_menu)
+            tz_menu.setProperty("class", "context-menu submenu")
 
             for tz in self._timezones_list:
                 tz_display = tz.replace("_", " ")

--- a/src/core/widgets/yasb/launchpad.py
+++ b/src/core/widgets/yasb/launchpad.py
@@ -879,8 +879,8 @@ class LaunchpadWidget(BaseWidget):
         """
         menu_parent = parent_widget if parent_widget else self._launchpad_popup
         menu = QMenu(menu_parent.window())
-        menu.setProperty("class", "context-menu")
         apply_qmenu_style(menu)
+        menu.setProperty("class", "context-menu")
 
         if app_data:
             edit_action = QAction("Edit", menu_parent)
@@ -915,8 +915,8 @@ class LaunchpadWidget(BaseWidget):
                 other_groups = [g for g in all_groups if g != self._current_group]
                 if other_groups:
                     move_menu = QMenu("Move to Group", menu)
-                    move_menu.setProperty("class", "context-menu")
                     apply_qmenu_style(move_menu)
+                    move_menu.setProperty("class", "context-menu")
 
                     for group in other_groups:
                         move_action = QAction(group, menu_parent)
@@ -930,8 +930,8 @@ class LaunchpadWidget(BaseWidget):
                     menu.addSeparator()
 
                     group_menu = QMenu("Add to Group", menu)
-                    group_menu.setProperty("class", "context-menu")
                     apply_qmenu_style(group_menu)
+                    group_menu.setProperty("class", "context-menu")
 
                     for group in all_groups:
                         group_action = QAction(group, menu_parent)
@@ -1660,8 +1660,8 @@ class LaunchpadWidget(BaseWidget):
         """Show context menu for group"""
         menu_parent = parent_widget
         menu = QMenu(menu_parent.window())
-        menu.setProperty("class", "context-menu")
         apply_qmenu_style(menu)
+        menu.setProperty("class", "context-menu")
 
         open_action = QAction(f"Open {group_name}", menu_parent)
         open_action.triggered.connect(lambda: self._open_group(group_name, parent_widget.apps_in_group))

--- a/src/core/widgets/yasb/systray.py
+++ b/src/core/widgets/yasb/systray.py
@@ -233,8 +233,8 @@ class SystrayWidget(BaseWidget):
     def show_context_menu(self, pos: QPoint):
         """Show the context menu for the unpinned visibility button"""
         menu = QMenu(self.window())
-        menu.setProperty("class", "context-menu")
         apply_qmenu_style(menu)
+        menu.setProperty("class", "context-menu")
         menu.setContentsMargins(0, 0, 0, 0)
         menu.setLayoutDirection(Qt.LayoutDirection.LeftToRight)
         refresh_action = menu.addAction("Refresh Systray")

--- a/src/core/widgets/yasb/volume.py
+++ b/src/core/widgets/yasb/volume.py
@@ -1,4 +1,3 @@
-import ctypes
 import logging
 import re
 
@@ -15,6 +14,7 @@ from core.utils.utilities import (
     refresh_widget_style,
 )
 from core.utils.win32.app_icons import get_process_icon
+from core.utils.win32.bindings import user32
 from core.utils.win32.utils import get_app_name_from_pid
 from core.validation.widgets.yasb.volume import VolumeConfig
 from core.widgets.base import BaseWidget
@@ -82,7 +82,7 @@ class VolumeWidget(BaseWidget):
         if self.config.slider_beep:
             # Play a beep sound when slider is released
             try:
-                ctypes.windll.user32.MessageBeep(0)
+                user32.MessageBeep(0)
             except Exception as e:
                 logging.debug("Failed to play volume sound: %s", e)
 

--- a/src/core/widgets/yasb/windows_desktops.py
+++ b/src/core/widgets/yasb/windows_desktops.py
@@ -78,10 +78,10 @@ class WorkspaceButton(QPushButton):
 
     def _show_context_menu(self):
         menu = QMenu(self.window())
+        apply_qmenu_style(menu)
         # Assign a class for global styling; apply rounded corners via helper
         menu.setProperty("class", "context-menu")
         # Apply Windows rounded corners to the QMenu when it is shown
-        apply_qmenu_style(menu)
 
         act_rename = QAction("Rename", self)
         act_rename.triggered.connect(self.rename_desktop)
@@ -113,8 +113,9 @@ class WorkspaceButton(QPushButton):
             menu.addAction(act_move_here)
 
             move_menu = QMenu("Move Window To", self.window())
-            move_menu.setProperty("class", "context-menu")
             apply_qmenu_style(move_menu)
+            move_menu.setProperty("class", "context-menu")
+
             try:
                 desktops = svc.get_desktops()
                 for desktop in desktops:


### PR DESCRIPTION
Moved the dark title bar DWM call out of ViewBase and into backdrop.py where it belongs ` set_dark_mode()` is now public alongside the other backdrop helpers. 

Also added a small `enable_dwm_frame()` util that gives frameless windows proper shadows and rounded corners via DWM.

The alert dialog got a full makeover. Ditched `QMessageBox` for a plain `QWidget` with animations, DWM frame, and theme-aware styling using our Button/TextBlock components. Looks way more at home now.

Fixed a dumb ordering bug where `apply_qmenu_style()` was being called after `setProperty("class", ...)` in a few places, which meant submenus weren't getting styled. Just moved the call before the property set.

Wallpaper gallery: added `.jpeg, .tif, .tiff` to the supported list, and fixed the prev/next buttons so they actually disable at the edges instead of letting you scroll past the last page.