### PR TITLE
feat(claude_usage): refresh button, expired-token indicator & configurable reset display

### DIFF
--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -14,6 +14,7 @@ extra configuration is required as long as you are signed in to Claude Code.
 | `label_alt`       | string  | `'Claude {seven_day}%'` | The alternative format string, toggled by the `toggle_label` callback. |
 | `update_interval` | integer | `60` | How often the label and reset countdown are refreshed, in seconds. Must be between 30 and 3600. |
 | `cache_ttl`       | integer | `120` | How long (seconds) a fetched result is cached on disk before the endpoint is queried again. The endpoint is rate-limited, so keep this at a sane value. |
+| `reset_format`    | string  | `'absolute'` | How the popup menu's reset line is phrased: `'absolute'` → `Resets on Sat 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h` (countdown). |
 | `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
 | `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. The popup menu also has a refresh button in its header. |
 | `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
@@ -44,6 +45,7 @@ claude_usage:
     label_alt: "Claude 7d {seven_day}% · {seven_day_reset}<span class='stale'>{stale}</span>"
     update_interval: 60
     cache_ttl: 120
+    reset_format: "absolute"  # or "relative" for a "Resets in 6d 21h" countdown
     callbacks:
       on_left: "toggle_menu"    # open the usage menu
       on_middle: "refresh"      # force an immediate re-fetch, bypassing the cache
@@ -65,6 +67,7 @@ claude_usage:
 - **label_alt:** The alternative format string, toggled with the `toggle_label` callback.
 - **update_interval:** How often the bar label and reset countdown are refreshed, in seconds (30–3600).
 - **cache_ttl:** How long a fetched result is cached on disk before the usage endpoint is queried again. Because the endpoint is rate-limited (HTTP 429), the widget serves the last cached value on any error instead of going blank.
+- **reset_format:** How the popup menu's "Resets …" line is phrased. `absolute` shows a local weekday and time (`Resets on Sat 6:00 AM`); `relative` shows a countdown (`Resets in 6d 21h`). The exact reset timestamp is always shown on the line below regardless of this setting.
 - **tooltip:** Whether to show a summary tooltip on hover.
 - **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `refresh` (force an immediate re-fetch of the usage data, bypassing `cache_ttl`), `do_nothing`, and `exec`. The popup menu header also has a refresh button that triggers the same action.
 - **menu:** A dictionary specifying the popup menu settings:

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -14,8 +14,8 @@ extra configuration is required as long as you are signed in to Claude Code.
 | `label_alt`       | string  | `'Claude {seven_day}%'` | The alternative format string, toggled by the `toggle_label` callback. |
 | `update_interval` | integer | `60` | How often the label and reset countdown are refreshed, in seconds. Must be between 30 and 3600. |
 | `cache_ttl`       | integer | `120` | How long (seconds) a fetched result is cached on disk before the endpoint is queried again. The endpoint is rate-limited, so keep this at a sane value. |
-| `reset_format`    | string  | `'absolute'` | How the popup menu's reset line is phrased: `'absolute'` → `Resets on Sat 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h` (countdown). |
-| `reset_show_date` | boolean | `true` | In `'absolute'` mode, include the month/day (`Resets on Sat, Jun 13 6:00 AM`) so windows that reset on the same weekday are distinguishable. No effect in `'relative'` mode. |
+| `reset_format`    | string  | `'absolute'` | How the popup menu's reset line is phrased: `'absolute'` → `Resets on Sat @ 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h` (countdown). |
+| `reset_show_date` | boolean | `true` | In `'absolute'` mode, include the month/day (`Resets on Sat, Jun 13 @ 6:00 AM`) so windows that reset on the same weekday are distinguishable. No effect in `'relative'` mode. |
 | `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
 | `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. The popup menu also has a refresh button in its header. |
 | `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
@@ -69,8 +69,8 @@ claude_usage:
 - **label_alt:** The alternative format string, toggled with the `toggle_label` callback.
 - **update_interval:** How often the bar label and reset countdown are refreshed, in seconds (30–3600).
 - **cache_ttl:** How long a fetched result is cached on disk before the usage endpoint is queried again. Because the endpoint is rate-limited (HTTP 429), the widget serves the last cached value on any error instead of going blank.
-- **reset_format:** How the popup menu's "Resets …" line is phrased. `absolute` shows a local weekday and time (`Resets on Sat 6:00 AM`); `relative` shows a countdown (`Resets in 6d 21h`). The exact reset timestamp is always shown on the line below regardless of this setting.
-- **reset_show_date:** In `absolute` mode, include the month and day in the reset line (`Resets on Sat, Jun 13 6:00 AM`). This disambiguates the 5-hour and 7-day windows when they happen to reset on the same weekday. Ignored in `relative` mode.
+- **reset_format:** How the popup menu's "Resets …" line is phrased. `absolute` shows a local weekday and time (`Resets on Sat @ 6:00 AM`); `relative` shows a countdown (`Resets in 6d 21h`). The exact reset timestamp is always shown on the line below regardless of this setting.
+- **reset_show_date:** In `absolute` mode, include the month and day in the reset line (`Resets on Sat, Jun 13 @ 6:00 AM`). This disambiguates the 5-hour and 7-day windows when they happen to reset on the same weekday. Ignored in `relative` mode.
 - **tooltip:** Whether to show a summary tooltip on hover.
 - **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `refresh` (force an immediate re-fetch of the usage data, bypassing `cache_ttl`), `do_nothing`, and `exec`. The popup menu header also has a refresh button that triggers the same action.
 - **menu:** A dictionary specifying the popup menu settings:

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -29,13 +29,19 @@ used in `label` / `label_alt`:
 - `{five_hour_reset}` — time until the 5-hour window resets. Shown as a countdown when under a
   day away (e.g. `4h 27m`), otherwise as a local weekday + time (e.g. `Sat 6:00 AM`).
 - `{seven_day_reset}` — time until the 7-day window resets (e.g. `Sat 6:00 AM`).
+- `{stale}` — an expired-token warning glyph (``), shown only when Claude Code's OAuth token
+  has expired and the widget is therefore serving stale cached values; empty otherwise. The
+  usage data is read from Claude Code's token, which only Claude Code can refresh, so this is a
+  cue to run a `claude` command to renew it. Wrap it in a `<span>` so it renders in your Nerd
+  Font and can be styled via `.claude-usage .stale`, e.g.
+  `{five_hour}%<span class='stale'>{stale}</span>`.
 
 ```yaml
 claude_usage:
   type: "yasb.claude_usage.ClaudeUsageWidget"
   options:
-    label: "Claude {five_hour}% · {five_hour_reset}"
-    label_alt: "Claude 7d {seven_day}% · {seven_day_reset}"
+    label: "Claude {five_hour}% · {five_hour_reset}<span class='stale'>{stale}</span>"
+    label_alt: "Claude 7d {seven_day}% · {seven_day_reset}<span class='stale'>{stale}</span>"
     update_interval: 60
     cache_ttl: 120
     callbacks:
@@ -83,6 +89,7 @@ signed in to Claude Code, the widget shows `--` until you sign in.
 .claude-usage .widget-container {}
 .claude-usage .icon {}
 .claude-usage .label {}
+.claude-usage .stale {}   /* expired-token warning glyph ({stale} placeholder) */
 /* Popup menu */
 .claude-usage-menu {}
 .claude-usage-menu .header {}            /* header row (title + refresh button) */
@@ -114,6 +121,11 @@ signed in to Claude Code, the widget shows `--` until you sign in.
 .claude-usage .label {
     color: #cdd6f4;
     padding: 0 2px;
+}
+.claude-usage .stale {
+    color: #f38ba8;
+    font-size: 13px;
+    margin-left: 4px;
 }
 .claude-usage-menu {
     background-color: #1e1e2e;

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -17,6 +17,7 @@ extra configuration is required as long as you are signed in to Claude Code.
 | `five_hour_reset_format` | string | `'relative'` | How the 5-hour window's reset line is phrased: `'relative'` → `Resets in 4h 11m` (countdown), or `'absolute'` → `Resets on Sat @ 6:00 AM`. |
 | `seven_day_reset_format` | string | `'absolute'` | How the 7-day window's reset line is phrased: `'absolute'` → `Resets on Sat @ 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h`. |
 | `reset_show_date` | boolean | `true` | For windows using `'absolute'`, include the month/day (`Resets on Sat, Jun 13 @ 6:00 AM`) so windows that reset on the same weekday are distinguishable. No effect on `'relative'` windows. |
+| `colorize_percent`| boolean | `false` | Colour the `{five_hour}`/`{seven_day}` percentage on the bar by usage level (same green/yellow/orange/red usage bands as the popup bars). See [Color-coded percentage](#color-coded-percentage). |
 | `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
 | `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. The popup menu also has a refresh button in its header. |
 | `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
@@ -73,6 +74,7 @@ claude_usage:
 - **cache_ttl:** How long a fetched result is cached on disk before the usage endpoint is queried again. Because the endpoint is rate-limited (HTTP 429), the widget serves the last cached value on any error instead of going blank.
 - **five_hour_reset_format / seven_day_reset_format:** How each window's "Resets …" line is phrased. `relative` shows a countdown (`Resets in 4h 11m`); `absolute` shows a local weekday and time (`Resets on Sat @ 6:00 AM`). The defaults suit each window — the near-term 5-hour window as a countdown, the multi-day 7-day window as a date. The exact reset timestamp is always shown on the line below regardless of this setting.
 - **reset_show_date:** For windows using `absolute`, include the month and day in the reset line (`Resets on Sat, Jun 13 @ 6:00 AM`). This disambiguates the two windows when they happen to reset on the same weekday. Ignored for `relative` windows.
+- **colorize_percent:** Colour the percentage shown on the bar by usage level. See [Color-coded percentage](#color-coded-percentage).
 - **tooltip:** Whether to show a summary tooltip on hover.
 - **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `refresh` (force an immediate re-fetch of the usage data, bypassing `cache_ttl`), `do_nothing`, and `exec`. The popup menu header also has a refresh button that triggers the same action.
 - **menu:** A dictionary specifying the popup menu settings:
@@ -83,6 +85,32 @@ claude_usage:
   - **alignment:** Horizontal alignment of the menu (`left`, `right`, `center`).
   - **direction:** Whether the menu opens `down` or `up`.
   - **offset_top / offset_left:** Pixel offsets for fine positioning.
+
+## Color-coded percentage
+
+With `colorize_percent: true`, the percentage on the bar is coloured by usage level using the
+**same usage bands as the popup progress bars** (`< 50` → low/green, `50–64` → medium/yellow,
+`65–79` → high/orange, `≥ 80` → critical/red) for whichever window is shown — `{five_hour}` on the main label or
+`{seven_day}` on the alt label.
+
+Because a label segment is coloured as a whole, wrap **only** the percent in its own span so
+the surrounding text (icon, reset countdown) keeps its normal colour:
+
+```yaml
+    label: "<span>\U000f06a9</span> <span class='percent'>{five_hour}%</span> · {five_hour_reset}"
+    label_alt: "<span>\U000f06a9</span> <span class='percent'>{seven_day}%</span> · {seven_day_reset}"
+    colorize_percent: true
+```
+
+The span gets a `low` / `medium` / `high` / `critical` (or `unknown`) class added automatically;
+style them to match the bars:
+
+```css
+.claude-usage .percent.low { color: #a6e3a1; }       /* green  */
+.claude-usage .percent.medium { color: #f9e2af; }    /* yellow */
+.claude-usage .percent.high { color: #fab387; }      /* orange */
+.claude-usage .percent.critical { color: #f38ba8; }  /* red    */
+```
 
 ## Authentication
 
@@ -98,6 +126,10 @@ signed in to Claude Code, the widget shows `--` until you sign in.
 .claude-usage .icon {}
 .claude-usage .label {}
 .claude-usage .stale {}   /* expired-token warning glyph ({stale} placeholder) */
+.claude-usage .percent.low {}       /* colorize_percent: < 50%  (green)  */
+.claude-usage .percent.medium {}    /* colorize_percent: 50-64% (yellow) */
+.claude-usage .percent.high {}      /* colorize_percent: 65-79% (orange) */
+.claude-usage .percent.critical {}  /* colorize_percent: >= 80% (red)    */
 /* Popup menu */
 .claude-usage-menu {}
 .claude-usage-menu .header {}            /* header row (title + refresh button) */
@@ -108,14 +140,16 @@ signed in to Claude Code, the widget shows `--` until you sign in.
 .claude-usage-menu .section .title {}
 .claude-usage-menu .section .progress {}               /* progress-bar track */
 .claude-usage-menu .section .progress .fill {}         /* filled portion */
-.claude-usage-menu .section .progress.low .fill {}     /* < 50%  */
-.claude-usage-menu .section .progress.medium .fill {}  /* 50-79% */
-.claude-usage-menu .section .progress.high .fill {}    /* >= 80% */
+.claude-usage-menu .section .progress.low .fill {}       /* < 50%  (green)  */
+.claude-usage-menu .section .progress.medium .fill {}    /* 50-64% (yellow) */
+.claude-usage-menu .section .progress.high .fill {}      /* 65-79% (orange) */
+.claude-usage-menu .section .progress.critical .fill {}  /* >= 80% (red)    */
 .claude-usage-menu .section .footer .reset {}
 .claude-usage-menu .section .footer .percent {}
 .claude-usage-menu .section .footer .percent.low {}
 .claude-usage-menu .section .footer .percent.medium {}
 .claude-usage-menu .section .footer .percent.high {}
+.claude-usage-menu .section .footer .percent.critical {}
 .claude-usage-menu .section .date {}     /* absolute reset timestamp */
 ```
 
@@ -177,7 +211,8 @@ signed in to Claude Code, the widget shows `--` until you sign in.
     border-radius: 5px;
 }
 .claude-usage-menu .progress.medium .fill { background-color: #f9e2af; }
-.claude-usage-menu .progress.high .fill { background-color: #f38ba8; }
+.claude-usage-menu .progress.high .fill { background-color: #fab387; }
+.claude-usage-menu .progress.critical .fill { background-color: #f38ba8; }
 .claude-usage-menu .reset {
     color: #a6adc8;
     font-size: 12px;
@@ -190,7 +225,8 @@ signed in to Claude Code, the widget shows `--` until you sign in.
     padding-top: 6px;
 }
 .claude-usage-menu .percent.medium { color: #f9e2af; }
-.claude-usage-menu .percent.high { color: #f38ba8; }
+.claude-usage-menu .percent.high { color: #fab387; }
+.claude-usage-menu .percent.critical { color: #f38ba8; }
 .claude-usage-menu .date {
     color: #6c7086;
     font-size: 11px;

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -14,8 +14,9 @@ extra configuration is required as long as you are signed in to Claude Code.
 | `label_alt`       | string  | `'Claude {seven_day}%'` | The alternative format string, toggled by the `toggle_label` callback. |
 | `update_interval` | integer | `60` | How often the label and reset countdown are refreshed, in seconds. Must be between 30 and 3600. |
 | `cache_ttl`       | integer | `120` | How long (seconds) a fetched result is cached on disk before the endpoint is queried again. The endpoint is rate-limited, so keep this at a sane value. |
-| `reset_format`    | string  | `'absolute'` | How the popup menu's reset line is phrased: `'absolute'` → `Resets on Sat @ 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h` (countdown). |
-| `reset_show_date` | boolean | `true` | In `'absolute'` mode, include the month/day (`Resets on Sat, Jun 13 @ 6:00 AM`) so windows that reset on the same weekday are distinguishable. No effect in `'relative'` mode. |
+| `five_hour_reset_format` | string | `'relative'` | How the 5-hour window's reset line is phrased: `'relative'` → `Resets in 4h 11m` (countdown), or `'absolute'` → `Resets on Sat @ 6:00 AM`. |
+| `seven_day_reset_format` | string | `'absolute'` | How the 7-day window's reset line is phrased: `'absolute'` → `Resets on Sat @ 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h`. |
+| `reset_show_date` | boolean | `true` | For windows using `'absolute'`, include the month/day (`Resets on Sat, Jun 13 @ 6:00 AM`) so windows that reset on the same weekday are distinguishable. No effect on `'relative'` windows. |
 | `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
 | `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. The popup menu also has a refresh button in its header. |
 | `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
@@ -46,8 +47,9 @@ claude_usage:
     label_alt: "Claude 7d {seven_day}% · {seven_day_reset}<span class='stale'>{stale}</span>"
     update_interval: 60
     cache_ttl: 120
-    reset_format: "absolute"  # or "relative" for a "Resets in 6d 21h" countdown
-    reset_show_date: true     # include month/day in the absolute reset line
+    five_hour_reset_format: "relative"  # 5-hour: "Resets in 4h 11m"
+    seven_day_reset_format: "absolute"  # 7-day:  "Resets on Sat, Jun 20 @ 2:59 AM"
+    reset_show_date: true               # include month/day in absolute reset lines
     callbacks:
       on_left: "toggle_menu"    # open the usage menu
       on_middle: "refresh"      # force an immediate re-fetch, bypassing the cache
@@ -69,8 +71,8 @@ claude_usage:
 - **label_alt:** The alternative format string, toggled with the `toggle_label` callback.
 - **update_interval:** How often the bar label and reset countdown are refreshed, in seconds (30–3600).
 - **cache_ttl:** How long a fetched result is cached on disk before the usage endpoint is queried again. Because the endpoint is rate-limited (HTTP 429), the widget serves the last cached value on any error instead of going blank.
-- **reset_format:** How the popup menu's "Resets …" line is phrased. `absolute` shows a local weekday and time (`Resets on Sat @ 6:00 AM`); `relative` shows a countdown (`Resets in 6d 21h`). The exact reset timestamp is always shown on the line below regardless of this setting.
-- **reset_show_date:** In `absolute` mode, include the month and day in the reset line (`Resets on Sat, Jun 13 @ 6:00 AM`). This disambiguates the 5-hour and 7-day windows when they happen to reset on the same weekday. Ignored in `relative` mode.
+- **five_hour_reset_format / seven_day_reset_format:** How each window's "Resets …" line is phrased. `relative` shows a countdown (`Resets in 4h 11m`); `absolute` shows a local weekday and time (`Resets on Sat @ 6:00 AM`). The defaults suit each window — the near-term 5-hour window as a countdown, the multi-day 7-day window as a date. The exact reset timestamp is always shown on the line below regardless of this setting.
+- **reset_show_date:** For windows using `absolute`, include the month and day in the reset line (`Resets on Sat, Jun 13 @ 6:00 AM`). This disambiguates the two windows when they happen to reset on the same weekday. Ignored for `relative` windows.
 - **tooltip:** Whether to show a summary tooltip on hover.
 - **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `refresh` (force an immediate re-fetch of the usage data, bypassing `cache_ttl`), `do_nothing`, and `exec`. The popup menu header also has a refresh button that triggers the same action.
 - **menu:** A dictionary specifying the popup menu settings:

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -15,7 +15,7 @@ extra configuration is required as long as you are signed in to Claude Code.
 | `update_interval` | integer | `60` | How often the label and reset countdown are refreshed, in seconds. Must be between 30 and 3600. |
 | `cache_ttl`       | integer | `120` | How long (seconds) a fetched result is cached on disk before the endpoint is queried again. The endpoint is rate-limited, so keep this at a sane value. |
 | `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
-| `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. |
+| `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. The popup menu also has a refresh button in its header. |
 | `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
 
 ## Placeholders
@@ -40,7 +40,7 @@ claude_usage:
     cache_ttl: 120
     callbacks:
       on_left: "toggle_menu"    # open the usage menu
-      on_middle: "do_nothing"
+      on_middle: "refresh"      # force an immediate re-fetch, bypassing the cache
       on_right: "toggle_label"  # switch the bar text between 5h and 7d
     menu:
       blur: true
@@ -60,7 +60,7 @@ claude_usage:
 - **update_interval:** How often the bar label and reset countdown are refreshed, in seconds (30–3600).
 - **cache_ttl:** How long a fetched result is cached on disk before the usage endpoint is queried again. Because the endpoint is rate-limited (HTTP 429), the widget serves the last cached value on any error instead of going blank.
 - **tooltip:** Whether to show a summary tooltip on hover.
-- **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `do_nothing`, and `exec`.
+- **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `refresh` (force an immediate re-fetch of the usage data, bypassing `cache_ttl`), `do_nothing`, and `exec`. The popup menu header also has a refresh button that triggers the same action.
 - **menu:** A dictionary specifying the popup menu settings:
   - **blur:** Enable blur effect for the menu.
   - **round_corners:** Enable round corners (not supported on Windows 10).
@@ -85,7 +85,10 @@ signed in to Claude Code, the widget shows `--` until you sign in.
 .claude-usage .label {}
 /* Popup menu */
 .claude-usage-menu {}
-.claude-usage-menu .header {}        /* "Claude Usage" title */
+.claude-usage-menu .header {}            /* header row (title + refresh button) */
+.claude-usage-menu .header .text {}      /* "Claude Usage" title */
+.claude-usage-menu .header .refresh {}   /* refresh button */
+.claude-usage-menu .header .refresh:hover {}
 .claude-usage-menu .section {}
 .claude-usage-menu .section .title {}
 .claude-usage-menu .section .progress {}               /* progress-bar track */
@@ -117,10 +120,22 @@ signed in to Claude Code, the widget shows `--` until you sign in.
     min-width: 260px;
 }
 .claude-usage-menu .header {
+    padding: 14px 16px 10px 16px;
+}
+.claude-usage-menu .header .text {
     color: #cdd6f4;
     font-size: 15px;
     font-weight: bold;
-    padding: 14px 16px 10px 16px;
+}
+.claude-usage-menu .header .refresh {
+    background: transparent;
+    border: none;
+    color: #6c7086;
+    font-size: 15px;
+    padding: 0 2px;
+}
+.claude-usage-menu .header .refresh:hover {
+    color: #fab387;
 }
 .claude-usage-menu .section {
     padding: 4px 16px 12px 16px;

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -15,6 +15,7 @@ extra configuration is required as long as you are signed in to Claude Code.
 | `update_interval` | integer | `60` | How often the label and reset countdown are refreshed, in seconds. Must be between 30 and 3600. |
 | `cache_ttl`       | integer | `120` | How long (seconds) a fetched result is cached on disk before the endpoint is queried again. The endpoint is rate-limited, so keep this at a sane value. |
 | `reset_format`    | string  | `'absolute'` | How the popup menu's reset line is phrased: `'absolute'` → `Resets on Sat 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h` (countdown). |
+| `reset_show_date` | boolean | `true` | In `'absolute'` mode, include the month/day (`Resets on Sat, Jun 13 6:00 AM`) so windows that reset on the same weekday are distinguishable. No effect in `'relative'` mode. |
 | `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
 | `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. The popup menu also has a refresh button in its header. |
 | `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
@@ -46,6 +47,7 @@ claude_usage:
     update_interval: 60
     cache_ttl: 120
     reset_format: "absolute"  # or "relative" for a "Resets in 6d 21h" countdown
+    reset_show_date: true     # include month/day in the absolute reset line
     callbacks:
       on_left: "toggle_menu"    # open the usage menu
       on_middle: "refresh"      # force an immediate re-fetch, bypassing the cache
@@ -68,6 +70,7 @@ claude_usage:
 - **update_interval:** How often the bar label and reset countdown are refreshed, in seconds (30–3600).
 - **cache_ttl:** How long a fetched result is cached on disk before the usage endpoint is queried again. Because the endpoint is rate-limited (HTTP 429), the widget serves the last cached value on any error instead of going blank.
 - **reset_format:** How the popup menu's "Resets …" line is phrased. `absolute` shows a local weekday and time (`Resets on Sat 6:00 AM`); `relative` shows a countdown (`Resets in 6d 21h`). The exact reset timestamp is always shown on the line below regardless of this setting.
+- **reset_show_date:** In `absolute` mode, include the month and day in the reset line (`Resets on Sat, Jun 13 6:00 AM`). This disambiguates the 5-hour and 7-day windows when they happen to reset on the same weekday. Ignored in `relative` mode.
 - **tooltip:** Whether to show a summary tooltip on hover.
 - **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `refresh` (force an immediate re-fetch of the usage data, bypassing `cache_ttl`), `do_nothing`, and `exec`. The popup menu header also has a refresh button that triggers the same action.
 - **menu:** A dictionary specifying the popup menu settings:

--- a/src/core/validation/widgets/yasb/claude_usage.py
+++ b/src/core/validation/widgets/yasb/claude_usage.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import Field
 
 from core.validation.widgets.base_model import (
@@ -28,6 +30,10 @@ class ClaudeUsageConfig(CustomBaseModel):
     label_alt: str = "Claude {seven_day}%"
     update_interval: int = Field(default=60, ge=30, le=3600)
     cache_ttl: int = Field(default=120, ge=0, le=3600)
+    # How the popup menu's reset line is phrased:
+    #   "absolute" -> "Resets on Sat 6:00 AM" (local weekday + time)
+    #   "relative" -> "Resets in 6d 21h" (countdown)
+    reset_format: Literal["absolute", "relative"] = "absolute"
     tooltip: bool = True
     callbacks: ClaudeUsageCallbacksConfig = ClaudeUsageCallbacksConfig()
     menu: ClaudeUsageMenuConfig = ClaudeUsageMenuConfig()

--- a/src/core/validation/widgets/yasb/claude_usage.py
+++ b/src/core/validation/widgets/yasb/claude_usage.py
@@ -34,6 +34,9 @@ class ClaudeUsageConfig(CustomBaseModel):
     #   "absolute" -> "Resets on Sat 6:00 AM" (local weekday + time)
     #   "relative" -> "Resets in 6d 21h" (countdown)
     reset_format: Literal["absolute", "relative"] = "absolute"
+    # Include the month/day in the "absolute" reset line ("Resets on Sat, Jun 13 6:00 AM"),
+    # disambiguating windows that reset on the same weekday. No effect on "relative".
+    reset_show_date: bool = True
     tooltip: bool = True
     callbacks: ClaudeUsageCallbacksConfig = ClaudeUsageCallbacksConfig()
     menu: ClaudeUsageMenuConfig = ClaudeUsageMenuConfig()

--- a/src/core/validation/widgets/yasb/claude_usage.py
+++ b/src/core/validation/widgets/yasb/claude_usage.py
@@ -39,6 +39,10 @@ class ClaudeUsageConfig(CustomBaseModel):
     # Include the month/day in the "absolute" reset line ("Resets on Sat, Jun 13 @ 6:00 AM"),
     # disambiguating windows that reset on the same weekday. No effect on "relative".
     reset_show_date: bool = True
+    # Colour the {five_hour}/{seven_day} percentage on the bar by usage level, using the same
+    # low/medium/high thresholds as the popup progress bars. Wrap the percent in its own span
+    # (e.g. "<span class='percent'>{five_hour}%</span>") so only the number is coloured.
+    colorize_percent: bool = False
     tooltip: bool = True
     callbacks: ClaudeUsageCallbacksConfig = ClaudeUsageCallbacksConfig()
     menu: ClaudeUsageMenuConfig = ClaudeUsageMenuConfig()

--- a/src/core/validation/widgets/yasb/claude_usage.py
+++ b/src/core/validation/widgets/yasb/claude_usage.py
@@ -31,10 +31,10 @@ class ClaudeUsageConfig(CustomBaseModel):
     update_interval: int = Field(default=60, ge=30, le=3600)
     cache_ttl: int = Field(default=120, ge=0, le=3600)
     # How the popup menu's reset line is phrased:
-    #   "absolute" -> "Resets on Sat 6:00 AM" (local weekday + time)
+    #   "absolute" -> "Resets on Sat @ 6:00 AM" (local weekday + time)
     #   "relative" -> "Resets in 6d 21h" (countdown)
     reset_format: Literal["absolute", "relative"] = "absolute"
-    # Include the month/day in the "absolute" reset line ("Resets on Sat, Jun 13 6:00 AM"),
+    # Include the month/day in the "absolute" reset line ("Resets on Sat, Jun 13 @ 6:00 AM"),
     # disambiguating windows that reset on the same weekday. No effect on "relative".
     reset_show_date: bool = True
     tooltip: bool = True

--- a/src/core/validation/widgets/yasb/claude_usage.py
+++ b/src/core/validation/widgets/yasb/claude_usage.py
@@ -30,10 +30,12 @@ class ClaudeUsageConfig(CustomBaseModel):
     label_alt: str = "Claude {seven_day}%"
     update_interval: int = Field(default=60, ge=30, le=3600)
     cache_ttl: int = Field(default=120, ge=0, le=3600)
-    # How the popup menu's reset line is phrased:
+    # How each window's popup reset line is phrased, per window:
+    #   "relative" -> "Resets in 4h 11m" / "Resets in 6d 21h" (countdown)
     #   "absolute" -> "Resets on Sat @ 6:00 AM" (local weekday + time)
-    #   "relative" -> "Resets in 6d 21h" (countdown)
-    reset_format: Literal["absolute", "relative"] = "absolute"
+    # The near-term 5-hour window defaults to a countdown; the multi-day 7-day window to a date.
+    five_hour_reset_format: Literal["relative", "absolute"] = "relative"
+    seven_day_reset_format: Literal["relative", "absolute"] = "absolute"
     # Include the month/day in the "absolute" reset line ("Resets on Sat, Jun 13 @ 6:00 AM"),
     # disambiguating windows that reset on the same weekday. No effect on "relative".
     reset_show_date: bool = True

--- a/src/core/widgets/services/claude_usage/claude_api.py
+++ b/src/core/widgets/services/claude_usage/claude_api.py
@@ -23,11 +23,30 @@ EMPTY_RECORD: dict[str, Any] = {
     "seven_raw": None,
     "seven_reset_iso": None,
     "fetched_at": 0,
+    "token_expired": False,
 }
 
 
 def _claude_config_dir() -> str:
     return os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
+
+
+def _token_expired() -> bool:
+    """True when Claude Code's OAuth access token has expired (so a refresh is needed).
+
+    Reads only the ``expiresAt`` timestamp (ms epoch); the token itself is never
+    touched here. Returns False when the value is missing/unreadable so a parsing
+    quirk never produces a false 'expired' warning.
+    """
+    try:
+        cred_path = os.path.join(_claude_config_dir(), ".credentials.json")
+        with open(cred_path, encoding="utf-8") as f:
+            expires_at = json.load(f)["claudeAiOauth"].get("expiresAt")
+        if not expires_at:
+            return False
+        return (expires_at / 1000) < time.time()
+    except Exception:
+        return False
 
 
 def _cache_path() -> str:
@@ -57,9 +76,14 @@ def fetch_usage(cache_path: str, cache_ttl: int) -> dict[str, Any]:
     returned so the widget keeps showing the most recent known values. The OAuth
     token is read from Claude Code's credentials store and is never logged.
     """
+    # Recomputed live on every call (independent of the usage cache) so the
+    # expired-token warning is accurate even when serving a stale record.
+    token_expired = _token_expired()
+
     cache = _read_cache(cache_path)
     now = int(time.time())
     if cache and (now - int(cache.get("fetched_at", 0))) < cache_ttl:
+        cache["token_expired"] = token_expired
         return cache
 
     try:
@@ -84,14 +108,19 @@ def fetch_usage(cache_path: str, cache_ttl: int) -> dict[str, Any]:
             "seven_raw": seven_raw,
             "seven_reset_iso": payload["seven_day"].get("resets_at"),
             "fetched_at": now,
+            # A successful fetch proves the token is currently valid.
+            "token_expired": False,
         }
         _write_cache(cache_path, record)
         return record
     except Exception as e:
         logger.debug("usage fetch failed: %s", e)
         if cache:
+            cache["token_expired"] = token_expired
             return cache
-        return dict(EMPTY_RECORD)
+        record = dict(EMPTY_RECORD)
+        record["token_expired"] = token_expired
+        return record
 
 
 class _UsageWorker(QThread):

--- a/src/core/widgets/services/claude_usage/claude_api.py
+++ b/src/core/widgets/services/claude_usage/claude_api.py
@@ -165,9 +165,16 @@ class ClaudeUsageService(QObject):
             self.deleteLater()
 
     def _tick(self) -> None:
+        self._start_worker(self._cache_ttl)
+
+    def refresh_now(self) -> None:
+        """Force an immediate fetch, bypassing the cache TTL."""
+        self._start_worker(0)
+
+    def _start_worker(self, cache_ttl: int) -> None:
         if self._worker is not None:
             return  # a fetch is already in flight
-        worker = _UsageWorker(self._cache_path, self._cache_ttl, self)
+        worker = _UsageWorker(self._cache_path, cache_ttl, self)
         worker.data_ready.connect(self._on_data)
         worker.finished.connect(self._on_finished)
         self._worker = worker

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -257,6 +257,7 @@ class ClaudeUsageWidget(BaseWidget):
             layout = self._menu_layout
             for frame in getattr(self, "_section_frames", []):
                 layout.removeWidget(frame)
+                frame.hide()
                 frame.deleteLater()
             self._add_menu_sections(layout)
             menu.adjustSize()
@@ -279,13 +280,13 @@ class ClaudeUsageWidget(BaseWidget):
         self._menu_layout = layout
 
         header = QFrame()
-        header.setProperty("class", "header")
+        header.setProperty("class", "header-row")
         header_layout = QHBoxLayout(header)
         header_layout.setContentsMargins(0, 0, 0, 0)
         header_layout.setSpacing(0)
 
         header_title = QLabel("Claude Usage")
-        header_title.setProperty("class", "header-title")
+        header_title.setProperty("class", "header")
         header_layout.addWidget(header_title)
         header_layout.addStretch()
 

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -10,6 +10,9 @@ from core.validation.widgets.yasb.claude_usage import ClaudeUsageConfig
 from core.widgets.base import BaseWidget
 from core.widgets.services.claude_usage.claude_api import ClaudeUsageService
 
+# Usage-level CSS classes (shared by the popup bars and the optional bar-percent colouring).
+_LEVEL_CLASSES = frozenset({"low", "medium", "high", "critical", "unknown"})
+
 
 class UsageBar(QFrame):
     """A rounded progress bar drawn as a track QFrame with a child `.fill` QFrame.
@@ -190,13 +193,22 @@ class ClaudeUsageWidget(BaseWidget):
 
     @staticmethod
     def _level_class(value: Any) -> str:
+        """Usage band: low < 50 ≤ medium < 65 ≤ high < 80 ≤ critical (green/yellow/orange/red)."""
         if not isinstance(value, (int, float)):
             return "unknown"
         if value >= 80:
+            return "critical"
+        if value >= 65:
             return "high"
         if value >= 50:
             return "medium"
         return "low"
+
+    @staticmethod
+    def _apply_level_class(widget: QLabel, level: str) -> None:
+        """Set ``widget``'s usage level (low/medium/high) while keeping its base class."""
+        base = " ".join(t for t in (widget.property("class") or "label").split() if t not in _LEVEL_CLASSES)
+        widget.setProperty("class", f"{base} {level}")
 
     def _toggle_label(self) -> None:
         self._show_alt_label = not self._show_alt_label
@@ -230,6 +242,11 @@ class ClaudeUsageWidget(BaseWidget):
             # Hide empty labels so an unused placeholder (e.g. {stale} when the token is
             # valid) doesn't leave a constant gap from its margin/spacing.
             current_widget.setVisible(bool(rendered))
+            # Optionally colour the percentage by usage level (same thresholds as the bars).
+            if self.config.colorize_percent:
+                window = "five" if "{five_hour}" in part else "seven" if "{seven_day}" in part else None
+                if window is not None:
+                    self._apply_level_class(current_widget, self._level_class(self._data.get(window)))
             if self.config.tooltip:
                 tip = f"Claude usage — 5h: {values['five_hour']}% · 7d: {values['seven_day']}%"
                 if self._data.get("token_expired"):

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -151,9 +151,9 @@ class ClaudeUsageWidget(BaseWidget):
 
     @staticmethod
     def _fmt_weekday(iso: str | None, with_date: bool = False) -> str:
-        """Absolute reset as a local weekday + time, e.g. 'Sat 6:00 AM'; '--' when unknown.
+        """Absolute reset as a local weekday + time, e.g. 'Sat @ 6:00 AM'; '--' when unknown.
 
-        With ``with_date`` the month/day is included ('Sat, Jun 13 6:00 AM') so two windows
+        With ``with_date`` the month/day is included ('Sat, Jun 13 @ 6:00 AM') so two windows
         resetting on the same weekday can be told apart.
         """
         if not iso:
@@ -163,7 +163,7 @@ class ClaudeUsageWidget(BaseWidget):
             hour12 = local.hour % 12 or 12
             ampm = "AM" if local.hour < 12 else "PM"
             day = f"{local:%a, %b} {local.day}" if with_date else f"{local:%a}"
-            return f"{day} {hour12}:{local.minute:02d} {ampm}"
+            return f"{day} @ {hour12}:{local.minute:02d} {ampm}"
         except Exception:
             return "--"
 

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -2,8 +2,7 @@ import re
 from datetime import UTC, datetime
 from typing import Any
 
-from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QVBoxLayout
+from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QVBoxLayout
 
 from core.utils.tooltip import set_tooltip
 from core.utils.utilities import PopupWidget, refresh_widget_style
@@ -35,19 +34,6 @@ class UsageBar(QFrame):
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self._update_fill()
-
-
-class ClickableLabel(QLabel):
-    clicked = pyqtSignal()
-
-    def __init__(self, text: str, parent: QFrame | None = None):
-        super().__init__(text, parent)
-        self.setCursor(Qt.CursorShape.PointingHandCursor)
-
-    def mousePressEvent(self, event):
-        if event.button() == Qt.MouseButton.LeftButton:
-            self.clicked.emit()
-        super().mousePressEvent(event)
 
 
 class ClaudeUsageWidget(BaseWidget):
@@ -280,21 +266,21 @@ class ClaudeUsageWidget(BaseWidget):
         self._menu_layout = layout
 
         header = QFrame()
-        header.setProperty("class", "header-row")
+        header.setProperty("class", "header")
         header_layout = QHBoxLayout(header)
         header_layout.setContentsMargins(0, 0, 0, 0)
         header_layout.setSpacing(0)
 
-        header_title = QLabel("Claude Usage")
-        header_title.setProperty("class", "header")
-        header_layout.addWidget(header_title)
+        title_label = QLabel("Claude Usage")
+        title_label.setProperty("class", "text")
+        header_layout.addWidget(title_label)
         header_layout.addStretch()
 
-        refresh_button = ClickableLabel("\U000f0450")
-        refresh_button.setProperty("class", "refresh")
-        set_tooltip(refresh_button, "Refresh now")
-        refresh_button.clicked.connect(self._refresh)
-        header_layout.addWidget(refresh_button)
+        refresh_btn = QPushButton("\U000f0450")
+        refresh_btn.setProperty("class", "refresh")
+        set_tooltip(refresh_btn, "Refresh now")
+        refresh_btn.clicked.connect(self._refresh)
+        header_layout.addWidget(refresh_btn)
 
         layout.addWidget(header)
         self._add_menu_sections(layout)

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -85,12 +85,16 @@ class ClaudeUsageWidget(BaseWidget):
     def _refresh(self) -> None:
         self._service.refresh_now()
 
+    # Warning glyph (nf-fa-warning) shown via {stale} when the OAuth token has expired.
+    STALE_ICON = ""
+
     def _format_values(self) -> dict[str, str]:
         return {
             "five_hour": self._pct(self._data.get("five")),
             "seven_day": self._pct(self._data.get("seven")),
             "five_hour_reset": self._fmt_reset(self._data.get("five_reset_iso")),
             "seven_day_reset": self._fmt_reset(self._data.get("seven_reset_iso")),
+            "stale": self.STALE_ICON if self._data.get("token_expired") else "",
         }
 
     @staticmethod
@@ -168,17 +172,18 @@ class ClaudeUsageWidget(BaseWidget):
                 continue
             current_widget = active_widgets[index]
             if "<span" in part and "</span>" in part:
-                current_widget.setText(re.sub(r"<span.*?>|</span>", "", part).strip())
+                text = re.sub(r"<span.*?>|</span>", "", part).strip()
             else:
-                try:
-                    current_widget.setText(part.strip().format(**values))
-                except Exception:
-                    current_widget.setText(part.strip())
+                text = part.strip()
+            try:
+                current_widget.setText(text.format(**values))
+            except Exception:
+                current_widget.setText(text)
             if self.config.tooltip:
-                set_tooltip(
-                    current_widget,
-                    f"Claude usage — 5h: {values['five_hour']}% · 7d: {values['seven_day']}%",
-                )
+                tip = f"Claude usage — 5h: {values['five_hour']}% · 7d: {values['seven_day']}%"
+                if self._data.get("token_expired"):
+                    tip += "\nToken expired — run `claude -p` to refresh"
+                set_tooltip(current_widget, tip)
         refresh_widget_style(*active_widgets)
 
     def _toggle_menu(self) -> None:

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -167,9 +167,9 @@ class ClaudeUsageWidget(BaseWidget):
         except Exception:
             return "--"
 
-    def _reset_phrase(self, iso: str | None) -> str:
-        """Grammatical reset line for the popup, honoring ``reset_format``."""
-        if self.config.reset_format == "absolute":
+    def _reset_phrase(self, iso: str | None, reset_format: str) -> str:
+        """Grammatical reset line for the popup, honoring the window's ``reset_format``."""
+        if reset_format == "absolute":
             value = self._fmt_weekday(iso, with_date=self.config.reset_show_date)
             return f"Resets on {value}" if value != "--" else "Reset time unknown"
         value = self._fmt_duration(iso)
@@ -240,7 +240,7 @@ class ClaudeUsageWidget(BaseWidget):
     def _toggle_menu(self) -> None:
         self._build_menu()
 
-    def _build_section(self, title: str, value: Any, raw: Any, reset_iso: str | None) -> QFrame:
+    def _build_section(self, title: str, value: Any, raw: Any, reset_iso: str | None, reset_format: str) -> QFrame:
         level = self._level_class(value)
         frame = QFrame()
         frame.setProperty("class", "section")
@@ -261,7 +261,7 @@ class ClaudeUsageWidget(BaseWidget):
         footer_layout.setContentsMargins(0, 0, 0, 0)
         footer_layout.setSpacing(0)
 
-        reset_label = QLabel(self._reset_phrase(reset_iso))
+        reset_label = QLabel(self._reset_phrase(reset_iso, reset_format))
         reset_label.setProperty("class", "reset")
         footer_layout.addWidget(reset_label)
         footer_layout.addStretch()
@@ -281,10 +281,18 @@ class ClaudeUsageWidget(BaseWidget):
     def _add_menu_sections(self, layout: QVBoxLayout) -> None:
         self._section_frames = [
             self._build_section(
-                "5-Hour", self._data.get("five"), self._data.get("five_raw"), self._data.get("five_reset_iso")
+                "5-Hour",
+                self._data.get("five"),
+                self._data.get("five_raw"),
+                self._data.get("five_reset_iso"),
+                self.config.five_hour_reset_format,
             ),
             self._build_section(
-                "7-Day", self._data.get("seven"), self._data.get("seven_raw"), self._data.get("seven_reset_iso")
+                "7-Day",
+                self._data.get("seven"),
+                self._data.get("seven_raw"),
+                self._data.get("seven_reset_iso"),
+                self.config.seven_day_reset_format,
             ),
         ]
         for frame in self._section_frames:

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -39,6 +39,9 @@ class UsageBar(QFrame):
 class ClaudeUsageWidget(BaseWidget):
     validation_schema = ClaudeUsageConfig
 
+    # Warning glyph (nf-fa-warning) shown via {stale} when the OAuth token has expired.
+    STALE_ICON = ""
+
     def __init__(self, config: ClaudeUsageConfig):
         super().__init__(class_name="claude-usage")
         self.config = config
@@ -85,9 +88,6 @@ class ClaudeUsageWidget(BaseWidget):
     def _refresh(self) -> None:
         self._service.refresh_now()
 
-    # Warning glyph (nf-fa-warning) shown via {stale} when the OAuth token has expired.
-    STALE_ICON = ""
-
     def _format_values(self) -> dict[str, str]:
         return {
             "five_hour": self._pct(self._data.get("five")),
@@ -127,6 +127,48 @@ class ClaudeUsageWidget(BaseWidget):
             return f"{local:%a} {hour12}:{local.minute:02d} {ampm}"
         except Exception:
             return "--"
+
+    @staticmethod
+    def _fmt_duration(iso: str | None) -> str:
+        """Relative time-until-reset, e.g. '6d 21h', '4h 14m', '10m'; '--' when unknown."""
+        if not iso:
+            return "--"
+        try:
+            target = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+            seconds = int((target - datetime.now(UTC)).total_seconds())
+            if seconds <= 0:
+                return "0m"
+            minutes = seconds // 60
+            days, rem = divmod(minutes, 1440)
+            hours, mins = divmod(rem, 60)
+            if days:
+                return f"{days}d {hours}h"
+            if hours:
+                return f"{hours}h {mins}m"
+            return f"{mins}m"
+        except Exception:
+            return "--"
+
+    @staticmethod
+    def _fmt_weekday(iso: str | None) -> str:
+        """Absolute reset as a local weekday + time, e.g. 'Sat 6:00 AM'; '--' when unknown."""
+        if not iso:
+            return "--"
+        try:
+            local = datetime.fromisoformat(iso.replace("Z", "+00:00")).astimezone()
+            hour12 = local.hour % 12 or 12
+            ampm = "AM" if local.hour < 12 else "PM"
+            return f"{local:%a} {hour12}:{local.minute:02d} {ampm}"
+        except Exception:
+            return "--"
+
+    def _reset_phrase(self, iso: str | None) -> str:
+        """Grammatical reset line for the popup, honoring ``reset_format``."""
+        if self.config.reset_format == "absolute":
+            value = self._fmt_weekday(iso)
+            return f"Resets on {value}" if value != "--" else "Reset time unknown"
+        value = self._fmt_duration(iso)
+        return f"Resets in {value}" if value != "--" else "Reset time unknown"
 
     @staticmethod
     def _fmt_reset_at(iso: str | None) -> str:
@@ -176,9 +218,13 @@ class ClaudeUsageWidget(BaseWidget):
             else:
                 text = part.strip()
             try:
-                current_widget.setText(text.format(**values))
+                rendered = text.format(**values)
             except Exception:
-                current_widget.setText(text)
+                rendered = text
+            current_widget.setText(rendered)
+            # Hide empty labels so an unused placeholder (e.g. {stale} when the token is
+            # valid) doesn't leave a constant gap from its margin/spacing.
+            current_widget.setVisible(bool(rendered))
             if self.config.tooltip:
                 tip = f"Claude usage — 5h: {values['five_hour']}% · 7d: {values['seven_day']}%"
                 if self._data.get("token_expired"):
@@ -210,7 +256,7 @@ class ClaudeUsageWidget(BaseWidget):
         footer_layout.setContentsMargins(0, 0, 0, 0)
         footer_layout.setSpacing(0)
 
-        reset_label = QLabel(f"Resets in {self._fmt_reset(reset_iso)}")
+        reset_label = QLabel(self._reset_phrase(reset_iso))
         reset_label.setProperty("class", "reset")
         footer_layout.addWidget(reset_label)
         footer_layout.addStretch()

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -2,6 +2,7 @@ import re
 from datetime import UTC, datetime
 from typing import Any
 
+from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QVBoxLayout
 
 from core.utils.tooltip import set_tooltip
@@ -36,6 +37,19 @@ class UsageBar(QFrame):
         self._update_fill()
 
 
+class ClickableLabel(QLabel):
+    clicked = pyqtSignal()
+
+    def __init__(self, text: str, parent: QFrame | None = None):
+        super().__init__(text, parent)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.clicked.emit()
+        super().mousePressEvent(event)
+
+
 class ClaudeUsageWidget(BaseWidget):
     validation_schema = ClaudeUsageConfig
 
@@ -54,6 +68,7 @@ class ClaudeUsageWidget(BaseWidget):
 
         self.register_callback("toggle_label", self._toggle_label)
         self.register_callback("toggle_menu", self._toggle_menu)
+        self.register_callback("refresh", self._refresh)
 
         self.callback_left = self.config.callbacks.on_left
         self.callback_middle = self.config.callbacks.on_middle
@@ -79,6 +94,10 @@ class ClaudeUsageWidget(BaseWidget):
     def _on_data(self, data: dict[str, Any]) -> None:
         self._data = data
         self._update_label()
+        self._refresh_menu_sections()
+
+    def _refresh(self) -> None:
+        self._service.refresh_now()
 
     def _format_values(self) -> dict[str, str]:
         return {
@@ -217,6 +236,33 @@ class ClaudeUsageWidget(BaseWidget):
 
         return frame
 
+    def _add_menu_sections(self, layout: QVBoxLayout) -> None:
+        self._section_frames = [
+            self._build_section(
+                "5-Hour", self._data.get("five"), self._data.get("five_raw"), self._data.get("five_reset_iso")
+            ),
+            self._build_section(
+                "7-Day", self._data.get("seven"), self._data.get("seven_raw"), self._data.get("seven_reset_iso")
+            ),
+        ]
+        for frame in self._section_frames:
+            layout.addWidget(frame)
+
+    def _refresh_menu_sections(self) -> None:
+        """Redraw the popup sections in place when fresh data arrives while it is open."""
+        menu = self._menu
+        try:
+            if menu is None or not menu.isVisible():
+                return
+            layout = self._menu_layout
+            for frame in getattr(self, "_section_frames", []):
+                layout.removeWidget(frame)
+                frame.deleteLater()
+            self._add_menu_sections(layout)
+            menu.adjustSize()
+        except RuntimeError:
+            self._menu = None  # popup was already destroyed
+
     def _build_menu(self) -> None:
         self._menu = PopupWidget(
             self,
@@ -230,21 +276,27 @@ class ClaudeUsageWidget(BaseWidget):
         layout = QVBoxLayout(self._menu)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
+        self._menu_layout = layout
 
-        header = QLabel("Claude Usage")
+        header = QFrame()
         header.setProperty("class", "header")
-        layout.addWidget(header)
+        header_layout = QHBoxLayout(header)
+        header_layout.setContentsMargins(0, 0, 0, 0)
+        header_layout.setSpacing(0)
 
-        layout.addWidget(
-            self._build_section(
-                "5-Hour", self._data.get("five"), self._data.get("five_raw"), self._data.get("five_reset_iso")
-            )
-        )
-        layout.addWidget(
-            self._build_section(
-                "7-Day", self._data.get("seven"), self._data.get("seven_raw"), self._data.get("seven_reset_iso")
-            )
-        )
+        header_title = QLabel("Claude Usage")
+        header_title.setProperty("class", "header-title")
+        header_layout.addWidget(header_title)
+        header_layout.addStretch()
+
+        refresh_button = ClickableLabel("\U000f0450")
+        refresh_button.setProperty("class", "refresh")
+        set_tooltip(refresh_button, "Refresh now")
+        refresh_button.clicked.connect(self._refresh)
+        header_layout.addWidget(refresh_button)
+
+        layout.addWidget(header)
+        self._add_menu_sections(layout)
 
         self._menu.adjustSize()
         self._menu.setPosition(

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -150,22 +150,27 @@ class ClaudeUsageWidget(BaseWidget):
             return "--"
 
     @staticmethod
-    def _fmt_weekday(iso: str | None) -> str:
-        """Absolute reset as a local weekday + time, e.g. 'Sat 6:00 AM'; '--' when unknown."""
+    def _fmt_weekday(iso: str | None, with_date: bool = False) -> str:
+        """Absolute reset as a local weekday + time, e.g. 'Sat 6:00 AM'; '--' when unknown.
+
+        With ``with_date`` the month/day is included ('Sat, Jun 13 6:00 AM') so two windows
+        resetting on the same weekday can be told apart.
+        """
         if not iso:
             return "--"
         try:
             local = datetime.fromisoformat(iso.replace("Z", "+00:00")).astimezone()
             hour12 = local.hour % 12 or 12
             ampm = "AM" if local.hour < 12 else "PM"
-            return f"{local:%a} {hour12}:{local.minute:02d} {ampm}"
+            day = f"{local:%a, %b} {local.day}" if with_date else f"{local:%a}"
+            return f"{day} {hour12}:{local.minute:02d} {ampm}"
         except Exception:
             return "--"
 
     def _reset_phrase(self, iso: str | None) -> str:
         """Grammatical reset line for the popup, honoring ``reset_format``."""
         if self.config.reset_format == "absolute":
-            value = self._fmt_weekday(iso)
+            value = self._fmt_weekday(iso, with_date=self.config.reset_show_date)
             return f"Resets on {value}" if value != "--" else "Reset time unknown"
         value = self._fmt_duration(iso)
         return f"Resets in {value}" if value != "--" else "Reset time unknown"


### PR DESCRIPTION
## Summary

The Claude Usage widget currently has no way to force a re-fetch — when the data goes stale (e.g. the OAuth token in `.credentials.json` expired for a while and every poll silently fell back to the disk cache), the widget keeps showing old percentages with no recourse besides restarting the bar.

This PR adds:

- **`refresh` widget callback** — bindable to any mouse button (e.g. `on_middle: "refresh"`), forces an immediate fetch that bypasses the cache TTL via a new `ClaudeUsageService.refresh_now()`.
- **Refresh button in the popup menu header** (nerd-font `\U000f0450` glyph, `ClickableLabel` following the pattern used in `wifi_widgets.py`), with a "Refresh now" tooltip.
- **Live menu updates** — the popup sections now redraw in place when fresh data arrives while the menu is open, instead of showing stale values until reopened.

In-flight fetches are still deduplicated (`refresh_now()` is a no-op while a worker is running), so the button can't stack requests.

## Styling notes

The menu header changed from a single `QLabel.header` to a `QFrame.header` row containing `QLabel.header-title` + `ClickableLabel.refresh`. Since Qt stylesheets don't propagate font/color to children, existing `.claude-usage-menu .header` font rules should be duplicated onto `.header-title`. Example CSS:

```css
.claude-usage-menu .header .header-title {
    font-size: 14px;
    font-weight: 600;
    color: #cdd6f4;
}
.claude-usage-menu .header .refresh {
    font-size: 15px;
    color: rgba(205, 214, 244, 0.55);
    padding: 0 2px;
}
.claude-usage-menu .header .refresh:hover {
    color: #fab387;
}
```

Happy to update the wiki page ((Widget)-Claude-Usage) to document the new callback and CSS classes if this is accepted.

## Testing

- Built the modified modules into a local v2.0.3 install (Python 3.14, frozen `library.zip`) and verified: middle-click refresh, menu button refresh, in-place menu redraw on data arrival, and no regressions on toggle_label/toggle_menu.
- `ruff check` / `ruff format` clean (no new findings vs. main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)