### PR TITLE
feat(battery): add progress bar configuration and implementation

### DIFF
--- a/docs/widgets/(Widget)-Battery.md
+++ b/docs/widgets/(Widget)-Battery.md
@@ -13,6 +13,7 @@
 | `status_thresholds`     | dict    | `{critical: 10, low: 25, medium: 75, high: 95, full: 100}` | Thresholds for different battery statuses.                                  |
 | `status_icons`          | dict    | `{icon_charging: '\uf0e7', icon_critical: '\uf244', icon_low: '\uf243', icon_medium: '\uf242', icon_high: '\uf241', icon_full: '\uf240'}` | Icons for different battery statuses.                                       |
 | `callbacks`             | dict    | `{on_left: 'toggle_label', on_middle: 'do_nothing', on_right: 'do_nothing'}` | Callback functions for different mouse button actions.                      |
+| `progress_bar`       | dict    | `{'enabled': false, 'position': 'left', 'size': 14, 'thickness': 2, 'color': '#57948a', 'animation': true}` | Progress bar settings.    |
 
 ## Label Placeholders
 
@@ -94,6 +95,14 @@ battery:
   - **on_left**: The name of the callback function for left mouse button click.
   - **on_middle**: The name of the callback function for middle mouse button click.
   - **on_right**: The name of the callback function for right mouse button click.
+- **progress_bar**: A dictionary containing settings for the progress bar. It includes:
+  - **enabled**: Whether the progress bar is enabled.
+  - **position**: The position of the progress bar, either "left" or "right".
+  - **size**: The size of the progress bar.
+  - **thickness**: The thickness of the progress bar.
+  - **color**: The color of the progress bar. Color can be single color or gradient. For example, `color: "#57948a"` or `color: ["#57948a", "#ff0000"]` for a gradient.
+  - **background_color**: The background color of the progress bar.
+  - **animation**: Whether to enable smooth change of the progress bar value.
 
 ## Style
 ```css

--- a/src/core/validation/widgets/yasb/battery.py
+++ b/src/core/validation/widgets/yasb/battery.py
@@ -30,6 +30,16 @@ class StatusIconsConfig(CustomBaseModel):
     icon_full: str = "\uf240"
 
 
+class ProgressBarConfig(CustomBaseModel):
+    enabled: bool = False
+    size: int = Field(default=18, ge=8, le=64)
+    thickness: int = Field(default=3, ge=1, le=10)
+    color: str | list[str] = "#00C800"
+    background_color: str = "#3C3C3C"
+    position: str = "left"
+    animation: bool = True
+
+
 class CallbacksBatteryConfig(CallbacksConfig):
     on_left: str = "toggle_label"
 
@@ -45,5 +55,6 @@ class BatteryConfig(CustomBaseModel):
     charging_options: ChargingOptionsConfig = ChargingOptionsConfig()
     status_thresholds: StatusThresholdsConfig = StatusThresholdsConfig()
     status_icons: StatusIconsConfig = StatusIconsConfig()
+    progress_bar: ProgressBarConfig = ProgressBarConfig()
     keybindings: list[KeybindingConfig] = []
     callbacks: CallbacksBatteryConfig = CallbacksBatteryConfig()

--- a/src/core/widgets/yasb/battery.py
+++ b/src/core/widgets/yasb/battery.py
@@ -5,7 +5,7 @@ import humanize
 from PyQt6.QtCore import QTimer
 from PyQt6.QtWidgets import QLabel
 
-from core.utils.utilities import refresh_widget_style
+from core.utils.utilities import build_progress_widget, refresh_widget_style
 from core.utils.win32.constants import POWER_TIME_UNKNOWN, POWER_TIME_UNLIMITED
 from core.validation.widgets.yasb.battery import BatteryConfig
 from core.widgets.base import BaseWidget
@@ -22,6 +22,8 @@ class BatteryWidget(BaseWidget):
         self._battery_api = BatteryAPI.instance()
         self._battery_state: BatteryData | None = None
         self._show_alt_label = False
+
+        self.progress_widget = build_progress_widget(self, self.config.progress_bar.model_dump())
 
         self._init_container()
         self.build_widget_label(self.config.label, self.config.label_alt)
@@ -157,6 +159,14 @@ class BatteryWidget(BaseWidget):
         cycle_count_str = str(state.cycle_count) if state.cycle_count is not None else "N/A"
         health_str = f"{state.health_percent:.1f}" if state.health_percent is not None else "N/A"
         chemistry_str = state.chemistry if state.chemistry else "N/A"
+
+        if self.config.progress_bar.enabled and self.progress_widget and self._battery_state.percent is not None:
+            if self._widget_container_layout.indexOf(self.progress_widget) == -1:
+                self._widget_container_layout.insertWidget(
+                    0 if self.config.progress_bar.position == "left" else self._widget_container_layout.count(),
+                    self.progress_widget,
+                )
+            self.progress_widget.set_value(self._battery_state.percent)
 
         for part in label_parts:
             part = part.strip()


### PR DESCRIPTION
This adds a progress bar to the battery widget that functions exactly like the other existing progress bars do.

It only displays the battery percentage, none of the other battery statistics.