### PR TITLE
feat(tooltip): add global tooltip configuration, blur effect, and fix positioning

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -45,8 +45,42 @@ Valid options are:
 | `debug`      | boolean  | `false`   | Enable debug mode to see more logs |
 | `update_check`      | boolean  | `true`   | Enable automatic update check. This works only if the application is installed. |
 | `show_systray`      | boolean  | `true`   | Show or hide the YASB system tray icon. |
+| `tooltip`           | object   | [See below](#tooltip-configuration) | Global tooltip configuration. |
 | `komorebi`      | object  | [See below](#komorebi-settings-for-tray-menu)   | Komorebi configuration for tray menu. |
 | `glazewm`      | object  | [See below](#glazewm-settings-for-tray-menu)   | Glazewm configuration for tray menu. |
+
+## Tooltip Configuration
+Global configuration for tooltips and their blur effects.
+
+| Option            | Type    | Default       | Description |
+|-------------------|---------|---------------|-------------|
+| `offset`          | integer | `5`           | The distance in pixels between the tooltip and the hovered item or bar. |
+| `blur_effect`     | object  | [See below](#tooltip-blur-effect-configuration) | Global tooltip blur configuration. |
+
+### Tooltip Blur Effect Configuration
+
+| Option            | Type    | Default       | Description |
+|-------------------|---------|---------------|-------------|
+| `enabled`         | boolean | `false`       | Whether the blur effect is enabled for tooltips. |
+| `dark_mode`       | boolean | `false`       | Whether to enable dark mode for the tooltip blur. |
+| `round_corners`   | boolean | `false`       | Whether to enable rounded corners for the tooltips. Note: This is only effective on Windows 11. |
+| `round_corners_type` | string | `'normal'` | The type of rounded corners, can be `normal` or `small`. Note: This is only effective on Windows 11. |
+| `border_color`    | string  | `'None'`      | The border color for the tooltip, can be `None`, `"system"`, or a hex color (e.g., `"#ff0000"`). Note: This is only effective on Windows 11. |
+
+> **Note:**
+> Rounded corners, border color and rounded corners type are only effective on Windows 11.
+
+**Example Configuration:**
+```yaml
+tooltip:
+  offset: 5
+  blur_effect:
+    enabled: true
+    dark_mode: false
+    round_corners: true
+    round_corners_type: "small"
+    border_color: "None"
+```
 
 
 ## Komorebi settings for tray menu

--- a/src/core/bar_helper.py
+++ b/src/core/bar_helper.py
@@ -5,6 +5,7 @@ import subprocess
 import winreg
 from datetime import datetime
 from functools import partial
+from typing import Any
 
 import win32gui
 import win32process
@@ -44,11 +45,12 @@ from core.utils.win32.utils import apply_qmenu_style
 WM_TASKBARCREATED = RegisterWindowMessage("TaskbarCreated")
 
 
-class ThemeState:
-    """Centralized dark/light theme state and stylesheet cache for detached widgets."""
+class GlobalState:
+    """Centralized global state for detached widgets and application-wide configurations."""
 
     _is_dark = False
     _stylesheet = None
+    _tooltip_options = None
 
     @classmethod
     def is_dark(cls) -> bool:
@@ -65,6 +67,14 @@ class ThemeState:
     @classmethod
     def set_stylesheet(cls, value: str):
         cls._stylesheet = value
+
+    @classmethod
+    def tooltip_options(cls) -> Any:
+        return cls._tooltip_options
+
+    @classmethod
+    def set_tooltip_options(cls, value: Any):
+        cls._tooltip_options = value
 
 
 class BarAnimationManager(QObject):
@@ -778,7 +788,7 @@ class OsThemeManager(QObject):
             self.target_widget.setProperty("class", class_property)
             self._update_styles(self.target_widget)
             self._is_dark_theme = is_dark_theme
-            ThemeState.set_dark(is_dark_theme)
+            GlobalState.set_dark(is_dark_theme)
 
     def _update_styles(self, widget):
         """Update styles for widget and its children by unpolishing and re-polishing"""
@@ -800,7 +810,7 @@ class BarContextMenu:
     def show(self, position):
         self._menu = QMenu(self.parent)
         apply_qmenu_style(self._menu)
-        self._menu.setProperty("class", "context-menu dark" if ThemeState.is_dark() else "context-menu")
+        self._menu.setProperty("class", "context-menu dark" if GlobalState.is_dark() else "context-menu")
         self._menu.aboutToHide.connect(self._on_menu_about_to_hide)
 
         # Bar info
@@ -811,7 +821,7 @@ class BarContextMenu:
         widgets_menu = self._menu.addMenu("Active Widgets")
         apply_qmenu_style(widgets_menu)
         widgets_menu.setProperty(
-            "class", "context-menu submenu dark" if ThemeState.is_dark() else "context-menu submenu"
+            "class", "context-menu submenu dark" if GlobalState.is_dark() else "context-menu submenu"
         )
         self._populate_widgets_menu(widgets_menu)
 

--- a/src/core/bar_manager.py
+++ b/src/core/bar_manager.py
@@ -8,7 +8,7 @@ from PyQt6.QtWidgets import QApplication
 from qt_css_engine import TransitionEngine, extract_rules
 
 from core.bar import Bar
-from core.bar_helper import ThemeState
+from core.bar_helper import GlobalState
 from core.config import get_config, get_stylesheet
 from core.events.service import EventService
 from core.utils.controller import reload_application
@@ -33,7 +33,8 @@ class BarManager(QObject):
         self.config = config
         self.stylesheet, self.rules = extract_rules(stylesheet)
         self.animation_engine = TransitionEngine(self.rules)
-        ThemeState.set_stylesheet(self.stylesheet)
+        GlobalState.set_stylesheet(self.stylesheet)
+        GlobalState.set_tooltip_options(self.config.tooltip)
         self.event_service = EventService()
         self.widget_event_listeners = set()
         self.bars: list[Bar] = []
@@ -66,7 +67,7 @@ class BarManager(QObject):
         stylesheet = get_stylesheet(show_error_dialog=True)
         if stylesheet and (stylesheet != self.stylesheet):
             self.stylesheet, new_rules = extract_rules(stylesheet)
-            ThemeState.set_stylesheet(self.stylesheet)
+            GlobalState.set_stylesheet(self.stylesheet)
             self.animation_engine.reload_rules(new_rules)
             for bar in self.bars:
                 bar.setStyleSheet(self.stylesheet)

--- a/src/core/utils/tooltip.py
+++ b/src/core/utils/tooltip.py
@@ -11,7 +11,8 @@ from PyQt6.QtCore import (
 from PyQt6.QtGui import QCursor, QGuiApplication
 from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QWidget
 
-from core.bar_helper import ThemeState
+from core.bar_helper import GlobalState
+from core.utils.win32.backdrop import enable_blur
 
 
 class CustomToolTip(QFrame):
@@ -34,7 +35,7 @@ class CustomToolTip(QFrame):
 
         # Create label for text content
         self.label = QLabel()
-        self.label.setProperty("class", "tooltip dark" if ThemeState.is_dark() else "tooltip")
+        self.label.setProperty("class", "tooltip dark" if GlobalState.is_dark() else "tooltip")
 
         # cast to int for margins
         self.layout = QHBoxLayout(self)
@@ -113,8 +114,8 @@ class CustomToolTip(QFrame):
         if cls._tooltip_pool:
             tooltip = cls._tooltip_pool.pop()
             tooltip._is_destroyed = False
-            tooltip.label.setProperty("class", "tooltip dark" if ThemeState.is_dark() else "tooltip")
-            tooltip.setStyleSheet(ThemeState.stylesheet())
+            tooltip.label.setProperty("class", "tooltip dark" if GlobalState.is_dark() else "tooltip")
+            tooltip.setStyleSheet(GlobalState.stylesheet())
             return tooltip
         return cls()
 
@@ -132,8 +133,8 @@ class CustomToolTip(QFrame):
             tooltip.deleteLater()
 
     def apply_stylesheet(self):
-        """Apply the tooltip stylesheet from ThemeState."""
-        self.setStyleSheet(ThemeState.stylesheet())
+        """Apply the tooltip stylesheet from GlobalState."""
+        self.setStyleSheet(GlobalState.stylesheet())
 
     def get_opacity(self):
         return self._opacity
@@ -162,38 +163,45 @@ class CustomToolTip(QFrame):
             if self.isVisible() and self._base_pos:
                 self.move(self._base_pos.x(), self._base_pos.y() + int(self._slide_offset))
 
-    def _calculate_position(self, widget_geometry):
+    def _calculate_position(self, widget_geometry, top_level_geometry=None):
         """Calculate tooltip position based on widget geometry and screen bounds."""
+        if top_level_geometry is None:
+            top_level_geometry = widget_geometry
+
         screen = QGuiApplication.screenAt(widget_geometry.center()) or QGuiApplication.primaryScreen()
         screen_geometry = screen.geometry()
 
         # Center horizontally on widget
         x = widget_geometry.center().x() - (self.width() // 2)
 
-        # Position vertically based on preference
-        space_below = screen_geometry.bottom() - widget_geometry.bottom()
-        space_above = widget_geometry.top() - screen_geometry.top()
+        # Position vertically based on top level window (Bar or Popup)
+        space_below = screen_geometry.bottom() - top_level_geometry.bottom()
+        space_above = top_level_geometry.top() - screen_geometry.top()
+
+        # Get dynamic offset
+        opts = GlobalState.tooltip_options()
+        offset = opts.offset if opts else 5
 
         if self._position == "top":
             # Force top position if there's space, otherwise fallback to bottom
-            if space_above >= self.height() + 5:
-                y = widget_geometry.top() - self.height() - 5
+            if space_above >= self.height() + offset:
+                y = top_level_geometry.top() - self.height() - offset
             else:
-                y = widget_geometry.bottom() + 5
+                y = top_level_geometry.bottom() + offset
         elif self._position == "bottom":
             # Force bottom position if there's space, otherwise fallback to top
-            if space_below >= self.height() + 5:
-                y = widget_geometry.bottom() + 5
+            if space_below >= self.height() + offset:
+                y = top_level_geometry.bottom() + offset
             else:
-                y = widget_geometry.top() - self.height() - 5
+                y = top_level_geometry.top() - self.height() - offset
         else:
             # Auto: prefer below, but above if no space
-            if space_below >= self.height() + 5:
-                y = widget_geometry.bottom() + 5
-            elif space_above >= self.height() + 5:
-                y = widget_geometry.top() - self.height() - 5
+            if space_below >= self.height() + offset:
+                y = top_level_geometry.bottom() + offset
+            elif space_above >= self.height() + offset:
+                y = top_level_geometry.top() - self.height() - offset
             else:
-                y = widget_geometry.bottom() + 5  # Default to below
+                y = top_level_geometry.bottom() + offset  # Default to below
 
         # Clamp to screen bounds
         x = max(screen_geometry.left(), min(x, screen_geometry.right() - self.width()))
@@ -201,7 +209,7 @@ class CustomToolTip(QFrame):
 
         return QPoint(x, y)
 
-    def show_tooltip(self, text, widget_geometry=None, duration=None):
+    def show_tooltip(self, text, widget_geometry=None, top_level_geometry=None, duration=None):
         """Show tooltip centered below or above the widget."""
         if CustomToolTip._active_tooltip and CustomToolTip._active_tooltip is not self:
             CustomToolTip._active_tooltip.hide()
@@ -211,13 +219,24 @@ class CustomToolTip(QFrame):
         self.adjustSize()
 
         if widget_geometry:
-            self._base_pos = self._calculate_position(widget_geometry)
+            self._base_pos = self._calculate_position(widget_geometry, top_level_geometry)
             self.move(self._base_pos.x(), self._base_pos.y())
         else:
             return
 
         self._start_animations(fade_in=True)
         self.show()
+
+        opts = GlobalState.tooltip_options()
+        if opts and opts.blur_effect and opts.blur_effect.enabled:
+            blur_cfg = opts.blur_effect
+            enable_blur(
+                self.winId(),
+                DarkMode=blur_cfg.dark_mode,
+                RoundCorners=blur_cfg.round_corners,
+                RoundCornersType=blur_cfg.round_corners_type,
+                BorderColor=blur_cfg.border_color,
+            )
 
         if duration:
             self.hide_timer.start(duration)
@@ -327,7 +346,15 @@ class TooltipEventFilter(QObject):
                 if (self.widget.isVisible() and widget_rect.width() > 0 and widget_rect.height() > 0)
                 else None
             )
-            self.tooltip.show_tooltip(self.tooltip_text, geometry)
+            top_level = self.widget.window()
+            if top_level and top_level.__class__.__name__ == "Bar":
+                top_level_rect = top_level.rect()
+                top_level_global_pos = top_level.mapToGlobal(QPoint(0, 0))
+                top_level_geometry = top_level_rect.translated(top_level_global_pos)
+            else:
+                top_level_geometry = global_geometry
+
+            self.tooltip.show_tooltip(self.tooltip_text, geometry, top_level_geometry)
 
         self.hide_timer.stop()
         if not self._app_event_filter_installed:

--- a/src/core/validation/config.py
+++ b/src/core/validation/config.py
@@ -1,7 +1,20 @@
-from typing import Any
+from typing import Any, Literal
 
 from core.validation.bar import BarConfig
 from core.validation.widgets.base_model import CustomBaseModel
+
+
+class TooltipBlurEffect(CustomBaseModel):
+    enabled: bool = False
+    dark_mode: bool = False
+    round_corners: bool = False
+    round_corners_type: Literal["normal", "small"] = "normal"
+    border_color: str = "None"
+
+
+class TooltipOptions(CustomBaseModel):
+    offset: int = 5
+    blur_effect: TooltipBlurEffect = TooltipBlurEffect()
 
 
 class KomorebiConfig(CustomBaseModel):
@@ -22,6 +35,7 @@ class YasbConfig(CustomBaseModel):
     debug: bool = False
     update_check: bool = True
     show_systray: bool = True
+    tooltip: TooltipOptions = TooltipOptions()
     komorebi: KomorebiConfig = KomorebiConfig()
     glazewm: GlazeWMConfig = GlazeWMConfig()
     bars: dict[str, BarConfig] = {"yasb-bar": BarConfig()}

--- a/src/core/widgets/services/wallpapers/wallpapers_gallery.py
+++ b/src/core/widgets/services/wallpapers/wallpapers_gallery.py
@@ -29,7 +29,7 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
 )
 
-from core.bar_helper import ThemeState
+from core.bar_helper import GlobalState
 from core.utils.system import get_build_and_ubr
 from core.utils.utilities import refresh_widget_style
 from core.utils.win32.backdrop import enable_blur
@@ -289,9 +289,9 @@ class ImageGallery(QMainWindow):
         central_widget = QFrame()
         self.setCentralWidget(central_widget)
         central_widget.setProperty(
-            "class", "wallpapers-gallery-window dark" if ThemeState.is_dark() else "wallpapers-gallery-window"
+            "class", "wallpapers-gallery-window dark" if GlobalState.is_dark() else "wallpapers-gallery-window"
         )
-        self.setStyleSheet(ThemeState.stylesheet())
+        self.setStyleSheet(GlobalState.stylesheet())
 
         self.setContentsMargins(0, 0, 0, 0)
         layout = QVBoxLayout()


### PR DESCRIPTION
- Add a global `tooltip` configuration object to customize offset and blur effects
- Implement DWM blur on tooltips using `enable_blur` when configured
- Fix tooltip vertical positioning inside popups by anchoring to top-level windows
- Rename `ThemeState` to `GlobalState` to better reflect its role in storing UI configuration
- Update `Configuration.md` documentation with tooltip options and examples