### PR TITLE
feat(open-meteo): add configurable forecast_days option

### DIFF
--- a/docs/widgets/(Widget)-Open-Meteo.md
+++ b/docs/widgets/(Widget)-Open-Meteo.md
@@ -9,6 +9,7 @@
 | `update_interval`  | integer | `3600`                                                                             | The interval in seconds to update the weather data. Must be between 60 and 36000000.            |
 | `hide_decimal`     | boolean | `false`                                                                            | Whether to hide the decimal part of the temperature.                                            |
 | `units`            | string  | `'metric'`                                                                         | The units for the weather data. Can be `'metric'` or `'imperial'`.                              |
+| `forecast_days`    | integer | `7`                                                                                | Number of days to fetch and display in the forecast popup. Must be between 1 and 14.            |
 | `icons`            | dict    | See [icons section](#icons)                                                        | A dictionary of icons for different weather conditions.                                         |
 | `callbacks`        | dict    | `{ 'on_left': 'do_nothing', 'on_middle': 'do_nothing', 'on_right': 'do_nothing' }` | Callbacks for mouse events on the weather widget.                                               |
 | `weather_card`     | dict    | [See below](#advanced-configuration)                                               | Configuration for the weather card popup display.                                               |
@@ -92,6 +93,7 @@ open_meteo:
     update_interval: 600
     hide_decimal: true
     units: "metric"
+    forecast_days: 7
     callbacks:
       on_left: "toggle_card"
       on_middle: "do_nothing"
@@ -110,6 +112,7 @@ open_meteo:
     update_interval: 600
     hide_decimal: true
     units: "metric"
+    forecast_days: 7
     callbacks:
       on_left: "toggle_card"
       on_middle: "do_nothing"
@@ -175,6 +178,7 @@ open_meteo:
 - **hide_decimal:** Whether to hide the decimal part of the temperature.
 - **tooltip:** Whether to show a tooltip with the min/max temperatures and precipitation info.
 - **units:** The units for the weather data. Can be `'metric'` (°C, km/h) or `'imperial'` (°F, mph).
+- **forecast_days:** Number of days to fetch from the Open-Meteo API and show in the forecast popup. Must be between `1` and `14`. Defaults to `7`.
 - **icons:** A dictionary of icons for different weather conditions. The icon keys are mapped from WMO weather codes. See [Icons](#icons) for the full list.
 - **weather_card:** Configuration for the weather card popup display.
   - **blur:** Enable blur effect for the weather card.
@@ -227,12 +231,12 @@ The location is stored in `%LOCALAPPDATA%/YASB/weather.json`. Each widget instan
 
 To change the location, click on the **location name / current temperature** displayed at the very top of the weather card. This will reset the widget and show the location search dialog again.
 
-## 7-Day Forecast Card
+## Forecast Card
 
 The weather card shows:
 
 - **Current conditions**: Location, temperature, feels-like, humidity, pressure, cloud cover, wind, precipitation, UV index
-- **7-day forecast row**: Day name, weather icon, min/max temperature for each day
+- **Forecast row**: Day name, weather icon, min/max temperature for each day (1–14 days, controlled by `forecast_days`)
 - **Hourly chart** (if `show_hourly_forecast` is enabled): Temperature curve, rain/snow toggle, weather icons, wind speed
 - Clicking a day in the forecast row switches the hourly chart to that day's data
 

--- a/src/core/validation/widgets/yasb/open_meteo.py
+++ b/src/core/validation/widgets/yasb/open_meteo.py
@@ -81,6 +81,7 @@ class OpenMeteoWidgetConfig(CustomBaseModel):
     update_interval: int = Field(default=3600, ge=60, le=36000000)
     hide_decimal: bool = False
     units: Literal["metric", "imperial"] = "metric"
+    forecast_days: int = Field(default=7, ge=1, le=14)
     tooltip: bool = True
     icons: OpenMeteoIconsConfig = OpenMeteoIconsConfig()
     weather_card: OpenMeteoCardConfig = OpenMeteoCardConfig()

--- a/src/core/widgets/services/open_meteo/api.py
+++ b/src/core/widgets/services/open_meteo/api.py
@@ -48,6 +48,7 @@ class OpenMeteoDataFetcher(QObject):
         longitude: float,
         timeout: int,
         units: str = "metric",
+        forecast_days: int = 7,
     ):
         super().__init__(parent)
         self.started = False
@@ -69,7 +70,7 @@ class OpenMeteoDataFetcher(QObject):
             f"&daily={DAILY_VARS}"
             f"&current={CURRENT_VARS}"
             f"&timezone=auto"
-            f"&forecast_days=7"
+            f"&forecast_days={forecast_days}"
             f"&temperature_unit={temp_unit}"
             f"&wind_speed_unit={wind_unit}"
         )

--- a/src/core/widgets/yasb/open_meteo.py
+++ b/src/core/widgets/yasb/open_meteo.py
@@ -60,7 +60,7 @@ class OpenMeteoWidget(BaseWidget):
         # Weather state
         self._weather_data: dict[str, Any] | None = None
         self._has_valid_weather_data = False
-        self._hourly_data: list[list[dict[str, Any]]] = [[] for _ in range(7)]
+        self._hourly_data: list[list[dict[str, Any]]] = [[] for _ in range(self.config.forecast_days)]
         self._current_time: datetime | None = None
         self._show_alt_label = False
         self._weather_card_daily_widgets: list[ClickableWidget] = []
@@ -114,7 +114,8 @@ class OpenMeteoWidget(BaseWidget):
             if cached_data:
                 time_diff_ms = int(time.time() * 1000) - last_updated_ms
                 update_interval_ms = self.config.update_interval * 1000
-                is_cache_valid = time_diff_ms < update_interval_ms
+                cached_days = len(cached_data.get("daily", {}).get("time", []))
+                is_cache_valid = time_diff_ms < update_interval_ms and cached_days >= self.config.forecast_days
 
                 # Load the cached data instantly to prevent "weather loading..." flash
                 try:
@@ -154,6 +155,7 @@ class OpenMeteoWidget(BaseWidget):
             longitude=self._location_data["longitude"],
             timeout=self.config.update_interval * 1000,
             units=self.config.units,
+            forecast_days=self.config.forecast_days,
         )
         OpenMeteoWidget._shared_fetchers[self._widget_id] = fetcher
         fetcher.finished.connect(self._on_shared_weather_data)
@@ -471,9 +473,10 @@ class OpenMeteoWidget(BaseWidget):
         @pyqtSlot(int)
         def switch_hourly_data(day_idx: int):
             if day_idx == 0:
-                combined = self._hourly_data[0] + self._hourly_data[1]
+                next_day_data = self._hourly_data[1] if len(self._hourly_data) > 1 else []
+                combined = self._hourly_data[0] + next_day_data
                 current_time = self._current_time
-            elif 0 < day_idx < 7:
+            elif 0 < day_idx < self.config.forecast_days:
                 combined = self._hourly_data[day_idx]
                 current_time = None
             else:
@@ -504,7 +507,7 @@ class OpenMeteoWidget(BaseWidget):
 
         day_widgets: list[QWidget] = []
         self._weather_card_daily_widgets = []
-        for i in range(7):
+        for i in range(self.config.forecast_days):
             frame_day = ClickableWidget()
             self._weather_card_daily_widgets.append(frame_day)
             if self._hourly_data[0] and self.config.weather_card.show_hourly_forecast:
@@ -605,7 +608,7 @@ class OpenMeteoWidget(BaseWidget):
             instance._weather_data = None
             instance._has_valid_weather_data = False
             instance._location_data = None
-            instance._hourly_data = [[] for _ in range(7)]
+            instance._hourly_data = [[] for _ in range(instance.config.forecast_days)]
             instance._current_time = None
             for widget in instance._widgets + instance._widgets_alt:
                 if widget.property("class") and "icon" in (widget.property("class") or ""):
@@ -722,7 +725,7 @@ class OpenMeteoWidget(BaseWidget):
             daily_sunrise = daily.get("sunrise", [])
             daily_sunset = daily.get("sunset", [])
 
-            for day_idx in range(7):
+            for day_idx in range(self.config.forecast_days):
                 start = day_idx * 24
                 end = start + 24
                 day_hourly: list[dict[str, Any]] = []
@@ -833,7 +836,7 @@ class OpenMeteoWidget(BaseWidget):
             }
 
             # Per-day forecast data
-            for i in range(7):
+            for i in range(self.config.forecast_days):
                 if i < len(daily_times):
                     date_obj = datetime.strptime(daily_times[i], "%Y-%m-%d")
                     day_name = date_obj.strftime("%B %d")
@@ -881,7 +884,7 @@ class OpenMeteoWidget(BaseWidget):
                     "{cloud}": "N/A",
                     "{feelslike}": "N/A",
                 }
-                for i in range(7):
+                for i in range(self.config.forecast_days):
                     self._weather_data[f"{{day{i}_name}}"] = "N/A"
                     self._weather_data[f"{{day{i}_min_temp}}"] = "N/A"
                     self._weather_data[f"{{day{i}_max_temp}}"] = "N/A"

--- a/src/core/widgets/yasb/volume.py
+++ b/src/core/widgets/yasb/volume.py
@@ -532,7 +532,13 @@ class VolumeWidget(BaseWidget):
         widget_index = 0
 
         if self.volume is None:
-            fallback_icon = next(iter(self.config.icons.values())) if isinstance(self.config.icons, dict) else self.config.icons[0] if self.config.icons else ""
+            fallback_icon = (
+                next(iter(self.config.icons.values()))
+                if isinstance(self.config.icons, dict)
+                else self.config.icons[0]
+                if self.config.icons
+                else ""
+            )
             mute_status, icon_volume, level_volume = None, fallback_icon, "No Device"
             set_tooltip(self, "No audio device connected.")
         else:


### PR DESCRIPTION
- Add forecast_days option (1-14, default 7) to widget config
- Pass forecast_days to API fetcher so correct number of days is requested
- Invalidate cache when cached data covers fewer days than configured
- Update docs with new option, valid range and examples