### PR TITLE
docs(claude-usage): mention <img> custom icon + list widget in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ choco install yasb
 | [Bluetooth](https://github.com/amnweb/yasb/wiki/(Widget)-Bluetooth) | Shows the current Bluetooth status and connected devices. |
 | [Brightness](https://github.com/amnweb/yasb/wiki/(Widget)-Brightness) | Displays and change the current brightness level. |
 | [Cava](https://github.com/amnweb/yasb/wiki/(Widget)-Cava) | Displays audio visualizer using Cava. |
+| [Claude Usage](https://github.com/amnweb/yasb/wiki/(Widget)-Claude-Usage) | Shows your Claude (Claude Code) subscription usage with a popup of the 5-hour and 7-day limits. |
 | [Copilot](https://github.com/amnweb/yasb/wiki/(Widget)-Copilot) | GitHub Copilot usage with a detailed menu showing statistics |
 | [CPU](https://github.com/amnweb/yasb/wiki/(Widget)-CPU) | Shows the current CPU usage and information. |
 | [Clock](https://github.com/amnweb/yasb/wiki/(Widget)-Clock) | Displays the current time and date, with customizable formats. |

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -21,8 +21,9 @@ extra configuration is required as long as you are signed in to Claude Code.
 ## Placeholders
 
 The label is plain text by default. You can prepend a Nerd Font glyph in a `<span>` if you
-want an icon (e.g. `<span>\U000f06a9</span> {five_hour}%`). The following placeholders can be
-used in `label` / `label_alt`:
+want an icon (e.g. `<span>\U000f06a9</span> {five_hour}%`), or embed your own image with an
+`<img>` tag (e.g. `<img src='C:/path/to/claude.svg' width='14' height='14'> {five_hour}%`). The
+following placeholders can be used in `label` / `label_alt`:
 
 - `{five_hour}` — 5-hour window utilization (percent, `--` when unavailable).
 - `{seven_day}` — 7-day window utilization (percent, `--` when unavailable).


### PR DESCRIPTION
Two small docs-only fixes for the Claude Usage widget (shipped in v2.0.3):

1. **`<img>` custom icon note** — in the widget's **Placeholders** section, document that the label can embed a custom image via an `<img>` tag, alongside the existing Nerd Font `<span>` glyph example.
2. **README index** — the widget was never added to the README widget list; add it alphabetically between Cava and Copilot.

No code changes.