### PR TITLE
feat: add Claude usage widget

### DIFF
--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -16,6 +16,7 @@
     - [Bluetooth](./(Widget)-Bluetooth)
     - [Brightness](./(Widget)-Brightness)
     - [Cava](./(Widget)-Cava)
+    - [Claude Usage](./(Widget)-Claude-Usage)
     - [Copilot](./(Widget)-Copilot)
     - [CPU](./(Widget)-CPU)
     - [Clock](./(Widget)-Clock)

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -1,0 +1,164 @@
+# Claude Usage Widget Options
+
+Shows your Claude (Claude Code) subscription usage on the bar — the 5-hour and 7-day
+rolling limit utilization — with a popup menu that displays both windows as progress bars
+together with their reset times (a countdown plus the exact reset timestamp).
+
+The data is read from the same OAuth credentials the Claude Code CLI uses
+(`~/.claude/.credentials.json`) and fetched from Anthropic's usage endpoint. No API key or
+extra configuration is required as long as you are signed in to Claude Code.
+
+| Option            | Type    | Default | Description |
+|-------------------|---------|---------|-------------|
+| `label`           | string  | `'Claude {five_hour}%'` | The format string for the label. Supports the placeholders below. |
+| `label_alt`       | string  | `'Claude {seven_day}%'` | The alternative format string, toggled by the `toggle_label` callback. |
+| `update_interval` | integer | `60` | How often the label and reset countdown are refreshed, in seconds. Must be between 30 and 3600. |
+| `cache_ttl`       | integer | `120` | How long (seconds) a fetched result is cached on disk before the endpoint is queried again. The endpoint is rate-limited, so keep this at a sane value. |
+| `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
+| `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. |
+| `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
+
+## Placeholders
+
+The label is plain text by default. You can prepend a Nerd Font glyph in a `<span>` if you
+want an icon (e.g. `<span>\U000f06a9</span> {five_hour}%`). The following placeholders can be
+used in `label` / `label_alt`:
+
+- `{five_hour}` — 5-hour window utilization (percent, `--` when unavailable).
+- `{seven_day}` — 7-day window utilization (percent, `--` when unavailable).
+- `{five_hour_reset}` — time until the 5-hour window resets. Shown as a countdown when under a
+  day away (e.g. `4h 27m`), otherwise as a local weekday + time (e.g. `Sat 6:00 AM`).
+- `{seven_day_reset}` — time until the 7-day window resets (e.g. `Sat 6:00 AM`).
+
+```yaml
+claude_usage:
+  type: "yasb.claude_usage.ClaudeUsageWidget"
+  options:
+    label: "Claude {five_hour}% · {five_hour_reset}"
+    label_alt: "Claude 7d {seven_day}% · {seven_day_reset}"
+    update_interval: 60
+    cache_ttl: 120
+    callbacks:
+      on_left: "toggle_menu"    # open the usage menu
+      on_middle: "do_nothing"
+      on_right: "toggle_label"  # switch the bar text between 5h and 7d
+    menu:
+      blur: true
+      round_corners: true
+      round_corners_type: "normal"
+      border_color: "System"
+      alignment: "right"
+      direction: "down"
+      offset_top: 6
+      offset_left: 0
+```
+
+## Description of Options
+
+- **label:** The format string for the label. Supports the placeholders listed above.
+- **label_alt:** The alternative format string, toggled with the `toggle_label` callback.
+- **update_interval:** How often the bar label and reset countdown are refreshed, in seconds (30–3600).
+- **cache_ttl:** How long a fetched result is cached on disk before the usage endpoint is queried again. Because the endpoint is rate-limited (HTTP 429), the widget serves the last cached value on any error instead of going blank.
+- **tooltip:** Whether to show a summary tooltip on hover.
+- **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `do_nothing`, and `exec`.
+- **menu:** A dictionary specifying the popup menu settings:
+  - **blur:** Enable blur effect for the menu.
+  - **round_corners:** Enable round corners (not supported on Windows 10).
+  - **round_corners_type:** Type of round corners (`normal`, `small`).
+  - **border_color:** Border color of the menu.
+  - **alignment:** Horizontal alignment of the menu (`left`, `right`, `center`).
+  - **direction:** Whether the menu opens `down` or `up`.
+  - **offset_top / offset_left:** Pixel offsets for fine positioning.
+
+## Authentication
+
+The widget reuses Claude Code's existing OAuth session. It reads the access token from
+`%USERPROFILE%\.claude\.credentials.json` (or `$CLAUDE_CONFIG_DIR\.credentials.json` when
+that environment variable is set) and never logs or stores it elsewhere. If you are not
+signed in to Claude Code, the widget shows `--` until you sign in.
+
+## Widget Style
+```css
+.claude-usage {}
+.claude-usage .widget-container {}
+.claude-usage .icon {}
+.claude-usage .label {}
+/* Popup menu */
+.claude-usage-menu {}
+.claude-usage-menu .header {}        /* "Claude Usage" title */
+.claude-usage-menu .section {}
+.claude-usage-menu .section .title {}
+.claude-usage-menu .section .progress {}               /* progress-bar track */
+.claude-usage-menu .section .progress .fill {}         /* filled portion */
+.claude-usage-menu .section .progress.low .fill {}     /* < 50%  */
+.claude-usage-menu .section .progress.medium .fill {}  /* 50-79% */
+.claude-usage-menu .section .progress.high .fill {}    /* >= 80% */
+.claude-usage-menu .section .footer .reset {}
+.claude-usage-menu .section .footer .percent {}
+.claude-usage-menu .section .footer .percent.low {}
+.claude-usage-menu .section .footer .percent.medium {}
+.claude-usage-menu .section .footer .percent.high {}
+.claude-usage-menu .section .date {}     /* absolute reset timestamp */
+```
+
+## Example Style
+```css
+.claude-usage .icon {
+    color: #fab387;
+    font-size: 16px;
+    margin: 1px 4px 0 0;
+}
+.claude-usage .label {
+    color: #cdd6f4;
+    padding: 0 2px;
+}
+.claude-usage-menu {
+    background-color: #1e1e2e;
+    min-width: 260px;
+}
+.claude-usage-menu .header {
+    color: #cdd6f4;
+    font-size: 15px;
+    font-weight: bold;
+    padding: 14px 16px 10px 16px;
+}
+.claude-usage-menu .section {
+    padding: 4px 16px 12px 16px;
+}
+.claude-usage-menu .section .title {
+    color: #cdd6f4;
+    font-size: 13px;
+    font-weight: 600;
+    padding-bottom: 6px;
+}
+.claude-usage-menu .progress {
+    background-color: #313244;
+    border-radius: 5px;
+    min-height: 10px;
+    max-height: 10px;
+}
+.claude-usage-menu .progress .fill {
+    background-color: #a6e3a1;
+    border-radius: 5px;
+}
+.claude-usage-menu .progress.medium .fill { background-color: #f9e2af; }
+.claude-usage-menu .progress.high .fill { background-color: #f38ba8; }
+.claude-usage-menu .reset {
+    color: #a6adc8;
+    font-size: 12px;
+    padding-top: 6px;
+}
+.claude-usage-menu .percent {
+    color: #a6e3a1;
+    font-size: 13px;
+    font-weight: bold;
+    padding-top: 6px;
+}
+.claude-usage-menu .percent.medium { color: #f9e2af; }
+.claude-usage-menu .percent.high { color: #f38ba8; }
+.claude-usage-menu .date {
+    color: #6c7086;
+    font-size: 11px;
+    padding-top: 2px;
+}
+```

--- a/src/core/validation/widgets/yasb/claude_usage.py
+++ b/src/core/validation/widgets/yasb/claude_usage.py
@@ -1,0 +1,34 @@
+from pydantic import Field
+
+from core.validation.widgets.base_model import (
+    CallbacksConfig,
+    CustomBaseModel,
+    KeybindingConfig,
+)
+
+
+class ClaudeUsageCallbacksConfig(CallbacksConfig):
+    on_left: str = "toggle_menu"
+    on_right: str = "toggle_label"
+
+
+class ClaudeUsageMenuConfig(CustomBaseModel):
+    blur: bool = True
+    round_corners: bool = True
+    round_corners_type: str = "normal"
+    border_color: str = "System"
+    alignment: str = "right"
+    direction: str = "down"
+    offset_top: int = 6
+    offset_left: int = 0
+
+
+class ClaudeUsageConfig(CustomBaseModel):
+    label: str = "Claude {five_hour}%"
+    label_alt: str = "Claude {seven_day}%"
+    update_interval: int = Field(default=60, ge=30, le=3600)
+    cache_ttl: int = Field(default=120, ge=0, le=3600)
+    tooltip: bool = True
+    callbacks: ClaudeUsageCallbacksConfig = ClaudeUsageCallbacksConfig()
+    menu: ClaudeUsageMenuConfig = ClaudeUsageMenuConfig()
+    keybindings: list[KeybindingConfig] = []

--- a/src/core/widgets/services/claude_usage/claude_api.py
+++ b/src/core/widgets/services/claude_usage/claude_api.py
@@ -1,0 +1,184 @@
+import json
+import logging
+import os
+import time
+import urllib.request
+from typing import Any, ClassVar
+
+from PyQt6.QtCore import QObject, QThread, QTimer, pyqtSignal
+
+from core.utils.system import app_data_path
+
+logger = logging.getLogger("claude_usage")
+
+USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
+# Beta header the Claude Code CLI sends for the OAuth usage endpoint.
+OAUTH_BETA = "oauth-2025-04-20"
+
+EMPTY_RECORD: dict[str, Any] = {
+    "five": None,
+    "five_raw": None,
+    "five_reset_iso": None,
+    "seven": None,
+    "seven_raw": None,
+    "seven_reset_iso": None,
+    "fetched_at": 0,
+}
+
+
+def _claude_config_dir() -> str:
+    return os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
+
+
+def _cache_path() -> str:
+    return str(app_data_path("claude_usage_cache.json"))
+
+
+def _read_cache(path: str) -> dict[str, Any] | None:
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def _write_cache(path: str, data: dict[str, Any]) -> None:
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+    except Exception as e:
+        logger.debug("failed to write cache: %s", e)
+
+
+def fetch_usage(cache_path: str, cache_ttl: int) -> dict[str, Any]:
+    """Return a usage record, hitting the network only when the cache is stale.
+
+    On any error (including HTTP 429 rate limiting) the last cached record is
+    returned so the widget keeps showing the most recent known values. The OAuth
+    token is read from Claude Code's credentials store and is never logged.
+    """
+    cache = _read_cache(cache_path)
+    now = int(time.time())
+    if cache and (now - int(cache.get("fetched_at", 0))) < cache_ttl:
+        return cache
+
+    try:
+        cred_path = os.path.join(_claude_config_dir(), ".credentials.json")
+        with open(cred_path, encoding="utf-8") as f:
+            token = json.load(f)["claudeAiOauth"]["accessToken"]
+
+        request = urllib.request.Request(
+            USAGE_URL,
+            headers={"Authorization": f"Bearer {token}", "anthropic-beta": OAUTH_BETA},
+        )
+        with urllib.request.urlopen(request, timeout=10) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+
+        five_raw = float(payload["five_hour"]["utilization"])
+        seven_raw = float(payload["seven_day"]["utilization"])
+        record = {
+            "five": round(five_raw),
+            "five_raw": five_raw,
+            "five_reset_iso": payload["five_hour"].get("resets_at"),
+            "seven": round(seven_raw),
+            "seven_raw": seven_raw,
+            "seven_reset_iso": payload["seven_day"].get("resets_at"),
+            "fetched_at": now,
+        }
+        _write_cache(cache_path, record)
+        return record
+    except Exception as e:
+        logger.debug("usage fetch failed: %s", e)
+        if cache:
+            return cache
+        return dict(EMPTY_RECORD)
+
+
+class _UsageWorker(QThread):
+    """Runs the (blocking) credential read + HTTP request off the UI thread."""
+
+    data_ready = pyqtSignal(dict)
+
+    def __init__(self, cache_path: str, cache_ttl: int, parent: Any = None):
+        super().__init__(parent)
+        self._cache_path = cache_path
+        self._cache_ttl = cache_ttl
+
+    def run(self) -> None:
+        self.data_ready.emit(fetch_usage(self._cache_path, self._cache_ttl))
+
+
+class ClaudeUsageService(QObject):
+    """Shared Claude usage poller.
+
+    One service instance fetches the usage record on a timer and shares it with
+    every widget that requests the same ``(update_interval, cache_ttl)`` pair, so
+    multiple Claude widgets never duplicate the network request or the on-disk
+    cache. Instances are reference-counted and released when the last widget goes
+    away (mirrors the ``server_monitor`` service).
+    """
+
+    data_ready = pyqtSignal(dict)
+
+    _instances: ClassVar[dict[tuple, ClaudeUsageService]] = {}
+
+    @classmethod
+    def get_instance(cls, update_interval_s: int, cache_ttl: int) -> ClaudeUsageService:
+        key = (int(update_interval_s), int(cache_ttl))
+        inst = cls._instances.get(key)
+        if inst is None:
+            inst = cls(update_interval_s=int(update_interval_s), cache_ttl=int(cache_ttl), _key=key)
+            cls._instances[key] = inst
+        inst._refcount += 1
+        return inst
+
+    def __init__(self, update_interval_s: int, cache_ttl: int, _key: tuple):
+        super().__init__()
+        self._key = _key
+        self._refcount = 0
+        self._cache_path = _cache_path()
+        self._cache_ttl = cache_ttl
+        self._worker: _UsageWorker | None = None
+        self._data: dict[str, Any] = _read_cache(self._cache_path) or dict(EMPTY_RECORD)
+
+        self._timer = QTimer(self)
+        self._timer.setInterval(max(int(update_interval_s), 1) * 1000)
+        self._timer.timeout.connect(self._tick)
+        self._timer.start()
+        self._tick()
+
+    def latest(self) -> dict[str, Any]:
+        """The most recent usage record (cached value, available immediately)."""
+        return self._data
+
+    def release(self) -> None:
+        self._refcount -= 1
+        if self._refcount > 0:
+            return
+        self._timer.stop()
+        ClaudeUsageService._instances.pop(self._key, None)
+        if self._worker is not None and self._worker.isRunning():
+            # Tear down only once the in-flight fetch finishes, so we never block the
+            # GUI thread (or destroy a running QThread) during a config reload.
+            self._worker.finished.connect(self.deleteLater)
+        else:
+            self.deleteLater()
+
+    def _tick(self) -> None:
+        if self._worker is not None:
+            return  # a fetch is already in flight
+        worker = _UsageWorker(self._cache_path, self._cache_ttl, self)
+        worker.data_ready.connect(self._on_data)
+        worker.finished.connect(self._on_finished)
+        self._worker = worker
+        worker.start()
+
+    def _on_data(self, data: dict[str, Any]) -> None:
+        self._data = data
+        self.data_ready.emit(data)
+
+    def _on_finished(self) -> None:
+        worker = self._worker
+        self._worker = None
+        if worker is not None:
+            worker.deleteLater()

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -1,0 +1,256 @@
+import re
+from datetime import UTC, datetime
+from typing import Any
+
+from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QVBoxLayout
+
+from core.utils.tooltip import set_tooltip
+from core.utils.utilities import PopupWidget, refresh_widget_style
+from core.validation.widgets.yasb.claude_usage import ClaudeUsageConfig
+from core.widgets.base import BaseWidget
+from core.widgets.services.claude_usage.claude_api import ClaudeUsageService
+
+
+class UsageBar(QFrame):
+    """A rounded progress bar drawn as a track QFrame with a child `.fill` QFrame.
+
+    Keeps the fill at least as wide as it is tall so the rounded corners are preserved at
+    low values (the QProgressBar::chunk square-fill issue), and stays fully CSS-styleable.
+    """
+
+    def __init__(self, value: int, level: str, parent: QFrame | None = None):
+        super().__init__(parent)
+        self._value = max(0, min(100, value))
+        self.setProperty("class", f"progress {level}")
+        self._fill = QFrame(self)
+        self._fill.setProperty("class", "fill")
+
+    def _update_fill(self) -> None:
+        fill_width = int(self.width() * self._value / 100)
+        if fill_width > 0:
+            fill_width = max(fill_width, self.height())
+        self._fill.setGeometry(0, 0, fill_width, self.height())
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._update_fill()
+
+
+class ClaudeUsageWidget(BaseWidget):
+    validation_schema = ClaudeUsageConfig
+
+    def __init__(self, config: ClaudeUsageConfig):
+        super().__init__(class_name="claude-usage")
+        self.config = config
+        self._show_alt_label = False
+        self._menu: PopupWidget | None = None
+        self._service_released = False
+
+        self._service = ClaudeUsageService.get_instance(self.config.update_interval, self.config.cache_ttl)
+        self._data: dict[str, Any] = self._service.latest()
+
+        self._init_container()
+        self.build_widget_label(self.config.label, self.config.label_alt)
+
+        self.register_callback("toggle_label", self._toggle_label)
+        self.register_callback("toggle_menu", self._toggle_menu)
+
+        self.callback_left = self.config.callbacks.on_left
+        self.callback_middle = self.config.callbacks.on_middle
+        self.callback_right = self.config.callbacks.on_right
+
+        self._service.data_ready.connect(self._on_data)
+        self.destroyed.connect(lambda *_: self._release_service())
+        self._update_label()
+
+    def _release_service(self) -> None:
+        if getattr(self, "_service_released", False):
+            return
+        self._service_released = True
+        try:
+            self._service.release()
+        except RuntimeError:
+            pass
+
+    def closeEvent(self, event):
+        self._release_service()
+        super().closeEvent(event)
+
+    def _on_data(self, data: dict[str, Any]) -> None:
+        self._data = data
+        self._update_label()
+
+    def _format_values(self) -> dict[str, str]:
+        return {
+            "five_hour": self._pct(self._data.get("five")),
+            "seven_day": self._pct(self._data.get("seven")),
+            "five_hour_reset": self._fmt_reset(self._data.get("five_reset_iso")),
+            "seven_day_reset": self._fmt_reset(self._data.get("seven_reset_iso")),
+        }
+
+    @staticmethod
+    def _pct(value: Any) -> str:
+        return "--" if value is None else str(value)
+
+    @staticmethod
+    def _pct_decimal(raw: Any, rounded: Any) -> str:
+        """One-decimal percentage ('28.0') from the raw value, falling back to the rounded one."""
+        value = raw if isinstance(raw, (int, float)) else rounded
+        return f"{value:.1f}" if isinstance(value, (int, float)) else "--"
+
+    @staticmethod
+    def _fmt_reset(iso: str | None) -> str:
+        """Short time-until-reset: a countdown ('4h 14m') when under a day away,
+        otherwise a local weekday + time ('Sat 6:00 AM')."""
+        if not iso:
+            return "--"
+        try:
+            target = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+            seconds = int((target - datetime.now(UTC)).total_seconds())
+            if seconds <= 0:
+                return "0m"
+            if seconds < 24 * 3600:
+                hours, minutes = divmod(seconds // 60, 60)
+                return f"{hours}h {minutes}m" if hours else f"{minutes}m"
+            local = target.astimezone()
+            hour12 = local.hour % 12 or 12
+            ampm = "AM" if local.hour < 12 else "PM"
+            return f"{local:%a} {hour12}:{local.minute:02d} {ampm}"
+        except Exception:
+            return "--"
+
+    @staticmethod
+    def _fmt_reset_at(iso: str | None) -> str:
+        """Absolute local reset timestamp, e.g. '6/7/2026, 5:50:00 AM'."""
+        if not iso:
+            return "--"
+        try:
+            local = datetime.fromisoformat(iso.replace("Z", "+00:00")).astimezone()
+            hour12 = local.hour % 12 or 12
+            ampm = "AM" if local.hour < 12 else "PM"
+            return f"{local.month}/{local.day}/{local.year}, {hour12}:{local.minute:02d}:{local.second:02d} {ampm}"
+        except Exception:
+            return "--"
+
+    @staticmethod
+    def _level_class(value: Any) -> str:
+        if not isinstance(value, (int, float)):
+            return "unknown"
+        if value >= 80:
+            return "high"
+        if value >= 50:
+            return "medium"
+        return "low"
+
+    def _toggle_label(self) -> None:
+        self._show_alt_label = not self._show_alt_label
+        for widget in self._widgets:
+            widget.setVisible(not self._show_alt_label)
+        for widget in self._widgets_alt:
+            widget.setVisible(self._show_alt_label)
+        self._update_label()
+
+    def _update_label(self) -> None:
+        active_widgets = self._widgets_alt if self._show_alt_label else self._widgets
+        active_template = self.config.label_alt if self._show_alt_label else self.config.label
+        values = self._format_values()
+        # Skip whitespace-only parts so the widget/template indices stay aligned with
+        # build_widget_label (which drops them); otherwise multi-<span> labels misalign.
+        label_parts = [part for part in re.split(r"(<span.*?>.*?</span>)", active_template) if part.strip()]
+
+        for index, part in enumerate(label_parts):
+            if index >= len(active_widgets):
+                continue
+            current_widget = active_widgets[index]
+            if "<span" in part and "</span>" in part:
+                current_widget.setText(re.sub(r"<span.*?>|</span>", "", part).strip())
+            else:
+                try:
+                    current_widget.setText(part.strip().format(**values))
+                except Exception:
+                    current_widget.setText(part.strip())
+            if self.config.tooltip:
+                set_tooltip(
+                    current_widget,
+                    f"Claude usage — 5h: {values['five_hour']}% · 7d: {values['seven_day']}%",
+                )
+        refresh_widget_style(*active_widgets)
+
+    def _toggle_menu(self) -> None:
+        self._build_menu()
+
+    def _build_section(self, title: str, value: Any, raw: Any, reset_iso: str | None) -> QFrame:
+        level = self._level_class(value)
+        frame = QFrame()
+        frame.setProperty("class", "section")
+        layout = QVBoxLayout(frame)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        title_label = QLabel(f"{title} Window")
+        title_label.setProperty("class", "title")
+        layout.addWidget(title_label)
+
+        progress = UsageBar(int(value) if isinstance(value, (int, float)) else 0, level)
+        layout.addWidget(progress)
+
+        footer = QFrame()
+        footer.setProperty("class", "footer")
+        footer_layout = QHBoxLayout(footer)
+        footer_layout.setContentsMargins(0, 0, 0, 0)
+        footer_layout.setSpacing(0)
+
+        reset_label = QLabel(f"Resets in {self._fmt_reset(reset_iso)}")
+        reset_label.setProperty("class", "reset")
+        footer_layout.addWidget(reset_label)
+        footer_layout.addStretch()
+
+        percent_label = QLabel(f"{self._pct_decimal(raw, value)}%")
+        percent_label.setProperty("class", f"percent {level}")
+        footer_layout.addWidget(percent_label)
+
+        layout.addWidget(footer)
+
+        date_label = QLabel(self._fmt_reset_at(reset_iso))
+        date_label.setProperty("class", "date")
+        layout.addWidget(date_label)
+
+        return frame
+
+    def _build_menu(self) -> None:
+        self._menu = PopupWidget(
+            self,
+            self.config.menu.blur,
+            self.config.menu.round_corners,
+            self.config.menu.round_corners_type,
+            self.config.menu.border_color,
+        )
+        self._menu.setProperty("class", "claude-usage-menu")
+
+        layout = QVBoxLayout(self._menu)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        header = QLabel("Claude Usage")
+        header.setProperty("class", "header")
+        layout.addWidget(header)
+
+        layout.addWidget(
+            self._build_section(
+                "5-Hour", self._data.get("five"), self._data.get("five_raw"), self._data.get("five_reset_iso")
+            )
+        )
+        layout.addWidget(
+            self._build_section(
+                "7-Day", self._data.get("seven"), self._data.get("seven_raw"), self._data.get("seven_reset_iso")
+            )
+        )
+
+        self._menu.adjustSize()
+        self._menu.setPosition(
+            alignment=self.config.menu.alignment,
+            direction=self.config.menu.direction,
+            offset_left=self.config.menu.offset_left,
+            offset_top=self.config.menu.offset_top,
+        )
+        self._menu.show()


### PR DESCRIPTION
Adds a widget showing Claude Code subscription usage (5-hour and 7-day limits) on the bar, with a popup card of progress bars and reset countdowns. Reads the existing Claude Code OAuth token from ~/.claude/.credentials.json and caches results in app_data_path with a TTL (429-safe). Includes a docs page and regenerated schema.json.
