### PR TITLE
feat(claude_usage): local token-usage history (Session/Today/Week/Month/Year)

### DIFF
--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -14,6 +14,7 @@ extra configuration is required as long as you are signed in to Claude Code.
 | `label_alt`       | string  | `'Claude {seven_day}%'` | The alternative format string, toggled by the `toggle_label` callback. |
 | `update_interval` | integer | `60` | How often the label and reset countdown are refreshed, in seconds. Must be between 30 and 3600. |
 | `cache_ttl`       | integer | `120` | How long (seconds) a fetched result is cached on disk before the endpoint is queried again. The endpoint is rate-limited, so keep this at a sane value. |
+| `reset_format`    | string  | `'absolute'` | How the popup menu's reset line is phrased: `'absolute'` → `Resets on Sat 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h` (countdown). |
 | `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
 | `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. The popup menu also has a refresh button in its header. |
 | `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
@@ -44,6 +45,7 @@ claude_usage:
     label_alt: "Claude 7d {seven_day}% · {seven_day_reset}<span class='stale'>{stale}</span>"
     update_interval: 60
     cache_ttl: 120
+    reset_format: "absolute"  # or "relative" for a "Resets in 6d 21h" countdown
     callbacks:
       on_left: "toggle_menu"    # open the usage menu
       on_middle: "refresh"      # force an immediate re-fetch, bypassing the cache
@@ -65,6 +67,7 @@ claude_usage:
 - **label_alt:** The alternative format string, toggled with the `toggle_label` callback.
 - **update_interval:** How often the bar label and reset countdown are refreshed, in seconds (30–3600).
 - **cache_ttl:** How long a fetched result is cached on disk before the usage endpoint is queried again. Because the endpoint is rate-limited (HTTP 429), the widget serves the last cached value on any error instead of going blank.
+- **reset_format:** How the popup menu's "Resets …" line is phrased. `absolute` shows a local weekday and time (`Resets on Sat 6:00 AM`); `relative` shows a countdown (`Resets in 6d 21h`). The exact reset timestamp is always shown on the line below regardless of this setting.
 - **tooltip:** Whether to show a summary tooltip on hover.
 - **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `refresh` (force an immediate re-fetch of the usage data, bypassing `cache_ttl`), `do_nothing`, and `exec`. The popup menu header also has a refresh button that triggers the same action.
 - **menu:** A dictionary specifying the popup menu settings:

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -14,8 +14,8 @@ extra configuration is required as long as you are signed in to Claude Code.
 | `label_alt`       | string  | `'Claude {seven_day}%'` | The alternative format string, toggled by the `toggle_label` callback. |
 | `update_interval` | integer | `60` | How often the label and reset countdown are refreshed, in seconds. Must be between 30 and 3600. |
 | `cache_ttl`       | integer | `120` | How long (seconds) a fetched result is cached on disk before the endpoint is queried again. The endpoint is rate-limited, so keep this at a sane value. |
-| `reset_format`    | string  | `'absolute'` | How the popup menu's reset line is phrased: `'absolute'` → `Resets on Sat 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h` (countdown). |
-| `reset_show_date` | boolean | `true` | In `'absolute'` mode, include the month/day (`Resets on Sat, Jun 13 6:00 AM`) so windows that reset on the same weekday are distinguishable. No effect in `'relative'` mode. |
+| `reset_format`    | string  | `'absolute'` | How the popup menu's reset line is phrased: `'absolute'` → `Resets on Sat @ 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h` (countdown). |
+| `reset_show_date` | boolean | `true` | In `'absolute'` mode, include the month/day (`Resets on Sat, Jun 13 @ 6:00 AM`) so windows that reset on the same weekday are distinguishable. No effect in `'relative'` mode. |
 | `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
 | `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. The popup menu also has a refresh button in its header. |
 | `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
@@ -69,8 +69,8 @@ claude_usage:
 - **label_alt:** The alternative format string, toggled with the `toggle_label` callback.
 - **update_interval:** How often the bar label and reset countdown are refreshed, in seconds (30–3600).
 - **cache_ttl:** How long a fetched result is cached on disk before the usage endpoint is queried again. Because the endpoint is rate-limited (HTTP 429), the widget serves the last cached value on any error instead of going blank.
-- **reset_format:** How the popup menu's "Resets …" line is phrased. `absolute` shows a local weekday and time (`Resets on Sat 6:00 AM`); `relative` shows a countdown (`Resets in 6d 21h`). The exact reset timestamp is always shown on the line below regardless of this setting.
-- **reset_show_date:** In `absolute` mode, include the month and day in the reset line (`Resets on Sat, Jun 13 6:00 AM`). This disambiguates the 5-hour and 7-day windows when they happen to reset on the same weekday. Ignored in `relative` mode.
+- **reset_format:** How the popup menu's "Resets …" line is phrased. `absolute` shows a local weekday and time (`Resets on Sat @ 6:00 AM`); `relative` shows a countdown (`Resets in 6d 21h`). The exact reset timestamp is always shown on the line below regardless of this setting.
+- **reset_show_date:** In `absolute` mode, include the month and day in the reset line (`Resets on Sat, Jun 13 @ 6:00 AM`). This disambiguates the 5-hour and 7-day windows when they happen to reset on the same weekday. Ignored in `relative` mode.
 - **tooltip:** Whether to show a summary tooltip on hover.
 - **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `refresh` (force an immediate re-fetch of the usage data, bypassing `cache_ttl`), `do_nothing`, and `exec`. The popup menu header also has a refresh button that triggers the same action.
 - **menu:** A dictionary specifying the popup menu settings:

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -29,13 +29,19 @@ used in `label` / `label_alt`:
 - `{five_hour_reset}` — time until the 5-hour window resets. Shown as a countdown when under a
   day away (e.g. `4h 27m`), otherwise as a local weekday + time (e.g. `Sat 6:00 AM`).
 - `{seven_day_reset}` — time until the 7-day window resets (e.g. `Sat 6:00 AM`).
+- `{stale}` — an expired-token warning glyph (``), shown only when Claude Code's OAuth token
+  has expired and the widget is therefore serving stale cached values; empty otherwise. The
+  usage data is read from Claude Code's token, which only Claude Code can refresh, so this is a
+  cue to run a `claude` command to renew it. Wrap it in a `<span>` so it renders in your Nerd
+  Font and can be styled via `.claude-usage .stale`, e.g.
+  `{five_hour}%<span class='stale'>{stale}</span>`.
 
 ```yaml
 claude_usage:
   type: "yasb.claude_usage.ClaudeUsageWidget"
   options:
-    label: "Claude {five_hour}% · {five_hour_reset}"
-    label_alt: "Claude 7d {seven_day}% · {seven_day_reset}"
+    label: "Claude {five_hour}% · {five_hour_reset}<span class='stale'>{stale}</span>"
+    label_alt: "Claude 7d {seven_day}% · {seven_day_reset}<span class='stale'>{stale}</span>"
     update_interval: 60
     cache_ttl: 120
     callbacks:
@@ -83,6 +89,7 @@ signed in to Claude Code, the widget shows `--` until you sign in.
 .claude-usage .widget-container {}
 .claude-usage .icon {}
 .claude-usage .label {}
+.claude-usage .stale {}   /* expired-token warning glyph ({stale} placeholder) */
 /* Popup menu */
 .claude-usage-menu {}
 .claude-usage-menu .header {}            /* header row (title + refresh button) */
@@ -114,6 +121,11 @@ signed in to Claude Code, the widget shows `--` until you sign in.
 .claude-usage .label {
     color: #cdd6f4;
     padding: 0 2px;
+}
+.claude-usage .stale {
+    color: #f38ba8;
+    font-size: 13px;
+    margin-left: 4px;
 }
 .claude-usage-menu {
     background-color: #1e1e2e;

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -17,6 +17,7 @@ extra configuration is required as long as you are signed in to Claude Code.
 | `five_hour_reset_format` | string | `'relative'` | How the 5-hour window's reset line is phrased: `'relative'` → `Resets in 4h 11m` (countdown), or `'absolute'` → `Resets on Sat @ 6:00 AM`. |
 | `seven_day_reset_format` | string | `'absolute'` | How the 7-day window's reset line is phrased: `'absolute'` → `Resets on Sat @ 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h`. |
 | `reset_show_date` | boolean | `true` | For windows using `'absolute'`, include the month/day (`Resets on Sat, Jun 13 @ 6:00 AM`) so windows that reset on the same weekday are distinguishable. No effect on `'relative'` windows. |
+| `colorize_percent`| boolean | `false` | Colour the `{five_hour}`/`{seven_day}` percentage on the bar by usage level (same green/yellow/orange/red usage bands as the popup bars). See [Color-coded percentage](#color-coded-percentage). |
 | `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
 | `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. The popup menu also has a refresh button in its header. |
 | `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
@@ -73,6 +74,7 @@ claude_usage:
 - **cache_ttl:** How long a fetched result is cached on disk before the usage endpoint is queried again. Because the endpoint is rate-limited (HTTP 429), the widget serves the last cached value on any error instead of going blank.
 - **five_hour_reset_format / seven_day_reset_format:** How each window's "Resets …" line is phrased. `relative` shows a countdown (`Resets in 4h 11m`); `absolute` shows a local weekday and time (`Resets on Sat @ 6:00 AM`). The defaults suit each window — the near-term 5-hour window as a countdown, the multi-day 7-day window as a date. The exact reset timestamp is always shown on the line below regardless of this setting.
 - **reset_show_date:** For windows using `absolute`, include the month and day in the reset line (`Resets on Sat, Jun 13 @ 6:00 AM`). This disambiguates the two windows when they happen to reset on the same weekday. Ignored for `relative` windows.
+- **colorize_percent:** Colour the percentage shown on the bar by usage level. See [Color-coded percentage](#color-coded-percentage).
 - **tooltip:** Whether to show a summary tooltip on hover.
 - **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `refresh` (force an immediate re-fetch of the usage data, bypassing `cache_ttl`), `do_nothing`, and `exec`. The popup menu header also has a refresh button that triggers the same action.
 - **menu:** A dictionary specifying the popup menu settings:
@@ -83,6 +85,32 @@ claude_usage:
   - **alignment:** Horizontal alignment of the menu (`left`, `right`, `center`).
   - **direction:** Whether the menu opens `down` or `up`.
   - **offset_top / offset_left:** Pixel offsets for fine positioning.
+
+## Color-coded percentage
+
+With `colorize_percent: true`, the percentage on the bar is coloured by usage level using the
+**same usage bands as the popup progress bars** (`< 50` → low/green, `50–64` → medium/yellow,
+`65–79` → high/orange, `≥ 80` → critical/red) for whichever window is shown — `{five_hour}` on the main label or
+`{seven_day}` on the alt label.
+
+Because a label segment is coloured as a whole, wrap **only** the percent in its own span so
+the surrounding text (icon, reset countdown) keeps its normal colour:
+
+```yaml
+    label: "<span>\U000f06a9</span> <span class='percent'>{five_hour}%</span> · {five_hour_reset}"
+    label_alt: "<span>\U000f06a9</span> <span class='percent'>{seven_day}%</span> · {seven_day_reset}"
+    colorize_percent: true
+```
+
+The span gets a `low` / `medium` / `high` / `critical` (or `unknown`) class added automatically;
+style them to match the bars:
+
+```css
+.claude-usage .percent.low { color: #a6e3a1; }       /* green  */
+.claude-usage .percent.medium { color: #f9e2af; }    /* yellow */
+.claude-usage .percent.high { color: #fab387; }      /* orange */
+.claude-usage .percent.critical { color: #f38ba8; }  /* red    */
+```
 
 ## Authentication
 
@@ -98,6 +126,10 @@ signed in to Claude Code, the widget shows `--` until you sign in.
 .claude-usage .icon {}
 .claude-usage .label {}
 .claude-usage .stale {}   /* expired-token warning glyph ({stale} placeholder) */
+.claude-usage .percent.low {}       /* colorize_percent: < 50%  (green)  */
+.claude-usage .percent.medium {}    /* colorize_percent: 50-64% (yellow) */
+.claude-usage .percent.high {}      /* colorize_percent: 65-79% (orange) */
+.claude-usage .percent.critical {}  /* colorize_percent: >= 80% (red)    */
 /* Popup menu */
 .claude-usage-menu {}
 .claude-usage-menu .header {}            /* header row (title + refresh button) */
@@ -108,14 +140,16 @@ signed in to Claude Code, the widget shows `--` until you sign in.
 .claude-usage-menu .section .title {}
 .claude-usage-menu .section .progress {}               /* progress-bar track */
 .claude-usage-menu .section .progress .fill {}         /* filled portion */
-.claude-usage-menu .section .progress.low .fill {}     /* < 50%  */
-.claude-usage-menu .section .progress.medium .fill {}  /* 50-79% */
-.claude-usage-menu .section .progress.high .fill {}    /* >= 80% */
+.claude-usage-menu .section .progress.low .fill {}       /* < 50%  (green)  */
+.claude-usage-menu .section .progress.medium .fill {}    /* 50-64% (yellow) */
+.claude-usage-menu .section .progress.high .fill {}      /* 65-79% (orange) */
+.claude-usage-menu .section .progress.critical .fill {}  /* >= 80% (red)    */
 .claude-usage-menu .section .footer .reset {}
 .claude-usage-menu .section .footer .percent {}
 .claude-usage-menu .section .footer .percent.low {}
 .claude-usage-menu .section .footer .percent.medium {}
 .claude-usage-menu .section .footer .percent.high {}
+.claude-usage-menu .section .footer .percent.critical {}
 .claude-usage-menu .section .date {}     /* absolute reset timestamp */
 ```
 
@@ -177,7 +211,8 @@ signed in to Claude Code, the widget shows `--` until you sign in.
     border-radius: 5px;
 }
 .claude-usage-menu .progress.medium .fill { background-color: #f9e2af; }
-.claude-usage-menu .progress.high .fill { background-color: #f38ba8; }
+.claude-usage-menu .progress.high .fill { background-color: #fab387; }
+.claude-usage-menu .progress.critical .fill { background-color: #f38ba8; }
 .claude-usage-menu .reset {
     color: #a6adc8;
     font-size: 12px;
@@ -190,7 +225,8 @@ signed in to Claude Code, the widget shows `--` until you sign in.
     padding-top: 6px;
 }
 .claude-usage-menu .percent.medium { color: #f9e2af; }
-.claude-usage-menu .percent.high { color: #f38ba8; }
+.claude-usage-menu .percent.high { color: #fab387; }
+.claude-usage-menu .percent.critical { color: #f38ba8; }
 .claude-usage-menu .date {
     color: #6c7086;
     font-size: 11px;

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -19,6 +19,7 @@ extra configuration is required as long as you are signed in to Claude Code.
 | `reset_show_date` | boolean | `true` | For windows using `'absolute'`, include the month/day (`Resets on Sat, Jun 13 @ 6:00 AM`) so windows that reset on the same weekday are distinguishable. No effect on `'relative'` windows. |
 | `colorize_percent`| boolean | `false` | Colour the `{five_hour}`/`{seven_day}` percentage on the bar by usage level (same green/yellow/orange/red usage bands as the popup bars). See [Color-coded percentage](#color-coded-percentage). |
 | `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
+| `token_history`   | dict    | disabled | Optional local token-usage history (Session/Today/Week/Month/Year). See [Token history](#token-history). |
 | `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. The popup menu also has a refresh button in its header. |
 | `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
 
@@ -39,6 +40,13 @@ used in `label` / `label_alt`:
   cue to run a `claude` command to renew it. Wrap it in a `<span>` so it renders in your Nerd
   Font and can be styled via `.claude-usage .stale`, e.g.
   `{five_hour}%<span class='stale'>{stale}</span>`.
+
+When `token_history` is enabled, these compact token-count placeholders are also available
+(e.g. `15K`, `1.2M`, `218M`, `3.4B`, `1T`; `--` when unavailable):
+
+- `{session_tokens}` — tokens used by the most recent Claude Code session.
+- `{today_tokens}` / `{week_tokens}` / `{month_tokens}` / `{year_tokens}` — tokens used in the
+  current day / week / month / year (local time).
 
 ```yaml
 claude_usage:
@@ -112,6 +120,45 @@ style them to match the bars:
 .claude-usage .percent.critical { color: #f38ba8; }  /* red    */
 ```
 
+## Token history
+
+When `token_history.enabled` is `true`, the popup menu gains a **Tokens** section with a
+Session / Today / Week / Month / Year toggle, the selected period's total token count, and an
+optional usage graph. The data comes from Claude Code's own local session transcripts
+(`~/.claude/projects/**/*.jsonl`) — **no API key and no network**. Only numeric token counts,
+timestamps, the model name and the session id are read; message content is never touched. The
+scan is incremental (each file is re-parsed only when its size/mtime changes) and runs off the
+UI thread.
+
+The graph window matches the selected period: **Today** and **Session** are hourly, **Week**
+and **Month** are daily, and **Year** is monthly. The graph reuses the shared `GraphWidget`
+(the same chart the CPU/Memory/GPU widgets use) and is styled via `.token-graph`.
+
+| Option            | Type    | Default | Description |
+|-------------------|---------|---------|-------------|
+| `enabled`         | boolean | `false` | Enable the Tokens section and the `{*_tokens}` placeholders. |
+| `default_period`  | string  | `'today'` | Which period is selected when the menu opens: `session`, `today`, `week`, `month`, or `year`. |
+| `show_graph`      | boolean | `false` | Show the usage graph under the totals. |
+| `show_graph_grid` | boolean | `false` | Draw a faint grid behind the graph. |
+| `week_starts_on`  | string  | `'monday'` | Week boundary for the Week total: `monday` or `sunday`. |
+| `count_cache_read`| boolean | `true` | Whether cache-read tokens count toward totals. Cache reads dominate for heavy users, so totals are far smaller when this is `false` (closer to "new" work done). |
+| `scan_interval`   | integer | `120` | How often (seconds) the transcripts are re-scanned (30–3600). |
+
+```yaml
+    token_history:
+      enabled: true
+      default_period: "today"
+      show_graph: true
+      show_graph_grid: false
+      week_starts_on: "monday"
+      count_cache_read: true
+      scan_interval: 120
+```
+
+> [!NOTE]
+> **Session** is the most recently active session's *entire lifetime*, which can span several
+> days, so it may exceed **Today** (which counts every session but only the current date).
+
 ## Authentication
 
 The widget reuses Claude Code's existing OAuth session. It reads the access token from
@@ -151,6 +198,14 @@ signed in to Claude Code, the widget shows `--` until you sign in.
 .claude-usage-menu .section .footer .percent.high {}
 .claude-usage-menu .section .footer .percent.critical {}
 .claude-usage-menu .section .date {}     /* absolute reset timestamp */
+/* Token history section (token_history.enabled) */
+.claude-usage-menu .section.tokens .period-toggle {}        /* Session/Today/Week/... row */
+.claude-usage-menu .section.tokens .period-btn {}           /* a period button */
+.claude-usage-menu .section.tokens .period-btn:hover {}
+.claude-usage-menu .section.tokens .period-btn.active {}    /* the selected period */
+.claude-usage-menu .section.tokens .token-total {}          /* the big total count */
+.claude-usage-menu .section.tokens .token-graph {}          /* usage graph (its color drives the line) */
+.claude-usage-menu .section.tokens .token-graph-grid {}     /* graph grid color (show_graph_grid) */
 ```
 
 ## Example Style

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -14,8 +14,9 @@ extra configuration is required as long as you are signed in to Claude Code.
 | `label_alt`       | string  | `'Claude {seven_day}%'` | The alternative format string, toggled by the `toggle_label` callback. |
 | `update_interval` | integer | `60` | How often the label and reset countdown are refreshed, in seconds. Must be between 30 and 3600. |
 | `cache_ttl`       | integer | `120` | How long (seconds) a fetched result is cached on disk before the endpoint is queried again. The endpoint is rate-limited, so keep this at a sane value. |
-| `reset_format`    | string  | `'absolute'` | How the popup menu's reset line is phrased: `'absolute'` → `Resets on Sat @ 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h` (countdown). |
-| `reset_show_date` | boolean | `true` | In `'absolute'` mode, include the month/day (`Resets on Sat, Jun 13 @ 6:00 AM`) so windows that reset on the same weekday are distinguishable. No effect in `'relative'` mode. |
+| `five_hour_reset_format` | string | `'relative'` | How the 5-hour window's reset line is phrased: `'relative'` → `Resets in 4h 11m` (countdown), or `'absolute'` → `Resets on Sat @ 6:00 AM`. |
+| `seven_day_reset_format` | string | `'absolute'` | How the 7-day window's reset line is phrased: `'absolute'` → `Resets on Sat @ 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h`. |
+| `reset_show_date` | boolean | `true` | For windows using `'absolute'`, include the month/day (`Resets on Sat, Jun 13 @ 6:00 AM`) so windows that reset on the same weekday are distinguishable. No effect on `'relative'` windows. |
 | `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
 | `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. The popup menu also has a refresh button in its header. |
 | `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
@@ -46,8 +47,9 @@ claude_usage:
     label_alt: "Claude 7d {seven_day}% · {seven_day_reset}<span class='stale'>{stale}</span>"
     update_interval: 60
     cache_ttl: 120
-    reset_format: "absolute"  # or "relative" for a "Resets in 6d 21h" countdown
-    reset_show_date: true     # include month/day in the absolute reset line
+    five_hour_reset_format: "relative"  # 5-hour: "Resets in 4h 11m"
+    seven_day_reset_format: "absolute"  # 7-day:  "Resets on Sat, Jun 20 @ 2:59 AM"
+    reset_show_date: true               # include month/day in absolute reset lines
     callbacks:
       on_left: "toggle_menu"    # open the usage menu
       on_middle: "refresh"      # force an immediate re-fetch, bypassing the cache
@@ -69,8 +71,8 @@ claude_usage:
 - **label_alt:** The alternative format string, toggled with the `toggle_label` callback.
 - **update_interval:** How often the bar label and reset countdown are refreshed, in seconds (30–3600).
 - **cache_ttl:** How long a fetched result is cached on disk before the usage endpoint is queried again. Because the endpoint is rate-limited (HTTP 429), the widget serves the last cached value on any error instead of going blank.
-- **reset_format:** How the popup menu's "Resets …" line is phrased. `absolute` shows a local weekday and time (`Resets on Sat @ 6:00 AM`); `relative` shows a countdown (`Resets in 6d 21h`). The exact reset timestamp is always shown on the line below regardless of this setting.
-- **reset_show_date:** In `absolute` mode, include the month and day in the reset line (`Resets on Sat, Jun 13 @ 6:00 AM`). This disambiguates the 5-hour and 7-day windows when they happen to reset on the same weekday. Ignored in `relative` mode.
+- **five_hour_reset_format / seven_day_reset_format:** How each window's "Resets …" line is phrased. `relative` shows a countdown (`Resets in 4h 11m`); `absolute` shows a local weekday and time (`Resets on Sat @ 6:00 AM`). The defaults suit each window — the near-term 5-hour window as a countdown, the multi-day 7-day window as a date. The exact reset timestamp is always shown on the line below regardless of this setting.
+- **reset_show_date:** For windows using `absolute`, include the month and day in the reset line (`Resets on Sat, Jun 13 @ 6:00 AM`). This disambiguates the two windows when they happen to reset on the same weekday. Ignored for `relative` windows.
 - **tooltip:** Whether to show a summary tooltip on hover.
 - **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `refresh` (force an immediate re-fetch of the usage data, bypassing `cache_ttl`), `do_nothing`, and `exec`. The popup menu header also has a refresh button that triggers the same action.
 - **menu:** A dictionary specifying the popup menu settings:

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -15,7 +15,7 @@ extra configuration is required as long as you are signed in to Claude Code.
 | `update_interval` | integer | `60` | How often the label and reset countdown are refreshed, in seconds. Must be between 30 and 3600. |
 | `cache_ttl`       | integer | `120` | How long (seconds) a fetched result is cached on disk before the endpoint is queried again. The endpoint is rate-limited, so keep this at a sane value. |
 | `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
-| `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. |
+| `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. The popup menu also has a refresh button in its header. |
 | `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
 
 ## Placeholders
@@ -40,7 +40,7 @@ claude_usage:
     cache_ttl: 120
     callbacks:
       on_left: "toggle_menu"    # open the usage menu
-      on_middle: "do_nothing"
+      on_middle: "refresh"      # force an immediate re-fetch, bypassing the cache
       on_right: "toggle_label"  # switch the bar text between 5h and 7d
     menu:
       blur: true
@@ -60,7 +60,7 @@ claude_usage:
 - **update_interval:** How often the bar label and reset countdown are refreshed, in seconds (30–3600).
 - **cache_ttl:** How long a fetched result is cached on disk before the usage endpoint is queried again. Because the endpoint is rate-limited (HTTP 429), the widget serves the last cached value on any error instead of going blank.
 - **tooltip:** Whether to show a summary tooltip on hover.
-- **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `do_nothing`, and `exec`.
+- **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `refresh` (force an immediate re-fetch of the usage data, bypassing `cache_ttl`), `do_nothing`, and `exec`. The popup menu header also has a refresh button that triggers the same action.
 - **menu:** A dictionary specifying the popup menu settings:
   - **blur:** Enable blur effect for the menu.
   - **round_corners:** Enable round corners (not supported on Windows 10).
@@ -85,7 +85,10 @@ signed in to Claude Code, the widget shows `--` until you sign in.
 .claude-usage .label {}
 /* Popup menu */
 .claude-usage-menu {}
-.claude-usage-menu .header {}        /* "Claude Usage" title */
+.claude-usage-menu .header {}            /* header row (title + refresh button) */
+.claude-usage-menu .header .text {}      /* "Claude Usage" title */
+.claude-usage-menu .header .refresh {}   /* refresh button */
+.claude-usage-menu .header .refresh:hover {}
 .claude-usage-menu .section {}
 .claude-usage-menu .section .title {}
 .claude-usage-menu .section .progress {}               /* progress-bar track */
@@ -117,10 +120,22 @@ signed in to Claude Code, the widget shows `--` until you sign in.
     min-width: 260px;
 }
 .claude-usage-menu .header {
+    padding: 14px 16px 10px 16px;
+}
+.claude-usage-menu .header .text {
     color: #cdd6f4;
     font-size: 15px;
     font-weight: bold;
-    padding: 14px 16px 10px 16px;
+}
+.claude-usage-menu .header .refresh {
+    background: transparent;
+    border: none;
+    color: #6c7086;
+    font-size: 15px;
+    padding: 0 2px;
+}
+.claude-usage-menu .header .refresh:hover {
+    color: #fab387;
 }
 .claude-usage-menu .section {
     padding: 4px 16px 12px 16px;

--- a/docs/widgets/(Widget)-Claude-Usage.md
+++ b/docs/widgets/(Widget)-Claude-Usage.md
@@ -15,6 +15,7 @@ extra configuration is required as long as you are signed in to Claude Code.
 | `update_interval` | integer | `60` | How often the label and reset countdown are refreshed, in seconds. Must be between 30 and 3600. |
 | `cache_ttl`       | integer | `120` | How long (seconds) a fetched result is cached on disk before the endpoint is queried again. The endpoint is rate-limited, so keep this at a sane value. |
 | `reset_format`    | string  | `'absolute'` | How the popup menu's reset line is phrased: `'absolute'` → `Resets on Sat 6:00 AM` (local weekday + time), or `'relative'` → `Resets in 6d 21h` (countdown). |
+| `reset_show_date` | boolean | `true` | In `'absolute'` mode, include the month/day (`Resets on Sat, Jun 13 6:00 AM`) so windows that reset on the same weekday are distinguishable. No effect in `'relative'` mode. |
 | `tooltip`         | boolean | `true` | Whether to show a summary tooltip on hover. |
 | `callbacks`       | dict    | `{'on_left': 'toggle_menu', 'on_middle': 'do_nothing', 'on_right': 'toggle_label'}` | Mouse-click callbacks. The popup menu also has a refresh button in its header. |
 | `menu`            | dict    | `{'blur': true, 'round_corners': true, 'round_corners_type': 'normal', 'border_color': 'System', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Popup menu settings. |
@@ -46,6 +47,7 @@ claude_usage:
     update_interval: 60
     cache_ttl: 120
     reset_format: "absolute"  # or "relative" for a "Resets in 6d 21h" countdown
+    reset_show_date: true     # include month/day in the absolute reset line
     callbacks:
       on_left: "toggle_menu"    # open the usage menu
       on_middle: "refresh"      # force an immediate re-fetch, bypassing the cache
@@ -68,6 +70,7 @@ claude_usage:
 - **update_interval:** How often the bar label and reset countdown are refreshed, in seconds (30–3600).
 - **cache_ttl:** How long a fetched result is cached on disk before the usage endpoint is queried again. Because the endpoint is rate-limited (HTTP 429), the widget serves the last cached value on any error instead of going blank.
 - **reset_format:** How the popup menu's "Resets …" line is phrased. `absolute` shows a local weekday and time (`Resets on Sat 6:00 AM`); `relative` shows a countdown (`Resets in 6d 21h`). The exact reset timestamp is always shown on the line below regardless of this setting.
+- **reset_show_date:** In `absolute` mode, include the month and day in the reset line (`Resets on Sat, Jun 13 6:00 AM`). This disambiguates the 5-hour and 7-day windows when they happen to reset on the same weekday. Ignored in `relative` mode.
 - **tooltip:** Whether to show a summary tooltip on hover.
 - **callbacks:** Mouse-click callbacks. Built-in actions: `toggle_menu` (open/close the popup menu), `toggle_label` (swap between `label` and `label_alt`), `refresh` (force an immediate re-fetch of the usage data, bypassing `cache_ttl`), `do_nothing`, and `exec`. The popup menu header also has a refresh button that triggers the same action.
 - **menu:** A dictionary specifying the popup menu settings:

--- a/src/core/validation/widgets/yasb/claude_usage.py
+++ b/src/core/validation/widgets/yasb/claude_usage.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from pydantic import Field
 
 from core.validation.widgets.base_model import (
@@ -28,6 +30,10 @@ class ClaudeUsageConfig(CustomBaseModel):
     label_alt: str = "Claude {seven_day}%"
     update_interval: int = Field(default=60, ge=30, le=3600)
     cache_ttl: int = Field(default=120, ge=0, le=3600)
+    # How the popup menu's reset line is phrased:
+    #   "absolute" -> "Resets on Sat 6:00 AM" (local weekday + time)
+    #   "relative" -> "Resets in 6d 21h" (countdown)
+    reset_format: Literal["absolute", "relative"] = "absolute"
     tooltip: bool = True
     callbacks: ClaudeUsageCallbacksConfig = ClaudeUsageCallbacksConfig()
     menu: ClaudeUsageMenuConfig = ClaudeUsageMenuConfig()

--- a/src/core/validation/widgets/yasb/claude_usage.py
+++ b/src/core/validation/widgets/yasb/claude_usage.py
@@ -25,11 +25,26 @@ class ClaudeUsageMenuConfig(CustomBaseModel):
     offset_left: int = 0
 
 
+class ClaudeTokenHistoryConfig(CustomBaseModel):
+    # Reads Claude Code's local session transcripts (~/.claude/projects/**/*.jsonl) to
+    # show Session / Today / Week / Month / Year token totals in the popup menu.
+    enabled: bool = False
+    default_period: Literal["session", "today", "week", "month", "year"] = "today"
+    show_graph: bool = False
+    show_graph_grid: bool = False
+    graph_period: Literal["week", "month", "year"] = "month"
+    week_starts_on: Literal["monday", "sunday"] = "monday"
+    # Whether cache-read tokens count toward the totals (they dominate for heavy users).
+    count_cache_read: bool = True
+    scan_interval: int = Field(default=120, ge=30, le=3600)
+
+
 class ClaudeUsageConfig(CustomBaseModel):
     label: str = "Claude {five_hour}%"
     label_alt: str = "Claude {seven_day}%"
     update_interval: int = Field(default=60, ge=30, le=3600)
     cache_ttl: int = Field(default=120, ge=0, le=3600)
+    token_history: ClaudeTokenHistoryConfig = ClaudeTokenHistoryConfig()
     # How each window's popup reset line is phrased, per window:
     #   "relative" -> "Resets in 4h 11m" / "Resets in 6d 21h" (countdown)
     #   "absolute" -> "Resets on Sat @ 6:00 AM" (local weekday + time)

--- a/src/core/validation/widgets/yasb/claude_usage.py
+++ b/src/core/validation/widgets/yasb/claude_usage.py
@@ -32,7 +32,6 @@ class ClaudeTokenHistoryConfig(CustomBaseModel):
     default_period: Literal["session", "today", "week", "month", "year"] = "today"
     show_graph: bool = False
     show_graph_grid: bool = False
-    graph_period: Literal["week", "month", "year"] = "month"
     week_starts_on: Literal["monday", "sunday"] = "monday"
     # Whether cache-read tokens count toward the totals (they dominate for heavy users).
     count_cache_read: bool = True

--- a/src/core/validation/widgets/yasb/claude_usage.py
+++ b/src/core/validation/widgets/yasb/claude_usage.py
@@ -34,6 +34,9 @@ class ClaudeUsageConfig(CustomBaseModel):
     #   "absolute" -> "Resets on Sat 6:00 AM" (local weekday + time)
     #   "relative" -> "Resets in 6d 21h" (countdown)
     reset_format: Literal["absolute", "relative"] = "absolute"
+    # Include the month/day in the "absolute" reset line ("Resets on Sat, Jun 13 6:00 AM"),
+    # disambiguating windows that reset on the same weekday. No effect on "relative".
+    reset_show_date: bool = True
     tooltip: bool = True
     callbacks: ClaudeUsageCallbacksConfig = ClaudeUsageCallbacksConfig()
     menu: ClaudeUsageMenuConfig = ClaudeUsageMenuConfig()

--- a/src/core/validation/widgets/yasb/claude_usage.py
+++ b/src/core/validation/widgets/yasb/claude_usage.py
@@ -39,6 +39,10 @@ class ClaudeUsageConfig(CustomBaseModel):
     # Include the month/day in the "absolute" reset line ("Resets on Sat, Jun 13 @ 6:00 AM"),
     # disambiguating windows that reset on the same weekday. No effect on "relative".
     reset_show_date: bool = True
+    # Colour the {five_hour}/{seven_day} percentage on the bar by usage level, using the same
+    # low/medium/high thresholds as the popup progress bars. Wrap the percent in its own span
+    # (e.g. "<span class='percent'>{five_hour}%</span>") so only the number is coloured.
+    colorize_percent: bool = False
     tooltip: bool = True
     callbacks: ClaudeUsageCallbacksConfig = ClaudeUsageCallbacksConfig()
     menu: ClaudeUsageMenuConfig = ClaudeUsageMenuConfig()

--- a/src/core/validation/widgets/yasb/claude_usage.py
+++ b/src/core/validation/widgets/yasb/claude_usage.py
@@ -31,10 +31,10 @@ class ClaudeUsageConfig(CustomBaseModel):
     update_interval: int = Field(default=60, ge=30, le=3600)
     cache_ttl: int = Field(default=120, ge=0, le=3600)
     # How the popup menu's reset line is phrased:
-    #   "absolute" -> "Resets on Sat 6:00 AM" (local weekday + time)
+    #   "absolute" -> "Resets on Sat @ 6:00 AM" (local weekday + time)
     #   "relative" -> "Resets in 6d 21h" (countdown)
     reset_format: Literal["absolute", "relative"] = "absolute"
-    # Include the month/day in the "absolute" reset line ("Resets on Sat, Jun 13 6:00 AM"),
+    # Include the month/day in the "absolute" reset line ("Resets on Sat, Jun 13 @ 6:00 AM"),
     # disambiguating windows that reset on the same weekday. No effect on "relative".
     reset_show_date: bool = True
     tooltip: bool = True

--- a/src/core/validation/widgets/yasb/claude_usage.py
+++ b/src/core/validation/widgets/yasb/claude_usage.py
@@ -30,10 +30,12 @@ class ClaudeUsageConfig(CustomBaseModel):
     label_alt: str = "Claude {seven_day}%"
     update_interval: int = Field(default=60, ge=30, le=3600)
     cache_ttl: int = Field(default=120, ge=0, le=3600)
-    # How the popup menu's reset line is phrased:
+    # How each window's popup reset line is phrased, per window:
+    #   "relative" -> "Resets in 4h 11m" / "Resets in 6d 21h" (countdown)
     #   "absolute" -> "Resets on Sat @ 6:00 AM" (local weekday + time)
-    #   "relative" -> "Resets in 6d 21h" (countdown)
-    reset_format: Literal["absolute", "relative"] = "absolute"
+    # The near-term 5-hour window defaults to a countdown; the multi-day 7-day window to a date.
+    five_hour_reset_format: Literal["relative", "absolute"] = "relative"
+    seven_day_reset_format: Literal["relative", "absolute"] = "absolute"
     # Include the month/day in the "absolute" reset line ("Resets on Sat, Jun 13 @ 6:00 AM"),
     # disambiguating windows that reset on the same weekday. No effect on "relative".
     reset_show_date: bool = True

--- a/src/core/widgets/services/claude_usage/claude_api.py
+++ b/src/core/widgets/services/claude_usage/claude_api.py
@@ -23,11 +23,30 @@ EMPTY_RECORD: dict[str, Any] = {
     "seven_raw": None,
     "seven_reset_iso": None,
     "fetched_at": 0,
+    "token_expired": False,
 }
 
 
 def _claude_config_dir() -> str:
     return os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(os.path.expanduser("~"), ".claude")
+
+
+def _token_expired() -> bool:
+    """True when Claude Code's OAuth access token has expired (so a refresh is needed).
+
+    Reads only the ``expiresAt`` timestamp (ms epoch); the token itself is never
+    touched here. Returns False when the value is missing/unreadable so a parsing
+    quirk never produces a false 'expired' warning.
+    """
+    try:
+        cred_path = os.path.join(_claude_config_dir(), ".credentials.json")
+        with open(cred_path, encoding="utf-8") as f:
+            expires_at = json.load(f)["claudeAiOauth"].get("expiresAt")
+        if not expires_at:
+            return False
+        return (expires_at / 1000) < time.time()
+    except Exception:
+        return False
 
 
 def _cache_path() -> str:
@@ -57,9 +76,14 @@ def fetch_usage(cache_path: str, cache_ttl: int) -> dict[str, Any]:
     returned so the widget keeps showing the most recent known values. The OAuth
     token is read from Claude Code's credentials store and is never logged.
     """
+    # Recomputed live on every call (independent of the usage cache) so the
+    # expired-token warning is accurate even when serving a stale record.
+    token_expired = _token_expired()
+
     cache = _read_cache(cache_path)
     now = int(time.time())
     if cache and (now - int(cache.get("fetched_at", 0))) < cache_ttl:
+        cache["token_expired"] = token_expired
         return cache
 
     try:
@@ -84,14 +108,19 @@ def fetch_usage(cache_path: str, cache_ttl: int) -> dict[str, Any]:
             "seven_raw": seven_raw,
             "seven_reset_iso": payload["seven_day"].get("resets_at"),
             "fetched_at": now,
+            # A successful fetch proves the token is currently valid.
+            "token_expired": False,
         }
         _write_cache(cache_path, record)
         return record
     except Exception as e:
         logger.debug("usage fetch failed: %s", e)
         if cache:
+            cache["token_expired"] = token_expired
             return cache
-        return dict(EMPTY_RECORD)
+        record = dict(EMPTY_RECORD)
+        record["token_expired"] = token_expired
+        return record
 
 
 class _UsageWorker(QThread):

--- a/src/core/widgets/services/claude_usage/claude_api.py
+++ b/src/core/widgets/services/claude_usage/claude_api.py
@@ -165,9 +165,16 @@ class ClaudeUsageService(QObject):
             self.deleteLater()
 
     def _tick(self) -> None:
+        self._start_worker(self._cache_ttl)
+
+    def refresh_now(self) -> None:
+        """Force an immediate fetch, bypassing the cache TTL."""
+        self._start_worker(0)
+
+    def _start_worker(self, cache_ttl: int) -> None:
         if self._worker is not None:
             return  # a fetch is already in flight
-        worker = _UsageWorker(self._cache_path, self._cache_ttl, self)
+        worker = _UsageWorker(self._cache_path, cache_ttl, self)
         worker.data_ready.connect(self._on_data)
         worker.finished.connect(self._on_finished)
         self._worker = worker

--- a/src/core/widgets/services/claude_usage/token_history.py
+++ b/src/core/widgets/services/claude_usage/token_history.py
@@ -27,7 +27,7 @@ from core.widgets.services.claude_usage.claude_api import _claude_config_dir
 
 logger = logging.getLogger("claude_usage")
 
-CACHE_VERSION = 1
+CACHE_VERSION = 2
 # Token count order used throughout: input, output, cache_creation, cache_read.
 _TOKEN_SLOTS = 4
 
@@ -69,6 +69,11 @@ def _merge_daily(into: dict[str, dict[str, list[int]]], src: dict[str, dict[str,
             _add4(slot, counts)
 
 
+def _merge_hourly(into: dict[str, list[int]], src: dict[str, list[int]]) -> None:
+    for hour, counts in src.items():
+        _add4(into.setdefault(hour, [0, 0, 0, 0]), counts)
+
+
 def _merge_sessions(into: dict[str, dict[str, Any]], src: dict[str, dict[str, Any]]) -> None:
     for sid, info in src.items():
         cur = into.get(sid)
@@ -81,8 +86,9 @@ def _merge_sessions(into: dict[str, dict[str, Any]], src: dict[str, dict[str, An
 
 
 def _parse_file(path: str) -> dict[str, Any]:
-    """Parse one JSONL transcript into its daily + session token contribution."""
+    """Parse one JSONL transcript into its daily + hourly + session token contribution."""
     daily: dict[str, dict[str, list[int]]] = {}
+    hourly: dict[str, list[int]] = {}
     sessions: dict[str, dict[str, Any]] = {}
     try:
         with open(path, encoding="utf-8") as f:
@@ -113,12 +119,14 @@ def _parse_file(path: str) -> dict[str, Any]:
                 except Exception:
                     continue
                 date_key = f"{local:%Y-%m-%d}"
+                hour_key = f"{local:%Y-%m-%dT%H}"
                 tsec = local.timestamp()
                 model = message.get("model") or "unknown"
                 sid = obj.get("sessionId") or "unknown"
 
                 slot = daily.setdefault(date_key, {}).setdefault(model, [0, 0, 0, 0])
                 _add4(slot, counts)
+                _add4(hourly.setdefault(hour_key, [0, 0, 0, 0]), counts)
 
                 sess = sessions.get(sid)
                 if sess is None:
@@ -129,7 +137,7 @@ def _parse_file(path: str) -> dict[str, Any]:
                     sess["last"] = max(sess["last"], tsec)
     except Exception as e:
         logger.debug("failed to parse %s: %s", path, e)
-    return {"daily": daily, "sessions": sessions}
+    return {"daily": daily, "hourly": hourly, "sessions": sessions}
 
 
 def scan(cache_path: str) -> dict[str, Any]:
@@ -158,13 +166,16 @@ def scan(cache_path: str) -> dict[str, Any]:
                 "mtime": st.st_mtime,
                 "size": st.st_size,
                 "daily": contrib["daily"],
+                "hourly": contrib["hourly"],
                 "sessions": contrib["sessions"],
             }
 
     daily: dict[str, dict[str, list[int]]] = {}
+    hourly: dict[str, list[int]] = {}
     sessions: dict[str, dict[str, Any]] = {}
     for fc in current_files.values():
         _merge_daily(daily, fc["daily"])
+        _merge_hourly(hourly, fc.get("hourly", {}))
         _merge_sessions(sessions, fc["sessions"])
 
     _write_json(
@@ -173,11 +184,12 @@ def scan(cache_path: str) -> dict[str, Any]:
             "version": CACHE_VERSION,
             "files": current_files,
             "daily": daily,
+            "hourly": hourly,
             "sessions": sessions,
             "updated_at": int(time.time()),
         },
     )
-    return {"daily": daily, "sessions": sessions, "scanned_at": int(time.time())}
+    return {"daily": daily, "hourly": hourly, "sessions": sessions, "scanned_at": int(time.time())}
 
 
 def _date_keys_in_range(start: datetime, end: datetime) -> list[str]:
@@ -203,24 +215,63 @@ def _sum_daily(daily: dict[str, dict[str, list[int]]], date_key: str, count_cach
     return total
 
 
+def _sum_hourly(hourly: dict[str, list[int]], hour_key: str, count_cache_read: bool) -> int:
+    counts = hourly.get(hour_key)
+    if not counts:
+        return 0
+    return counts[0] + counts[1] + counts[2] + (counts[3] if count_cache_read else 0)
+
+
+def _hour_keys_in_range(start: datetime, end: datetime) -> list[str]:
+    """Local YYYY-MM-DDTHH keys from start's hour through end's hour, inclusive."""
+    keys = []
+    cur = start.replace(minute=0, second=0, microsecond=0)
+    last = end.replace(minute=0, second=0, microsecond=0)
+    while cur <= last:
+        keys.append(f"{cur:%Y-%m-%dT%H}")
+        cur += timedelta(hours=1)
+    return keys
+
+
+def _month_keys_in_range(start: datetime, end: datetime) -> list[str]:
+    """Local YYYY-MM keys from start's month through end's month, inclusive."""
+    keys = []
+    year, month = start.year, start.month
+    while (year, month) <= (end.year, end.month):
+        keys.append(f"{year:04d}-{month:02d}")
+        month += 1
+        if month > 12:
+            month = 1
+            year += 1
+    return keys
+
+
+def _sum_month(daily: dict[str, dict[str, list[int]]], month_key: str, count_cache_read: bool) -> int:
+    prefix = f"{month_key}-"
+    return sum(_sum_daily(daily, dk, count_cache_read) for dk in daily if dk.startswith(prefix))
+
+
 def summarize(
     agg: dict[str, Any],
     *,
     count_cache_read: bool = True,
     week_starts_on: str = "monday",
-    graph_period: str = "month",
     now: datetime | None = None,
 ) -> dict[str, Any]:
-    """Derive Session/Today/Week/Month/Year totals and a daily series from an aggregate.
+    """Derive Session/Today/Week/Month/Year totals and a per-period graph series.
 
-    ``now`` (local, tz-aware) is injectable for deterministic tests.
+    Each period's series matches its window: Today is hourly (midnight→now), Session
+    is hourly across the session's span (capped to 14 days), Week and Month are daily,
+    and Year is monthly. ``now`` (local, tz-aware) is injectable for deterministic tests.
     """
     now = now or datetime.now().astimezone()
     daily = agg.get("daily", {})
+    hourly = agg.get("hourly", {})
     sessions = agg.get("sessions", {})
+    ccr = count_cache_read
 
     def window_total(start: datetime) -> int:
-        return sum(_sum_daily(daily, k, count_cache_read) for k in _date_keys_in_range(start, now))
+        return sum(_sum_daily(daily, k, ccr) for k in _date_keys_in_range(start, now))
 
     today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
     weekday = now.weekday()  # Mon=0
@@ -232,14 +283,23 @@ def summarize(
     # Session = the most recently active session id.
     session_total = 0
     session_id = None
+    session_series: list[float] = []
     if sessions:
         session_id, info = max(sessions.items(), key=lambda kv: kv[1]["last"])
         t = info["t"]
-        session_total = t[0] + t[1] + t[2] + (t[3] if count_cache_read else 0)
+        session_total = t[0] + t[1] + t[2] + (t[3] if ccr else 0)
+        first = datetime.fromtimestamp(info["first"]).astimezone()
+        last = datetime.fromtimestamp(info["last"]).astimezone()
+        s_start = max(first, now - timedelta(days=14))
+        session_series = [_sum_hourly(hourly, k, ccr) for k in _hour_keys_in_range(s_start, last)]
 
-    span_days = {"week": 7, "month": 30, "year": 365}.get(graph_period, 30)
-    series_start = today_start - timedelta(days=span_days - 1)
-    series = [_sum_daily(daily, k, count_cache_read) for k in _date_keys_in_range(series_start, now)]
+    series_by_period = {
+        "session": session_series,
+        "today": [_sum_hourly(hourly, k, ccr) for k in _hour_keys_in_range(today_start, now)],
+        "week": [_sum_daily(daily, k, ccr) for k in _date_keys_in_range(week_start, now)],
+        "month": [_sum_daily(daily, k, ccr) for k in _date_keys_in_range(month_start, now)],
+        "year": [_sum_month(daily, k, ccr) for k in _month_keys_in_range(year_start, now)],
+    }
 
     return {
         "totals": {
@@ -249,7 +309,7 @@ def summarize(
             "month": window_total(month_start),
             "year": window_total(year_start),
         },
-        "series": series,
+        "series_by_period": series_by_period,
         "session_id": session_id,
     }
 
@@ -268,7 +328,7 @@ class _ScanWorker(QThread):
             self.data_ready.emit(scan(self._cache_path))
         except Exception as e:
             logger.debug("token history scan failed: %s", e)
-            self.data_ready.emit({"daily": {}, "sessions": {}, "scanned_at": int(time.time())})
+            self.data_ready.emit({"daily": {}, "hourly": {}, "sessions": {}, "scanned_at": int(time.time())})
 
 
 class TokenHistoryService(QObject):
@@ -301,6 +361,7 @@ class TokenHistoryService(QObject):
         cached = _read_json(self._cache_path) or {}
         self._data: dict[str, Any] = {
             "daily": cached.get("daily", {}),
+            "hourly": cached.get("hourly", {}),
             "sessions": cached.get("sessions", {}),
             "scanned_at": cached.get("updated_at", 0),
         }

--- a/src/core/widgets/services/claude_usage/token_history.py
+++ b/src/core/widgets/services/claude_usage/token_history.py
@@ -1,0 +1,345 @@
+"""Local Claude Code token-usage history.
+
+Claude Code writes a JSONL transcript per session under
+``~/.claude/projects/**/*.jsonl``. Every assistant message line carries a
+``message.usage`` block with token counts. This module scans those files and
+aggregates the token counts into per-day (local time) and per-session buckets,
+which the widget turns into Session / Today / Week / Month / Year totals.
+
+Only numeric token counts, timestamps, the model name and the session id are
+read — never message content. The scan is incremental: each file's parsed
+contribution is cached keyed by (mtime, size), so a steady-state poll only
+re-parses the session file(s) that actually changed.
+"""
+
+import glob
+import json
+import logging
+import os
+import time
+from datetime import datetime, timedelta
+from typing import Any, ClassVar
+
+from PyQt6.QtCore import QObject, QThread, QTimer, pyqtSignal
+
+from core.utils.system import app_data_path
+from core.widgets.services.claude_usage.claude_api import _claude_config_dir
+
+logger = logging.getLogger("claude_usage")
+
+CACHE_VERSION = 1
+# Token count order used throughout: input, output, cache_creation, cache_read.
+_TOKEN_SLOTS = 4
+
+
+def _projects_dir() -> str:
+    return os.path.join(_claude_config_dir(), "projects")
+
+
+def _history_cache_path() -> str:
+    return str(app_data_path("claude_token_history.json"))
+
+
+def _read_json(path: str) -> dict[str, Any] | None:
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def _write_json(path: str, data: dict[str, Any]) -> None:
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+    except Exception as e:
+        logger.debug("failed to write token history cache: %s", e)
+
+
+def _add4(dst: list[int], src: list[int]) -> None:
+    for i in range(_TOKEN_SLOTS):
+        dst[i] += src[i]
+
+
+def _merge_daily(into: dict[str, dict[str, list[int]]], src: dict[str, dict[str, list[int]]]) -> None:
+    for date, models in src.items():
+        bucket = into.setdefault(date, {})
+        for model, counts in models.items():
+            slot = bucket.setdefault(model, [0, 0, 0, 0])
+            _add4(slot, counts)
+
+
+def _merge_sessions(into: dict[str, dict[str, Any]], src: dict[str, dict[str, Any]]) -> None:
+    for sid, info in src.items():
+        cur = into.get(sid)
+        if cur is None:
+            into[sid] = {"t": list(info["t"]), "first": info["first"], "last": info["last"]}
+        else:
+            _add4(cur["t"], info["t"])
+            cur["first"] = min(cur["first"], info["first"])
+            cur["last"] = max(cur["last"], info["last"])
+
+
+def _parse_file(path: str) -> dict[str, Any]:
+    """Parse one JSONL transcript into its daily + session token contribution."""
+    daily: dict[str, dict[str, list[int]]] = {}
+    sessions: dict[str, dict[str, Any]] = {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    continue
+                message = obj.get("message")
+                if not isinstance(message, dict):
+                    continue
+                usage = message.get("usage")
+                if not isinstance(usage, dict):
+                    continue
+                counts = [
+                    int(usage.get("input_tokens") or 0),
+                    int(usage.get("output_tokens") or 0),
+                    int(usage.get("cache_creation_input_tokens") or 0),
+                    int(usage.get("cache_read_input_tokens") or 0),
+                ]
+                if not any(counts):
+                    continue
+                iso = obj.get("timestamp")
+                if not iso:
+                    continue
+                try:
+                    local = datetime.fromisoformat(iso.replace("Z", "+00:00")).astimezone()
+                except Exception:
+                    continue
+                date_key = f"{local:%Y-%m-%d}"
+                tsec = local.timestamp()
+                model = message.get("model") or "unknown"
+                sid = obj.get("sessionId") or "unknown"
+
+                slot = daily.setdefault(date_key, {}).setdefault(model, [0, 0, 0, 0])
+                _add4(slot, counts)
+
+                sess = sessions.get(sid)
+                if sess is None:
+                    sessions[sid] = {"t": list(counts), "first": tsec, "last": tsec}
+                else:
+                    _add4(sess["t"], counts)
+                    sess["first"] = min(sess["first"], tsec)
+                    sess["last"] = max(sess["last"], tsec)
+    except Exception as e:
+        logger.debug("failed to parse %s: %s", path, e)
+    return {"daily": daily, "sessions": sessions}
+
+
+def scan(cache_path: str) -> dict[str, Any]:
+    """Incrementally scan all session transcripts and return the merged aggregate.
+
+    Returns a dict with ``daily`` (date -> model -> [in, out, cache_create,
+    cache_read]) and ``sessions`` (id -> {t, first, last}). Unchanged files reuse
+    their cached contribution; only new/modified files are re-parsed.
+    """
+    cache = _read_json(cache_path) or {}
+    prev_files: dict[str, Any] = cache.get("files", {}) if cache.get("version") == CACHE_VERSION else {}
+
+    current_files: dict[str, Any] = {}
+    pattern = os.path.join(_projects_dir(), "**", "*.jsonl")
+    for path in glob.glob(pattern, recursive=True):
+        try:
+            st = os.stat(path)
+        except OSError:
+            continue
+        prev = prev_files.get(path)
+        if prev and prev.get("mtime") == st.st_mtime and prev.get("size") == st.st_size:
+            current_files[path] = prev
+        else:
+            contrib = _parse_file(path)
+            current_files[path] = {
+                "mtime": st.st_mtime,
+                "size": st.st_size,
+                "daily": contrib["daily"],
+                "sessions": contrib["sessions"],
+            }
+
+    daily: dict[str, dict[str, list[int]]] = {}
+    sessions: dict[str, dict[str, Any]] = {}
+    for fc in current_files.values():
+        _merge_daily(daily, fc["daily"])
+        _merge_sessions(sessions, fc["sessions"])
+
+    _write_json(
+        cache_path,
+        {
+            "version": CACHE_VERSION,
+            "files": current_files,
+            "daily": daily,
+            "sessions": sessions,
+            "updated_at": int(time.time()),
+        },
+    )
+    return {"daily": daily, "sessions": sessions, "scanned_at": int(time.time())}
+
+
+def _date_keys_in_range(start: datetime, end: datetime) -> list[str]:
+    """Local YYYY-MM-DD keys from start.date() through end.date(), inclusive."""
+    keys = []
+    day = start.date()
+    last = end.date()
+    while day <= last:
+        keys.append(f"{day:%Y-%m-%d}")
+        day += timedelta(days=1)
+    return keys
+
+
+def _sum_daily(daily: dict[str, dict[str, list[int]]], date_key: str, count_cache_read: bool) -> int:
+    bucket = daily.get(date_key)
+    if not bucket:
+        return 0
+    total = 0
+    for counts in bucket.values():
+        total += counts[0] + counts[1] + counts[2]
+        if count_cache_read:
+            total += counts[3]
+    return total
+
+
+def summarize(
+    agg: dict[str, Any],
+    *,
+    count_cache_read: bool = True,
+    week_starts_on: str = "monday",
+    graph_period: str = "month",
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Derive Session/Today/Week/Month/Year totals and a daily series from an aggregate.
+
+    ``now`` (local, tz-aware) is injectable for deterministic tests.
+    """
+    now = now or datetime.now().astimezone()
+    daily = agg.get("daily", {})
+    sessions = agg.get("sessions", {})
+
+    def window_total(start: datetime) -> int:
+        return sum(_sum_daily(daily, k, count_cache_read) for k in _date_keys_in_range(start, now))
+
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    weekday = now.weekday()  # Mon=0
+    back = (weekday + 1) % 7 if week_starts_on == "sunday" else weekday
+    week_start = today_start - timedelta(days=back)
+    month_start = today_start.replace(day=1)
+    year_start = today_start.replace(month=1, day=1)
+
+    # Session = the most recently active session id.
+    session_total = 0
+    session_id = None
+    if sessions:
+        session_id, info = max(sessions.items(), key=lambda kv: kv[1]["last"])
+        t = info["t"]
+        session_total = t[0] + t[1] + t[2] + (t[3] if count_cache_read else 0)
+
+    span_days = {"week": 7, "month": 30, "year": 365}.get(graph_period, 30)
+    series_start = today_start - timedelta(days=span_days - 1)
+    series = [_sum_daily(daily, k, count_cache_read) for k in _date_keys_in_range(series_start, now)]
+
+    return {
+        "totals": {
+            "session": session_total,
+            "today": window_total(today_start),
+            "week": window_total(week_start),
+            "month": window_total(month_start),
+            "year": window_total(year_start),
+        },
+        "series": series,
+        "session_id": session_id,
+    }
+
+
+class _ScanWorker(QThread):
+    """Runs the (blocking) transcript scan off the UI thread."""
+
+    data_ready = pyqtSignal(dict)
+
+    def __init__(self, cache_path: str, parent: Any = None):
+        super().__init__(parent)
+        self._cache_path = cache_path
+
+    def run(self) -> None:
+        try:
+            self.data_ready.emit(scan(self._cache_path))
+        except Exception as e:
+            logger.debug("token history scan failed: %s", e)
+            self.data_ready.emit({"daily": {}, "sessions": {}, "scanned_at": int(time.time())})
+
+
+class TokenHistoryService(QObject):
+    """Shared local token-history poller (mirrors ClaudeUsageService).
+
+    One instance per ``scan_interval`` scans the transcripts on a timer and
+    shares the merged aggregate with every widget on the same interval.
+    """
+
+    data_ready = pyqtSignal(dict)
+
+    _instances: ClassVar[dict[int, TokenHistoryService]] = {}
+
+    @classmethod
+    def get_instance(cls, scan_interval_s: int) -> TokenHistoryService:
+        key = int(scan_interval_s)
+        inst = cls._instances.get(key)
+        if inst is None:
+            inst = cls(scan_interval_s=key, _key=key)
+            cls._instances[key] = inst
+        inst._refcount += 1
+        return inst
+
+    def __init__(self, scan_interval_s: int, _key: int):
+        super().__init__()
+        self._key = _key
+        self._refcount = 0
+        self._cache_path = _history_cache_path()
+        self._worker: _ScanWorker | None = None
+        cached = _read_json(self._cache_path) or {}
+        self._data: dict[str, Any] = {
+            "daily": cached.get("daily", {}),
+            "sessions": cached.get("sessions", {}),
+            "scanned_at": cached.get("updated_at", 0),
+        }
+
+        self._timer = QTimer(self)
+        self._timer.setInterval(max(int(scan_interval_s), 1) * 1000)
+        self._timer.timeout.connect(self._tick)
+        self._timer.start()
+        self._tick()
+
+    def latest(self) -> dict[str, Any]:
+        return self._data
+
+    def release(self) -> None:
+        self._refcount -= 1
+        if self._refcount > 0:
+            return
+        self._timer.stop()
+        TokenHistoryService._instances.pop(self._key, None)
+        if self._worker is not None and self._worker.isRunning():
+            self._worker.finished.connect(self.deleteLater)
+        else:
+            self.deleteLater()
+
+    def _tick(self) -> None:
+        if self._worker is not None:
+            return  # a scan is already in flight
+        worker = _ScanWorker(self._cache_path, self)
+        worker.data_ready.connect(self._on_data)
+        worker.finished.connect(self._on_finished)
+        self._worker = worker
+        worker.start()
+
+    def _on_data(self, data: dict[str, Any]) -> None:
+        self._data = data
+        self.data_ready.emit(data)
+
+    def _on_finished(self) -> None:
+        worker = self._worker
+        self._worker = None
+        if worker is not None:
+            worker.deleteLater()

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -257,6 +257,7 @@ class ClaudeUsageWidget(BaseWidget):
             layout = self._menu_layout
             for frame in getattr(self, "_section_frames", []):
                 layout.removeWidget(frame)
+                frame.hide()
                 frame.deleteLater()
             self._add_menu_sections(layout)
             menu.adjustSize()
@@ -279,13 +280,13 @@ class ClaudeUsageWidget(BaseWidget):
         self._menu_layout = layout
 
         header = QFrame()
-        header.setProperty("class", "header")
+        header.setProperty("class", "header-row")
         header_layout = QHBoxLayout(header)
         header_layout.setContentsMargins(0, 0, 0, 0)
         header_layout.setSpacing(0)
 
         header_title = QLabel("Claude Usage")
-        header_title.setProperty("class", "header-title")
+        header_title.setProperty("class", "header")
         header_layout.addWidget(header_title)
         header_layout.addStretch()
 

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -20,7 +20,7 @@ _TOKEN_PERIODS: list[tuple[str, str]] = [
     ("month", "Month"),
     ("year", "Year"),
 ]
-_EMPTY_TOKEN_SUMMARY: dict[str, Any] = {"totals": {}, "series": [], "session_id": None}
+_EMPTY_TOKEN_SUMMARY: dict[str, Any] = {"totals": {}, "series_by_period": {}, "session_id": None}
 
 # Usage-level CSS classes (shared by the popup bars and the optional bar-percent colouring).
 _LEVEL_CLASSES = frozenset({"low", "medium", "high", "critical", "unknown"})
@@ -123,12 +123,7 @@ class ClaudeUsageWidget(BaseWidget):
 
     def _summarize_tokens(self, agg: dict[str, Any]) -> dict[str, Any]:
         th = self.config.token_history
-        return summarize(
-            agg,
-            count_cache_read=th.count_cache_read,
-            week_starts_on=th.week_starts_on,
-            graph_period=th.graph_period,
-        )
+        return summarize(agg, count_cache_read=th.count_cache_read, week_starts_on=th.week_starts_on)
 
     def _on_token_data(self, agg: dict[str, Any]) -> None:
         self._token_summary = self._summarize_tokens(agg)
@@ -141,7 +136,7 @@ class ClaudeUsageWidget(BaseWidget):
         if not isinstance(value, (int, float)):
             return "--"
         n = int(value)
-        for div, unit in ((1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K")):
+        for div, unit in ((1_000_000_000_000, "T"), (1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K")):
             if n >= div:
                 return f"{n / div:.1f}".rstrip("0").rstrip(".") + unit
         return str(n)
@@ -419,7 +414,7 @@ class ClaudeUsageWidget(BaseWidget):
                 btn.setProperty("class", "period-btn active" if active else "period-btn")
                 refresh_widget_style(btn)
             if self._token_graph is not None:
-                series = self._token_summary.get("series", [])
+                series = self._token_summary.get("series_by_period", {}).get(self._selected_period, [])
                 peak = max(series) if series else 0
                 self._token_graph.set_data([(v / peak * 100.0) if peak else 0.0 for v in series])
         except RuntimeError:

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -10,6 +10,9 @@ from core.validation.widgets.yasb.claude_usage import ClaudeUsageConfig
 from core.widgets.base import BaseWidget
 from core.widgets.services.claude_usage.claude_api import ClaudeUsageService
 
+# Usage-level CSS classes (shared by the popup bars and the optional bar-percent colouring).
+_LEVEL_CLASSES = frozenset({"low", "medium", "high", "critical", "unknown"})
+
 
 class UsageBar(QFrame):
     """A rounded progress bar drawn as a track QFrame with a child `.fill` QFrame.
@@ -190,13 +193,22 @@ class ClaudeUsageWidget(BaseWidget):
 
     @staticmethod
     def _level_class(value: Any) -> str:
+        """Usage band: low < 50 ≤ medium < 65 ≤ high < 80 ≤ critical (green/yellow/orange/red)."""
         if not isinstance(value, (int, float)):
             return "unknown"
         if value >= 80:
+            return "critical"
+        if value >= 65:
             return "high"
         if value >= 50:
             return "medium"
         return "low"
+
+    @staticmethod
+    def _apply_level_class(widget: QLabel, level: str) -> None:
+        """Set ``widget``'s usage level (low/medium/high) while keeping its base class."""
+        base = " ".join(t for t in (widget.property("class") or "label").split() if t not in _LEVEL_CLASSES)
+        widget.setProperty("class", f"{base} {level}")
 
     def _toggle_label(self) -> None:
         self._show_alt_label = not self._show_alt_label
@@ -230,6 +242,11 @@ class ClaudeUsageWidget(BaseWidget):
             # Hide empty labels so an unused placeholder (e.g. {stale} when the token is
             # valid) doesn't leave a constant gap from its margin/spacing.
             current_widget.setVisible(bool(rendered))
+            # Optionally colour the percentage by usage level (same thresholds as the bars).
+            if self.config.colorize_percent:
+                window = "five" if "{five_hour}" in part else "seven" if "{seven_day}" in part else None
+                if window is not None:
+                    self._apply_level_class(current_widget, self._level_class(self._data.get(window)))
             if self.config.tooltip:
                 tip = f"Claude usage — 5h: {values['five_hour']}% · 7d: {values['seven_day']}%"
                 if self._data.get("token_expired"):

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -151,9 +151,9 @@ class ClaudeUsageWidget(BaseWidget):
 
     @staticmethod
     def _fmt_weekday(iso: str | None, with_date: bool = False) -> str:
-        """Absolute reset as a local weekday + time, e.g. 'Sat 6:00 AM'; '--' when unknown.
+        """Absolute reset as a local weekday + time, e.g. 'Sat @ 6:00 AM'; '--' when unknown.
 
-        With ``with_date`` the month/day is included ('Sat, Jun 13 6:00 AM') so two windows
+        With ``with_date`` the month/day is included ('Sat, Jun 13 @ 6:00 AM') so two windows
         resetting on the same weekday can be told apart.
         """
         if not iso:
@@ -163,7 +163,7 @@ class ClaudeUsageWidget(BaseWidget):
             hour12 = local.hour % 12 or 12
             ampm = "AM" if local.hour < 12 else "PM"
             day = f"{local:%a, %b} {local.day}" if with_date else f"{local:%a}"
-            return f"{day} {hour12}:{local.minute:02d} {ampm}"
+            return f"{day} @ {hour12}:{local.minute:02d} {ampm}"
         except Exception:
             return "--"
 

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -2,8 +2,7 @@ import re
 from datetime import UTC, datetime
 from typing import Any
 
-from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QVBoxLayout
+from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QVBoxLayout
 
 from core.utils.tooltip import set_tooltip
 from core.utils.utilities import PopupWidget, refresh_widget_style
@@ -35,19 +34,6 @@ class UsageBar(QFrame):
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self._update_fill()
-
-
-class ClickableLabel(QLabel):
-    clicked = pyqtSignal()
-
-    def __init__(self, text: str, parent: QFrame | None = None):
-        super().__init__(text, parent)
-        self.setCursor(Qt.CursorShape.PointingHandCursor)
-
-    def mousePressEvent(self, event):
-        if event.button() == Qt.MouseButton.LeftButton:
-            self.clicked.emit()
-        super().mousePressEvent(event)
 
 
 class ClaudeUsageWidget(BaseWidget):
@@ -280,21 +266,21 @@ class ClaudeUsageWidget(BaseWidget):
         self._menu_layout = layout
 
         header = QFrame()
-        header.setProperty("class", "header-row")
+        header.setProperty("class", "header")
         header_layout = QHBoxLayout(header)
         header_layout.setContentsMargins(0, 0, 0, 0)
         header_layout.setSpacing(0)
 
-        header_title = QLabel("Claude Usage")
-        header_title.setProperty("class", "header")
-        header_layout.addWidget(header_title)
+        title_label = QLabel("Claude Usage")
+        title_label.setProperty("class", "text")
+        header_layout.addWidget(title_label)
         header_layout.addStretch()
 
-        refresh_button = ClickableLabel("\U000f0450")
-        refresh_button.setProperty("class", "refresh")
-        set_tooltip(refresh_button, "Refresh now")
-        refresh_button.clicked.connect(self._refresh)
-        header_layout.addWidget(refresh_button)
+        refresh_btn = QPushButton("\U000f0450")
+        refresh_btn.setProperty("class", "refresh")
+        set_tooltip(refresh_btn, "Refresh now")
+        refresh_btn.clicked.connect(self._refresh)
+        header_layout.addWidget(refresh_btn)
 
         layout.addWidget(header)
         self._add_menu_sections(layout)

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -85,12 +85,16 @@ class ClaudeUsageWidget(BaseWidget):
     def _refresh(self) -> None:
         self._service.refresh_now()
 
+    # Warning glyph (nf-fa-warning) shown via {stale} when the OAuth token has expired.
+    STALE_ICON = ""
+
     def _format_values(self) -> dict[str, str]:
         return {
             "five_hour": self._pct(self._data.get("five")),
             "seven_day": self._pct(self._data.get("seven")),
             "five_hour_reset": self._fmt_reset(self._data.get("five_reset_iso")),
             "seven_day_reset": self._fmt_reset(self._data.get("seven_reset_iso")),
+            "stale": self.STALE_ICON if self._data.get("token_expired") else "",
         }
 
     @staticmethod
@@ -168,17 +172,18 @@ class ClaudeUsageWidget(BaseWidget):
                 continue
             current_widget = active_widgets[index]
             if "<span" in part and "</span>" in part:
-                current_widget.setText(re.sub(r"<span.*?>|</span>", "", part).strip())
+                text = re.sub(r"<span.*?>|</span>", "", part).strip()
             else:
-                try:
-                    current_widget.setText(part.strip().format(**values))
-                except Exception:
-                    current_widget.setText(part.strip())
+                text = part.strip()
+            try:
+                current_widget.setText(text.format(**values))
+            except Exception:
+                current_widget.setText(text)
             if self.config.tooltip:
-                set_tooltip(
-                    current_widget,
-                    f"Claude usage — 5h: {values['five_hour']}% · 7d: {values['seven_day']}%",
-                )
+                tip = f"Claude usage — 5h: {values['five_hour']}% · 7d: {values['seven_day']}%"
+                if self._data.get("token_expired"):
+                    tip += "\nToken expired — run `claude -p` to refresh"
+                set_tooltip(current_widget, tip)
         refresh_widget_style(*active_widgets)
 
     def _toggle_menu(self) -> None:

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -4,11 +4,23 @@ from typing import Any
 
 from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QPushButton, QVBoxLayout
 
+from core.utils.stat_popup import GraphWidget
 from core.utils.tooltip import set_tooltip
 from core.utils.utilities import PopupWidget, refresh_widget_style
 from core.validation.widgets.yasb.claude_usage import ClaudeUsageConfig
 from core.widgets.base import BaseWidget
 from core.widgets.services.claude_usage.claude_api import ClaudeUsageService
+from core.widgets.services.claude_usage.token_history import TokenHistoryService, summarize
+
+# Popup period selector order for the token-history section.
+_TOKEN_PERIODS: list[tuple[str, str]] = [
+    ("session", "Session"),
+    ("today", "Today"),
+    ("week", "Week"),
+    ("month", "Month"),
+    ("year", "Year"),
+]
+_EMPTY_TOKEN_SUMMARY: dict[str, Any] = {"totals": {}, "series": [], "session_id": None}
 
 # Usage-level CSS classes (shared by the popup bars and the optional bar-percent colouring).
 _LEVEL_CLASSES = frozenset({"low", "medium", "high", "critical", "unknown"})
@@ -55,6 +67,17 @@ class ClaudeUsageWidget(BaseWidget):
         self._service = ClaudeUsageService.get_instance(self.config.update_interval, self.config.cache_ttl)
         self._data: dict[str, Any] = self._service.latest()
 
+        # Local token-history (optional): scans Claude Code's session transcripts.
+        self._token_service: TokenHistoryService | None = None
+        self._token_summary: dict[str, Any] = dict(_EMPTY_TOKEN_SUMMARY)
+        self._selected_period = self.config.token_history.default_period
+        self._period_buttons: dict[str, QPushButton] = {}
+        self._token_total_label: QLabel | None = None
+        self._token_graph: GraphWidget | None = None
+        if self.config.token_history.enabled:
+            self._token_service = TokenHistoryService.get_instance(self.config.token_history.scan_interval)
+            self._token_summary = self._summarize_tokens(self._token_service.latest())
+
         self._init_container()
         self.build_widget_label(self.config.label, self.config.label_alt)
 
@@ -67,6 +90,8 @@ class ClaudeUsageWidget(BaseWidget):
         self.callback_right = self.config.callbacks.on_right
 
         self._service.data_ready.connect(self._on_data)
+        if self._token_service is not None:
+            self._token_service.data_ready.connect(self._on_token_data)
         self.destroyed.connect(lambda *_: self._release_service())
         self._update_label()
 
@@ -78,6 +103,11 @@ class ClaudeUsageWidget(BaseWidget):
             self._service.release()
         except RuntimeError:
             pass
+        if self._token_service is not None:
+            try:
+                self._token_service.release()
+            except RuntimeError:
+                pass
 
     def closeEvent(self, event):
         self._release_service()
@@ -91,13 +121,44 @@ class ClaudeUsageWidget(BaseWidget):
     def _refresh(self) -> None:
         self._service.refresh_now()
 
+    def _summarize_tokens(self, agg: dict[str, Any]) -> dict[str, Any]:
+        th = self.config.token_history
+        return summarize(
+            agg,
+            count_cache_read=th.count_cache_read,
+            week_starts_on=th.week_starts_on,
+            graph_period=th.graph_period,
+        )
+
+    def _on_token_data(self, agg: dict[str, Any]) -> None:
+        self._token_summary = self._summarize_tokens(agg)
+        self._update_label()
+        self._sync_token_section()
+
+    @staticmethod
+    def _fmt_tokens(value: Any) -> str:
+        """Compact token count, e.g. '15K', '1.2M', '218M'; '--' when unknown."""
+        if not isinstance(value, (int, float)):
+            return "--"
+        n = int(value)
+        for div, unit in ((1_000_000_000, "B"), (1_000_000, "M"), (1_000, "K")):
+            if n >= div:
+                return f"{n / div:.1f}".rstrip("0").rstrip(".") + unit
+        return str(n)
+
     def _format_values(self) -> dict[str, str]:
+        totals = self._token_summary.get("totals", {})
         return {
             "five_hour": self._pct(self._data.get("five")),
             "seven_day": self._pct(self._data.get("seven")),
             "five_hour_reset": self._fmt_reset(self._data.get("five_reset_iso")),
             "seven_day_reset": self._fmt_reset(self._data.get("seven_reset_iso")),
             "stale": self.STALE_ICON if self._data.get("token_expired") else "",
+            "session_tokens": self._fmt_tokens(totals.get("session")),
+            "today_tokens": self._fmt_tokens(totals.get("today")),
+            "week_tokens": self._fmt_tokens(totals.get("week")),
+            "month_tokens": self._fmt_tokens(totals.get("month")),
+            "year_tokens": self._fmt_tokens(totals.get("year")),
         }
 
     @staticmethod
@@ -295,6 +356,78 @@ class ClaudeUsageWidget(BaseWidget):
 
         return frame
 
+    def _build_token_section(self) -> QFrame:
+        """A 'Tokens' section: a Session/Today/Week/Month/Year toggle, the selected
+        total, and (optionally) a daily-usage graph."""
+        th = self.config.token_history
+        frame = QFrame()
+        frame.setProperty("class", "section tokens")
+        layout = QVBoxLayout(frame)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        title_label = QLabel("Tokens")
+        title_label.setProperty("class", "title")
+        layout.addWidget(title_label)
+
+        toggle = QFrame()
+        toggle.setProperty("class", "period-toggle")
+        toggle_layout = QHBoxLayout(toggle)
+        toggle_layout.setContentsMargins(0, 0, 0, 0)
+        toggle_layout.setSpacing(0)
+        self._period_buttons = {}
+        for key, text in _TOKEN_PERIODS:
+            btn = QPushButton(text)
+            btn.setProperty("class", "period-btn")
+            btn.clicked.connect(lambda _=False, k=key: self._select_period(k))
+            toggle_layout.addWidget(btn)
+            self._period_buttons[key] = btn
+        layout.addWidget(toggle)
+
+        self._token_total_label = QLabel("--")
+        self._token_total_label.setProperty("class", "token-total")
+        layout.addWidget(self._token_total_label)
+
+        if th.show_graph:
+            graph_container = QFrame()
+            graph_container.setProperty("class", "graph-container")
+            graph_layout = QVBoxLayout(graph_container)
+            graph_layout.setContentsMargins(0, 0, 0, 0)
+            graph_layout.setSpacing(0)
+            self._token_graph = GraphWidget("token-graph", show_grid=th.show_graph_grid)
+            graph_layout.addWidget(self._token_graph)
+            layout.addWidget(graph_container)
+        else:
+            self._token_graph = None
+
+        self._sync_token_section()
+        return frame
+
+    def _select_period(self, period: str) -> None:
+        self._selected_period = period
+        self._sync_token_section()
+
+    def _sync_token_section(self) -> None:
+        """Refresh the token total, active toggle button, and graph in place."""
+        if self._token_total_label is None:
+            return
+        totals = self._token_summary.get("totals", {})
+        try:
+            self._token_total_label.setText(self._fmt_tokens(totals.get(self._selected_period)))
+            for key, btn in self._period_buttons.items():
+                active = key == self._selected_period
+                btn.setProperty("class", "period-btn active" if active else "period-btn")
+                refresh_widget_style(btn)
+            if self._token_graph is not None:
+                series = self._token_summary.get("series", [])
+                peak = max(series) if series else 0
+                self._token_graph.set_data([(v / peak * 100.0) if peak else 0.0 for v in series])
+        except RuntimeError:
+            # Popup (and its labels) was destroyed; references are stale until reopened.
+            self._token_total_label = None
+            self._token_graph = None
+            self._period_buttons = {}
+
     def _add_menu_sections(self, layout: QVBoxLayout) -> None:
         self._section_frames = [
             self._build_section(
@@ -312,6 +445,8 @@ class ClaudeUsageWidget(BaseWidget):
                 self.config.seven_day_reset_format,
             ),
         ]
+        if self.config.token_history.enabled:
+            self._section_frames.append(self._build_token_section())
         for frame in self._section_frames:
             layout.addWidget(frame)
 

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -167,9 +167,9 @@ class ClaudeUsageWidget(BaseWidget):
         except Exception:
             return "--"
 
-    def _reset_phrase(self, iso: str | None) -> str:
-        """Grammatical reset line for the popup, honoring ``reset_format``."""
-        if self.config.reset_format == "absolute":
+    def _reset_phrase(self, iso: str | None, reset_format: str) -> str:
+        """Grammatical reset line for the popup, honoring the window's ``reset_format``."""
+        if reset_format == "absolute":
             value = self._fmt_weekday(iso, with_date=self.config.reset_show_date)
             return f"Resets on {value}" if value != "--" else "Reset time unknown"
         value = self._fmt_duration(iso)
@@ -240,7 +240,7 @@ class ClaudeUsageWidget(BaseWidget):
     def _toggle_menu(self) -> None:
         self._build_menu()
 
-    def _build_section(self, title: str, value: Any, raw: Any, reset_iso: str | None) -> QFrame:
+    def _build_section(self, title: str, value: Any, raw: Any, reset_iso: str | None, reset_format: str) -> QFrame:
         level = self._level_class(value)
         frame = QFrame()
         frame.setProperty("class", "section")
@@ -261,7 +261,7 @@ class ClaudeUsageWidget(BaseWidget):
         footer_layout.setContentsMargins(0, 0, 0, 0)
         footer_layout.setSpacing(0)
 
-        reset_label = QLabel(self._reset_phrase(reset_iso))
+        reset_label = QLabel(self._reset_phrase(reset_iso, reset_format))
         reset_label.setProperty("class", "reset")
         footer_layout.addWidget(reset_label)
         footer_layout.addStretch()
@@ -281,10 +281,18 @@ class ClaudeUsageWidget(BaseWidget):
     def _add_menu_sections(self, layout: QVBoxLayout) -> None:
         self._section_frames = [
             self._build_section(
-                "5-Hour", self._data.get("five"), self._data.get("five_raw"), self._data.get("five_reset_iso")
+                "5-Hour",
+                self._data.get("five"),
+                self._data.get("five_raw"),
+                self._data.get("five_reset_iso"),
+                self.config.five_hour_reset_format,
             ),
             self._build_section(
-                "7-Day", self._data.get("seven"), self._data.get("seven_raw"), self._data.get("seven_reset_iso")
+                "7-Day",
+                self._data.get("seven"),
+                self._data.get("seven_raw"),
+                self._data.get("seven_reset_iso"),
+                self.config.seven_day_reset_format,
             ),
         ]
         for frame in self._section_frames:

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -39,6 +39,9 @@ class UsageBar(QFrame):
 class ClaudeUsageWidget(BaseWidget):
     validation_schema = ClaudeUsageConfig
 
+    # Warning glyph (nf-fa-warning) shown via {stale} when the OAuth token has expired.
+    STALE_ICON = ""
+
     def __init__(self, config: ClaudeUsageConfig):
         super().__init__(class_name="claude-usage")
         self.config = config
@@ -85,9 +88,6 @@ class ClaudeUsageWidget(BaseWidget):
     def _refresh(self) -> None:
         self._service.refresh_now()
 
-    # Warning glyph (nf-fa-warning) shown via {stale} when the OAuth token has expired.
-    STALE_ICON = ""
-
     def _format_values(self) -> dict[str, str]:
         return {
             "five_hour": self._pct(self._data.get("five")),
@@ -127,6 +127,48 @@ class ClaudeUsageWidget(BaseWidget):
             return f"{local:%a} {hour12}:{local.minute:02d} {ampm}"
         except Exception:
             return "--"
+
+    @staticmethod
+    def _fmt_duration(iso: str | None) -> str:
+        """Relative time-until-reset, e.g. '6d 21h', '4h 14m', '10m'; '--' when unknown."""
+        if not iso:
+            return "--"
+        try:
+            target = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+            seconds = int((target - datetime.now(UTC)).total_seconds())
+            if seconds <= 0:
+                return "0m"
+            minutes = seconds // 60
+            days, rem = divmod(minutes, 1440)
+            hours, mins = divmod(rem, 60)
+            if days:
+                return f"{days}d {hours}h"
+            if hours:
+                return f"{hours}h {mins}m"
+            return f"{mins}m"
+        except Exception:
+            return "--"
+
+    @staticmethod
+    def _fmt_weekday(iso: str | None) -> str:
+        """Absolute reset as a local weekday + time, e.g. 'Sat 6:00 AM'; '--' when unknown."""
+        if not iso:
+            return "--"
+        try:
+            local = datetime.fromisoformat(iso.replace("Z", "+00:00")).astimezone()
+            hour12 = local.hour % 12 or 12
+            ampm = "AM" if local.hour < 12 else "PM"
+            return f"{local:%a} {hour12}:{local.minute:02d} {ampm}"
+        except Exception:
+            return "--"
+
+    def _reset_phrase(self, iso: str | None) -> str:
+        """Grammatical reset line for the popup, honoring ``reset_format``."""
+        if self.config.reset_format == "absolute":
+            value = self._fmt_weekday(iso)
+            return f"Resets on {value}" if value != "--" else "Reset time unknown"
+        value = self._fmt_duration(iso)
+        return f"Resets in {value}" if value != "--" else "Reset time unknown"
 
     @staticmethod
     def _fmt_reset_at(iso: str | None) -> str:
@@ -176,9 +218,13 @@ class ClaudeUsageWidget(BaseWidget):
             else:
                 text = part.strip()
             try:
-                current_widget.setText(text.format(**values))
+                rendered = text.format(**values)
             except Exception:
-                current_widget.setText(text)
+                rendered = text
+            current_widget.setText(rendered)
+            # Hide empty labels so an unused placeholder (e.g. {stale} when the token is
+            # valid) doesn't leave a constant gap from its margin/spacing.
+            current_widget.setVisible(bool(rendered))
             if self.config.tooltip:
                 tip = f"Claude usage — 5h: {values['five_hour']}% · 7d: {values['seven_day']}%"
                 if self._data.get("token_expired"):
@@ -210,7 +256,7 @@ class ClaudeUsageWidget(BaseWidget):
         footer_layout.setContentsMargins(0, 0, 0, 0)
         footer_layout.setSpacing(0)
 
-        reset_label = QLabel(f"Resets in {self._fmt_reset(reset_iso)}")
+        reset_label = QLabel(self._reset_phrase(reset_iso))
         reset_label.setProperty("class", "reset")
         footer_layout.addWidget(reset_label)
         footer_layout.addStretch()

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -2,6 +2,7 @@ import re
 from datetime import UTC, datetime
 from typing import Any
 
+from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import QFrame, QHBoxLayout, QLabel, QVBoxLayout
 
 from core.utils.tooltip import set_tooltip
@@ -36,6 +37,19 @@ class UsageBar(QFrame):
         self._update_fill()
 
 
+class ClickableLabel(QLabel):
+    clicked = pyqtSignal()
+
+    def __init__(self, text: str, parent: QFrame | None = None):
+        super().__init__(text, parent)
+        self.setCursor(Qt.CursorShape.PointingHandCursor)
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self.clicked.emit()
+        super().mousePressEvent(event)
+
+
 class ClaudeUsageWidget(BaseWidget):
     validation_schema = ClaudeUsageConfig
 
@@ -54,6 +68,7 @@ class ClaudeUsageWidget(BaseWidget):
 
         self.register_callback("toggle_label", self._toggle_label)
         self.register_callback("toggle_menu", self._toggle_menu)
+        self.register_callback("refresh", self._refresh)
 
         self.callback_left = self.config.callbacks.on_left
         self.callback_middle = self.config.callbacks.on_middle
@@ -79,6 +94,10 @@ class ClaudeUsageWidget(BaseWidget):
     def _on_data(self, data: dict[str, Any]) -> None:
         self._data = data
         self._update_label()
+        self._refresh_menu_sections()
+
+    def _refresh(self) -> None:
+        self._service.refresh_now()
 
     def _format_values(self) -> dict[str, str]:
         return {
@@ -217,6 +236,33 @@ class ClaudeUsageWidget(BaseWidget):
 
         return frame
 
+    def _add_menu_sections(self, layout: QVBoxLayout) -> None:
+        self._section_frames = [
+            self._build_section(
+                "5-Hour", self._data.get("five"), self._data.get("five_raw"), self._data.get("five_reset_iso")
+            ),
+            self._build_section(
+                "7-Day", self._data.get("seven"), self._data.get("seven_raw"), self._data.get("seven_reset_iso")
+            ),
+        ]
+        for frame in self._section_frames:
+            layout.addWidget(frame)
+
+    def _refresh_menu_sections(self) -> None:
+        """Redraw the popup sections in place when fresh data arrives while it is open."""
+        menu = self._menu
+        try:
+            if menu is None or not menu.isVisible():
+                return
+            layout = self._menu_layout
+            for frame in getattr(self, "_section_frames", []):
+                layout.removeWidget(frame)
+                frame.deleteLater()
+            self._add_menu_sections(layout)
+            menu.adjustSize()
+        except RuntimeError:
+            self._menu = None  # popup was already destroyed
+
     def _build_menu(self) -> None:
         self._menu = PopupWidget(
             self,
@@ -230,21 +276,27 @@ class ClaudeUsageWidget(BaseWidget):
         layout = QVBoxLayout(self._menu)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
+        self._menu_layout = layout
 
-        header = QLabel("Claude Usage")
+        header = QFrame()
         header.setProperty("class", "header")
-        layout.addWidget(header)
+        header_layout = QHBoxLayout(header)
+        header_layout.setContentsMargins(0, 0, 0, 0)
+        header_layout.setSpacing(0)
 
-        layout.addWidget(
-            self._build_section(
-                "5-Hour", self._data.get("five"), self._data.get("five_raw"), self._data.get("five_reset_iso")
-            )
-        )
-        layout.addWidget(
-            self._build_section(
-                "7-Day", self._data.get("seven"), self._data.get("seven_raw"), self._data.get("seven_reset_iso")
-            )
-        )
+        header_title = QLabel("Claude Usage")
+        header_title.setProperty("class", "header-title")
+        header_layout.addWidget(header_title)
+        header_layout.addStretch()
+
+        refresh_button = ClickableLabel("\U000f0450")
+        refresh_button.setProperty("class", "refresh")
+        set_tooltip(refresh_button, "Refresh now")
+        refresh_button.clicked.connect(self._refresh)
+        header_layout.addWidget(refresh_button)
+
+        layout.addWidget(header)
+        self._add_menu_sections(layout)
 
         self._menu.adjustSize()
         self._menu.setPosition(

--- a/src/core/widgets/yasb/claude_usage.py
+++ b/src/core/widgets/yasb/claude_usage.py
@@ -150,22 +150,27 @@ class ClaudeUsageWidget(BaseWidget):
             return "--"
 
     @staticmethod
-    def _fmt_weekday(iso: str | None) -> str:
-        """Absolute reset as a local weekday + time, e.g. 'Sat 6:00 AM'; '--' when unknown."""
+    def _fmt_weekday(iso: str | None, with_date: bool = False) -> str:
+        """Absolute reset as a local weekday + time, e.g. 'Sat 6:00 AM'; '--' when unknown.
+
+        With ``with_date`` the month/day is included ('Sat, Jun 13 6:00 AM') so two windows
+        resetting on the same weekday can be told apart.
+        """
         if not iso:
             return "--"
         try:
             local = datetime.fromisoformat(iso.replace("Z", "+00:00")).astimezone()
             hour12 = local.hour % 12 or 12
             ampm = "AM" if local.hour < 12 else "PM"
-            return f"{local:%a} {hour12}:{local.minute:02d} {ampm}"
+            day = f"{local:%a, %b} {local.day}" if with_date else f"{local:%a}"
+            return f"{day} {hour12}:{local.minute:02d} {ampm}"
         except Exception:
             return "--"
 
     def _reset_phrase(self, iso: str | None) -> str:
         """Grammatical reset line for the popup, honoring ``reset_format``."""
         if self.config.reset_format == "absolute":
-            value = self._fmt_weekday(iso)
+            value = self._fmt_weekday(iso, with_date=self.config.reset_show_date)
             return f"Resets on {value}" if value != "--" else "Reset time unknown"
         value = self._fmt_duration(iso)
         return f"Resets in {value}" if value != "--" else "Reset time unknown"


### PR DESCRIPTION
## Summary

Adds an **optional** `token_history` feature to the Claude Usage widget: a **Tokens** section in the popup with a **Session / Today / Week / Month / Year** toggle, the selected period's total token count, and an optional usage graph — plus optional `{*_tokens}` bar placeholders. Inspired by [CodexBar](https://github.com/steipete/codexbar)'s usage view, but using the source that actually reflects Claude Code subscription usage.

The data comes from Claude Code's own local session transcripts (`~/.claude/projects/**/*.jsonl`) — **no API key, no network**. Only numeric token counts, timestamps, the model name and session id are read; **message content is never touched**. The scan is incremental (each file re-parsed only when its size/mtime changes) and runs off the UI thread in a refcounted shared service (`TokenHistoryService`), mirroring `ClaudeUsageService`.

### Why local JSONL (not the Admin API)
I evaluated Anthropic's Admin API (`/v1/organizations/cost_report` + `usage_report/messages`): it gives clean daily token/cost buckets but reports **Console pay-per-token billing**, which on a Pro/Max subscription is ~empty — it does not reflect Claude Code usage. The local transcripts are the only source that answers "how many tokens have I used in Claude Code," and they work for every user with no setup.

## Highlights
- **Tokens section**: period toggle, compact total (`15K`/`1.2M`/`218M`/`3.4B`/`1T`), reusing the existing menu styling.
- **Graph** (optional, `show_graph`): reuses the shared `GraphWidget` (the CPU/Memory/GPU chart). The window matches the selected period — Today/Session hourly, Week/Month daily, Year monthly.
- **Bar placeholders**: `{session_tokens}` `{today_tokens}` `{week_tokens}` `{month_tokens}` `{year_tokens}`.
- **Config** (`ClaudeTokenHistoryConfig`, all off by default): `enabled`, `default_period`, `show_graph`, `show_graph_grid`, `week_starts_on`, `count_cache_read`, `scan_interval`.
- Docs updated in `docs/`.

> **Note:** Session = the most-recent session's whole lifetime (can span days), so it may exceed Today. Totals are cache-read-heavy by default (cache reads dominate); set `count_cache_read: false` for "new work only."

## Stacking
This is **stacked on #967** (it builds on that widget's menu work). The token-history changes are commits `efe9473` and `87826c4`; the earlier commits in the diff are #967 and will drop out once #967 merges (I'll rebase). Happy to reorder if you'd prefer I wait for #967 first.

## Testing
- Unit tests: period boundaries, incremental re-read, session detection, `count_cache_read`, per-period series (hourly/daily/monthly), compact formatting.
- Verified against a real install (154 transcripts) and offscreen Qt (toggle switches totals + graph; placeholders resolve).
- `ruff check`/`format` clean (the pre-existing `UP038` isinstance warnings are untouched).
- `schema.json` intentionally not regenerated (left for the usual maintainer chore commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)