### PR TITLE
feat(scroll): add invert_wheel option

### DIFF
--- a/docs/widgets/(Widget)-Brightness.md
+++ b/docs/widgets/(Widget)-Brightness.md
@@ -8,6 +8,7 @@ Displays your screen's brightness level and lets you adjust it on the fly. You c
 | `label_alt`     | string  | `"Brightness {percent}%"`                                          | The alternative format string for the brightness widget. |
 | `tooltip`  | boolean  | `True`        | Whether to show the tooltip on hover. |
 | `scroll_step`   | integer | `1`                                                                       | The step size for scrolling the brightness level. This value must be between 1 and 100. |
+| `invert_wheel`     | boolean     | `false`                  | Whether to invert wheel scroll direction (useful on laptop trackpads) |
 | `brightness_icons` | list  | `['\udb80\udcde', '\udb80\udcdd', '\udb80\udcdf', '\udb80\udce0']`                    | A list of icons representing different brightness levels. The icons are used based on the current brightness percentage. |
 | `hide_unsupported` | boolean | `True` | Whether to hide the widget if the current system does not support brightness control. |
 | `brightness_toggle_level` | list | `[0, 50, 100]` | The brightness levels to cycle through when the widget is clicked. |

--- a/docs/widgets/(Widget)-Microphone.md
+++ b/docs/widgets/(Widget)-Microphone.md
@@ -10,6 +10,7 @@ Shows your microphone volume and mute status. You can adjust the recording level
 | `mute_text` | string  | `'mute'` | Text used by `{level}` to indicate muted volume |
 | `tooltip`  | boolean  | `true`        | Whether to show the tooltip on hover. |
 | `scroll_step`     | int     | `2`                  | The step size for volume adjustment when scrolling. The value is in percentage points (0-100). |
+| `invert_wheel`     | boolean     | `false`                  | Whether to invert wheel scroll direction (useful on laptop trackpads) |
 | `icons`       | dict    | `{'normal': '\uf130', 'muted': '\uf131'}` | Icons for microphone widget |
 | `callbacks`       | dict    | `{'on_left': 'toggle_mute', 'on_middle': 'toggle_label', 'on_right': 'do_nothing'}` | Callbacks for mouse events on the memory widget. |
 | `mic_menu` | dict | `{'blur': True, 'round_corners': True, 'round_corners_type': 'normal', 'border_color': 'system', 'alignment': 'right', 'direction': 'down', 'offset_top': 6, 'offset_left': 0}` | Menu settings for the widget. |

--- a/docs/widgets/(Widget)-Volume.md
+++ b/docs/widgets/(Widget)-Volume.md
@@ -8,6 +8,7 @@ Displays your speaker volume and mute status. You can adjust the volume by scrol
 | `label_alt`  | string | `'{level}'`                                                             | The alternative format string for the volume label. Useful for displaying additional volume details. |
 | `class_name`      | string | `""`                                                                                  | Additional CSS class name for the widget.                                    |
 | `scroll_step`     | int     | `2`                  | The step size for volume adjustment when scrolling. The value is in percentage points (0-100). |
+| `invert_wheel`     | boolean     | `false`                  | Whether to invert wheel scroll direction (useful on laptop trackpads) |
 | `slider_beep`   | boolean | `true`              | Whether to play a sound when the volume slider is released. |
 | `mute_text` | string  | `'mute'` | Text used by `{level}` to indicate muted volume |
 | `tooltip`  | boolean  | `true`        | Whether to show the tooltip on hover. |

--- a/src/core/validation/widgets/yasb/brightness.py
+++ b/src/core/validation/widgets/yasb/brightness.py
@@ -44,6 +44,7 @@ class BrightnessConfig(CustomBaseModel):
     label_alt: str = "Brightness {percent}%"
     tooltip: bool = True
     scroll_step: int = Field(default=1, ge=1, le=100)
+    invert_wheel: bool = False
     brightness_icons: list[str] = [
         "\udb80\udcde",  # Icon for 0-25% brightness
         "\udb80\udcdd",  # Icon for 26-50% brightness

--- a/src/core/validation/widgets/yasb/microphone.py
+++ b/src/core/validation/widgets/yasb/microphone.py
@@ -50,6 +50,7 @@ class MicrophoneConfig(CustomBaseModel):
     mute_text: str = "mute"
     tooltip: bool = True
     scroll_step: int = Field(default=2, ge=1, le=100)
+    invert_wheel: bool = False
     icons: IconsConfig = IconsConfig()
     mic_menu: MicMenuConfig = MicMenuConfig()
     progress_bar: ProgressBarConfig = ProgressBarConfig()

--- a/src/core/validation/widgets/yasb/volume.py
+++ b/src/core/validation/widgets/yasb/volume.py
@@ -54,6 +54,7 @@ class VolumeConfig(CustomBaseModel):
     mute_text: str = "mute"
     tooltip: bool = True
     scroll_step: int = Field(default=2, ge=1, le=100)
+    invert_wheel: bool = False
     slider_beep: bool = True
     # Support both list and dict for backward compatibility.
     icons: list[str] | dict[str, str] = {

--- a/src/core/widgets/yasb/brightness.py
+++ b/src/core/widgets/yasb/brightness.py
@@ -412,7 +412,8 @@ class BrightnessWidget(BaseWidget):
         if current is None:
             return
 
-        if a0.angleDelta().y() > 0:
+        delta = -a0.angleDelta().y() if self.config.invert_wheel else a0.angleDelta().y()
+        if delta > 0:
             new_value = min(current + self.config.scroll_step, 100)
         else:
             new_value = max(current - self.config.scroll_step, 0)

--- a/src/core/widgets/yasb/microphone.py
+++ b/src/core/widgets/yasb/microphone.py
@@ -369,5 +369,7 @@ class MicrophoneWidget(BaseWidget):
                 # Show tooltip while actively dragging
                 if hasattr(self, "volume_slider"):
                     self._show_slider_tooltip(self.volume_slider, value)
+                if (self.audio_endpoint.GetMute() != 0) != (value == 0):
+                    self.toggle_mute()
             except Exception as e:
                 logging.error("Failed to set microphone volume: %s", e)

--- a/src/core/widgets/yasb/microphone.py
+++ b/src/core/widgets/yasb/microphone.py
@@ -252,9 +252,10 @@ class MicrophoneWidget(BaseWidget):
     def wheelEvent(self, event: QWheelEvent):
         if self.audio_endpoint is None:
             return
-        if event.angleDelta().y() > 0:
+        delta = -event.angleDelta().y() if self.config.invert_wheel else event.angleDelta().y()
+        if delta > 0:
             self._increase_volume()
-        elif event.angleDelta().y() < 0:
+        elif delta < 0:
             self._decrease_volume()
 
     def show_menu(self):

--- a/src/core/widgets/yasb/volume.py
+++ b/src/core/widgets/yasb/volume.py
@@ -123,6 +123,8 @@ class VolumeWidget(BaseWidget):
                 # Show tooltip while actively dragging
                 if hasattr(self, "volume_slider"):
                     self._show_slider_tooltip(self.volume_slider, value)
+                if (self.volume.GetMute() != 0) != (value == 0):
+                    self.toggle_mute()
             except Exception as e:
                 logging.error("Failed to set volume: %s", e)
 

--- a/src/core/widgets/yasb/volume.py
+++ b/src/core/widgets/yasb/volume.py
@@ -665,9 +665,10 @@ class VolumeWidget(BaseWidget):
     def wheelEvent(self, event: QWheelEvent):
         if self.volume is None:
             return
-        if event.angleDelta().y() > 0:
+        delta = -event.angleDelta().y() if self.config.invert_wheel else event.angleDelta().y()
+        if delta > 0:
             self._increase_volume()
-        elif event.angleDelta().y() < 0:
+        elif delta < 0:
             self._decrease_volume()
 
     def toggle_mute(self):


### PR DESCRIPTION
This is useful for laptop trackpads (when scrolling with 2 fingers on the pad) as moving your fingers up actually scrolls down however i think its more intuitive to move fingers up to increase volume. 

I can implement this for all the other widgets that have a system like this (brightness, mic i think?) but i would like to know whether this is something you want before i put further work in this. if so please give me a list of all widgets that have something like this (since i am not that familiar with the widgets other than the ones i use)

the slider in the drop down menu doesn't have their behaivour changed in the pr since qt widgets only supports inverting all inputs, so also arrow keys which we don't want to invert. however that can be added in the future if that change is PRd to QT (i might do that if i have some time)