### PR TITLE
refactor(core): implement async widget loading and optimize bar initialization

### DIFF
--- a/src/core/bar.py
+++ b/src/core/bar.py
@@ -31,6 +31,7 @@ except ImportError:
 
 class Bar(QWidget):
     handle_bar_management = pyqtSignal(str, str)
+    bar_loaded = pyqtSignal()
 
     def __init__(
         self,
@@ -45,7 +46,6 @@ class Bar(QWidget):
         super().__init__()
         self.config = config
         self._event_service = EventService()
-        self.hide()
         self.setScreen(bar_screen)
         self._bar_id = bar_id
         self._bar_name = bar_name
@@ -104,7 +104,7 @@ class Bar(QWidget):
         self.position_bar(init)
         self.monitor_hwnd = get_monitor_hwnd(int(self.winId()))
 
-        self._add_widgets(widgets)
+        self._setup_layouts()
 
         if self._is_auto_width:
             self._auto_width_manager = AutoWidthManager(self, self)
@@ -241,10 +241,11 @@ class Bar(QWidget):
         self.setGeometry(bar_x, bar_y, bar_width, bar_height)
         self._bar_frame.setGeometry(0, 0, bar_width, bar_height)
 
-    def _add_widgets(self, widgets: dict[str, list] = None):
+    def _setup_layouts(self):
         bar_layout = QGridLayout()
         bar_layout.setContentsMargins(0, 0, 0, 0)
         bar_layout.setSpacing(0)
+        self._column_layouts = {}
 
         for column_num, layout_type in enumerate(["left", "center", "right"]):
             config = self.config.layouts.model_dump()[layout_type]
@@ -254,28 +255,36 @@ class Bar(QWidget):
             layout_container = QFrame()
             layout_container.setProperty("class", f"container container-{layout_type}")
 
-            # Add widgets
-            if layout_type in widgets:
-                for widget in widgets[layout_type]:
-                    widget.parent_layout_type = layout_type
-                    widget.bar_id = self.bar_id
-                    widget.monitor_hwnd = self.monitor_hwnd
-                    layout.addWidget(widget, 0)
-
             if config["alignment"] == "left" and config["stretch"]:
                 layout.addStretch(1)
-
             elif config["alignment"] == "right" and config["stretch"]:
                 layout.insertStretch(0, 1)
-
             elif config["alignment"] == "center" and config["stretch"]:
                 layout.insertStretch(0, 1)
                 layout.addStretch(1)
 
+            self._column_layouts[layout_type] = layout
             layout_container.setLayout(layout)
             bar_layout.addWidget(layout_container, 0, column_num)
 
         self._bar_frame.setLayout(bar_layout)
+
+    def add_single_widget(self, layout_type: str, widget: QWidget):
+        layout = self._column_layouts[layout_type]
+        config = self.config.layouts.model_dump()[layout_type]
+
+        widget.parent_layout_type = layout_type
+        widget.bar_id = self.bar_id
+        widget.monitor_hwnd = self.monitor_hwnd
+
+        if config["alignment"] == "left" and config["stretch"]:
+            layout.insertWidget(layout.count() - 1, widget, 0)
+        elif config["alignment"] == "right" and config["stretch"]:
+            layout.addWidget(widget, 0)
+        elif config["alignment"] == "center" and config["stretch"]:
+            layout.insertWidget(layout.count() - 1, widget, 0)
+        else:
+            layout.addWidget(widget, 0)
 
     def show_bar(self):
         if self._animation_manager:
@@ -287,13 +296,20 @@ class Bar(QWidget):
 
     def showEvent(self, event):
         super().showEvent(event)
-        if self._animation.get("enabled", False) and self._animation_manager:
+
+        duration = self._animation["duration"]
+        is_animation_enabled = self._animation.get("enabled", False) and duration > 0
+
+        if is_animation_enabled and self._animation_manager:
             # Use fade on initial show to avoid DWM blur/shadow flash with slide
             if getattr(self, "_initial_show", False):
                 self._initial_show = False
                 self._animation_manager._start_fade(True)
             else:
                 self.show_bar()
+        elif getattr(self, "_initial_show", False):
+            self._initial_show = False
+            QTimer.singleShot(0, self.bar_loaded.emit)
 
     def closeEvent(self, event):
         if self._hide_on_fullscreen and self.app_bar_manager:
@@ -328,9 +344,12 @@ class Bar(QWidget):
         return super().eventFilter(obj, event)
 
     def hide(self):
+        duration = self._animation["duration"]
+        is_animation_enabled = self._animation.get("enabled", False) and duration > 0
+
         if getattr(self, "_skip_animation", False):
             super().hide()
-        elif self.isVisible() and self._animation.get("enabled") and self._animation_manager:
+        elif self.isVisible() and is_animation_enabled and self._animation_manager:
             self._animation_manager.hide_bar()
         else:
             super().hide()

--- a/src/core/bar_helper.py
+++ b/src/core/bar_helper.py
@@ -79,7 +79,8 @@ class BarAnimationManager(QObject):
         self._pending_action = None
 
     def show_bar(self):
-        if not self.bar_widget._animation.get("enabled"):
+        duration = self.bar_widget._animation["duration"]
+        if not self.bar_widget._animation.get("enabled") or duration <= 0:
             self.bar_widget.show()
             return
         if self._animation and self._animation.state() == QVariantAnimation.State.Running:
@@ -92,7 +93,8 @@ class BarAnimationManager(QObject):
             self._start_slide(True)
 
     def hide_bar(self):
-        if not self.bar_widget._animation.get("enabled"):
+        duration = self.bar_widget._animation["duration"]
+        if not self.bar_widget._animation.get("enabled") or duration <= 0:
             self.bar_widget._skip_animation = True
             self.bar_widget.hide()
             self.bar_widget._skip_animation = False
@@ -113,7 +115,7 @@ class BarAnimationManager(QObject):
 
     def _start_fade(self, show: bool):
         self._stop_animation()
-        duration = self.bar_widget._animation.get("duration", 300)
+        duration = self.bar_widget._animation["duration"]
         self._animation = QPropertyAnimation(self.bar_widget, b"windowOpacity")
         self._animation.setDuration(duration)
         self._animation.setStartValue(0.0 if show else 1.0)
@@ -152,7 +154,7 @@ class BarAnimationManager(QObject):
             self._update_slide(0.0)
 
         self._animation = QVariantAnimation(bar)
-        self._animation.setDuration(bar._animation.get("duration", 300))
+        self._animation.setDuration(bar._animation["duration"])
         self._animation.setStartValue(0.0 if show else 1.0)
         self._animation.setEndValue(1.0 if show else 0.0)
         self._animation.setEasingCurve(QEasingCurve.Type.OutQuad if show else QEasingCurve.Type.InQuad)
@@ -191,6 +193,7 @@ class BarAnimationManager(QObject):
         self.bar_widget._bar_frame.move(0, 0)
         self._animation = None
         self._process_pending()
+        self.bar_widget.bar_loaded.emit()
 
         # Check if mouse left during the animation
         if (

--- a/src/core/bar_manager.py
+++ b/src/core/bar_manager.py
@@ -4,7 +4,7 @@ from contextlib import suppress
 
 from PyQt6.QtCore import QObject, QTimer, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QScreen
-from PyQt6.QtWidgets import QApplication
+from PyQt6.QtWidgets import QApplication, QWidget
 from qt_css_engine import TransitionEngine, extract_rules
 
 from core.bar import Bar
@@ -46,8 +46,7 @@ class BarManager(QObject):
         self._hotkey_dispatcher: HotkeyDispatcher | None = None
         self._collected_keybindings: list[HotkeyBinding] = []
         self._registered_hotkey_widgets: set[tuple[str, str]] = set()  # (widget_name, screen_name)
-        self._widget_queues = []
-        self._bars_animation_count = 0
+        self._bars_count = 0
 
         self.styles_modified.connect(self.on_styles_modified)
         self.config_modified.connect(self.on_config_modified)
@@ -180,14 +179,13 @@ class BarManager(QObject):
                         initialized_screens.add(screen.name())
 
         self._initialized_screens = initialized_screens
-        self._bars_loading_count = len(self.bars)
-        self._bars_animation_count = len(self.bars)
+        self._bars_count = len(self.bars)
 
         self._widgets_with_keybindings = {
             n for n, cfg in self.config.widgets.items() if cfg.get("options", {}).get("keybindings")
         }
 
-        if self._bars_loading_count == 0:
+        if self._bars_count == 0:
             self._finish_initialization()
         else:
             for bar in self.bars:
@@ -199,6 +197,12 @@ class BarManager(QObject):
         self._start_hotkey_listener()
         self.run_listeners_in_threads()
         self._widget_builder.raise_alerts_if_errors_present()
+        QTimer.singleShot(0, self._engine_widget_registration)
+
+    def _engine_widget_registration(self) -> None:
+        for bar in self.bars:
+            for widget in bar.findChildren(QWidget):
+                self.animation_engine._on_polish(widget)
 
     def _on_bar_animation_finished(self):
         sender = self.sender()
@@ -206,42 +210,36 @@ class BarManager(QObject):
             with suppress(TypeError):
                 sender.bar_loaded.disconnect(self._on_bar_animation_finished)
 
-        self._bars_animation_count -= 1
-        if self._bars_animation_count <= 0:
+        self._bars_count -= 1
+        if self._bars_count <= 0:
             for bar in self.bars:
                 self._process_widget_queue(bar)
+            self._finish_initialization()
 
     def _process_widget_queue(self, bar: Bar) -> None:
         if not hasattr(bar, "_widget_queue") or not bar._widget_queue:
-            self._check_all_bars_loaded()
             return
 
-        column, w_name = bar._widget_queue.pop(0)
-        widget = self._widget_builder._build_widget(w_name)
-        if widget:
-            screen_name = bar.screen().name()
-            widget.screen_name = screen_name
-            if widget.widget_name in self._widgets_with_keybindings:
-                key = (widget.widget_name, screen_name)
-                if key in self._registered_hotkey_widgets:
-                    widget._hotkey_enabled = False
-                    logging.info(
-                        "%s on screen %s already has hotkey handler registered from another bar.",
-                        widget.widget_name,
-                        screen_name,
-                    )
-                else:
-                    self._registered_hotkey_widgets.add(key)
+        while bar._widget_queue:
+            column, w_name = bar._widget_queue.pop(0)
+            widget = self._widget_builder._build_widget(w_name)
+            if widget:
+                screen_name = bar.screen().name()
+                widget.screen_name = screen_name
+                if widget.widget_name in self._widgets_with_keybindings:
+                    key = (widget.widget_name, screen_name)
+                    if key in self._registered_hotkey_widgets:
+                        widget._hotkey_enabled = False
+                        logging.info(
+                            "%s on screen %s already has hotkey handler registered from another bar.",
+                            widget.widget_name,
+                            screen_name,
+                        )
+                    else:
+                        self._registered_hotkey_widgets.add(key)
 
-            bar.add_single_widget(column, widget)
-            bar._widgets[column].append(widget)
-
-        QTimer.singleShot(0, lambda: self._process_widget_queue(bar))
-
-    def _check_all_bars_loaded(self) -> None:
-        self._bars_loading_count -= 1
-        if self._bars_loading_count <= 0:
-            self._finish_initialization()
+                bar.add_single_widget(column, widget)
+                bar._widgets[column].append(widget)
 
     def _collect_keybindings(self) -> None:
         """Collect keybindings from all widget configurations."""

--- a/src/core/bar_manager.py
+++ b/src/core/bar_manager.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 from contextlib import suppress
 
-from PyQt6.QtCore import QObject, QTimer, pyqtSignal, pyqtSlot
+from PyQt6.QtCore import QObject, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QScreen
 from PyQt6.QtWidgets import QApplication, QWidget
 from qt_css_engine import TransitionEngine, extract_rules
@@ -51,7 +51,6 @@ class BarManager(QObject):
         self.styles_modified.connect(self.on_styles_modified)
         self.config_modified.connect(self.on_config_modified)
         self._app = QApplication.instance()
-        self._app.installEventFilter(self.animation_engine)
         self._app.aboutToQuit.connect(self.stop_listener_threads)
         self._app.screenAdded.connect(self.on_screens_update)
         self._app.screenRemoved.connect(self.on_screens_update)
@@ -197,7 +196,8 @@ class BarManager(QObject):
         self._start_hotkey_listener()
         self.run_listeners_in_threads()
         self._widget_builder.raise_alerts_if_errors_present()
-        QTimer.singleShot(0, self._engine_widget_registration)
+        self._app.installEventFilter(self.animation_engine)
+        self._engine_widget_registration()
 
     def _engine_widget_registration(self) -> None:
         for bar in self.bars:

--- a/src/core/bar_manager.py
+++ b/src/core/bar_manager.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 from contextlib import suppress
 
-from PyQt6.QtCore import QObject, pyqtSignal, pyqtSlot
+from PyQt6.QtCore import QObject, QTimer, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QScreen
 from PyQt6.QtWidgets import QApplication
 from qt_css_engine import TransitionEngine, extract_rules
@@ -46,6 +46,8 @@ class BarManager(QObject):
         self._hotkey_dispatcher: HotkeyDispatcher | None = None
         self._collected_keybindings: list[HotkeyBinding] = []
         self._registered_hotkey_widgets: set[tuple[str, str]] = set()  # (widget_name, screen_name)
+        self._widget_queues = []
+        self._bars_animation_count = 0
 
         self.styles_modified.connect(self.on_styles_modified)
         self.config_modified.connect(self.on_config_modified)
@@ -134,6 +136,8 @@ class BarManager(QObject):
 
     def initialize_bars(self, init: bool = False) -> None:
         self._widget_builder = WidgetBuilder(self.config.widgets)
+        self._widget_queues = []
+
         primary_screen = QApplication.primaryScreen()
         primary_screen_name = primary_screen.name() if primary_screen else None
 
@@ -176,10 +180,68 @@ class BarManager(QObject):
                         initialized_screens.add(screen.name())
 
         self._initialized_screens = initialized_screens
+        self._bars_loading_count = len(self.bars)
+        self._bars_animation_count = len(self.bars)
+
+        self._widgets_with_keybindings = {
+            n for n, cfg in self.config.widgets.items() if cfg.get("options", {}).get("keybindings")
+        }
+
+        if self._bars_loading_count == 0:
+            self._finish_initialization()
+        else:
+            for bar in self.bars:
+                bar.bar_loaded.connect(self._on_bar_animation_finished)
+
+    def _finish_initialization(self) -> None:
+        self.widget_event_listeners = self.widget_event_listeners.union(self._widget_builder._widget_event_listeners)
         self._collect_keybindings()
         self._start_hotkey_listener()
         self.run_listeners_in_threads()
         self._widget_builder.raise_alerts_if_errors_present()
+
+    def _on_bar_animation_finished(self):
+        sender = self.sender()
+        if sender:
+            with suppress(TypeError):
+                sender.bar_loaded.disconnect(self._on_bar_animation_finished)
+
+        self._bars_animation_count -= 1
+        if self._bars_animation_count <= 0:
+            for bar in self.bars:
+                self._process_widget_queue(bar)
+
+    def _process_widget_queue(self, bar: Bar) -> None:
+        if not hasattr(bar, "_widget_queue") or not bar._widget_queue:
+            self._check_all_bars_loaded()
+            return
+
+        column, w_name = bar._widget_queue.pop(0)
+        widget = self._widget_builder._build_widget(w_name)
+        if widget:
+            screen_name = bar.screen().name()
+            widget.screen_name = screen_name
+            if widget.widget_name in self._widgets_with_keybindings:
+                key = (widget.widget_name, screen_name)
+                if key in self._registered_hotkey_widgets:
+                    widget._hotkey_enabled = False
+                    logging.info(
+                        "%s on screen %s already has hotkey handler registered from another bar.",
+                        widget.widget_name,
+                        screen_name,
+                    )
+                else:
+                    self._registered_hotkey_widgets.add(key)
+
+            bar.add_single_widget(column, widget)
+            bar._widgets[column].append(widget)
+
+        QTimer.singleShot(0, lambda: self._process_widget_queue(bar))
+
+    def _check_all_bars_loaded(self) -> None:
+        self._bars_loading_count -= 1
+        if self._bars_loading_count <= 0:
+            self._finish_initialization()
 
     def _collect_keybindings(self) -> None:
         """Collect keybindings from all widget configurations."""
@@ -230,36 +292,20 @@ class BarManager(QObject):
     def create_bar(self, config: BarConfig, name: str, screen: QScreen, init: bool = False) -> None:
         screen_name = screen.name().replace("\\", "").replace(".", "")
         bar_id = f"{name}_{screen_name}_{str(uuid.uuid4())[:8]}"
-        bar_widgets, widget_event_listeners = self._widget_builder.build_widgets(config.widgets.model_dump())
 
-        # Set screen_name on all widgets and disable duplicate hotkey handlers
-        widgets_with_keybindings = {
-            name for name, cfg in self.config.widgets.items() if cfg.get("options", {}).get("keybindings")
-        }
-        for widget_list in bar_widgets.values():
-            for widget in widget_list:
-                widget.screen_name = screen.name()
-                if widget.widget_name in widgets_with_keybindings:
-                    key = (widget.widget_name, screen.name())
-                    if key in self._registered_hotkey_widgets:
-                        widget._hotkey_enabled = False
-                        logging.info(
-                            "%s on screen %s already has hotkey handler registered from another bar.",
-                            widget.widget_name,
-                            screen.name(),
-                        )
-                    else:
-                        self._registered_hotkey_widgets.add(key)
-
-        self.widget_event_listeners = self.widget_event_listeners.union(widget_event_listeners)
-        self.bars.append(
-            Bar(
-                bar_id=bar_id,
-                bar_name=name,
-                bar_screen=screen,
-                stylesheet=self.stylesheet,
-                widgets=bar_widgets,
-                config=config,
-                init=init,
-            )
+        bar = Bar(
+            bar_id=bar_id,
+            bar_name=name,
+            bar_screen=screen,
+            stylesheet=self.stylesheet,
+            widgets={"left": [], "center": [], "right": []},
+            config=config,
+            init=init,
         )
+        self.bars.append(bar)
+
+        bar._widget_queue = []
+        for column, w_names in config.widgets.model_dump().items():
+            if w_names:
+                for w_name in w_names:
+                    bar._widget_queue.append((column, w_name))


### PR DESCRIPTION
Refactored the widget loading system to be asynchronous so the bar renders instantly on startup. 

Previously, heavy widget configurations would block the main GUI thread, freezing the app until everything was built. Now, the bar initializes an empty layout immediately, runs any configured entrance animations, and then uses a `QTimer.singleShot` queue to build and insert widgets one by one. This keeps the UI completely responsive during heavy startups. 

Also cleaned up a few minor things along the way: renamed the `animation_finished` signal to `bar_loaded` to better reflect the new lifecycle, fixed an edge case where setting animation duration to `0` would swallow signals and hang the load, and dropped some legacy boilerplate `self.hide()` calls from the bar's `__init__` that were causing initialization race conditions.