### PR TITLE
feat(media): resolve sources dynamically and keep popup persistent

### DIFF
--- a/docs/widgets/(Widget)-Media.md
+++ b/docs/widgets/(Widget)-Media.md
@@ -75,7 +75,9 @@ media:
       thumbnail_size: 120
       max_title_size: 60
       max_artist_size: 20
+      max_source_size: 16
       show_source: true
+      show_volume_slider: true
     media_menu_icons:
       play: "\ue768"
       pause: "\ue769"
@@ -108,7 +110,8 @@ media:
       thumbnail_size: 120          # The size of the thumbnail in the popup.
       max_title_size: 60           # The maximum size for the title in the popup.
       max_artist_size: 20          # The maximum size for the artist name in the popup.
-      show_source: true            # Whether to show the media source (e.g., Spotify, YouTube) in the popup.
+      max_source_size: 16          # The maximum size for the source app name in the popup.
+      show_source: true            # Whether to show the media source app name in the popup (resolved from OS/app metadata).
       show_volume_slider: false    # Whether to show the volume slider in the popup. Volume control per application.
 ```
 
@@ -147,7 +150,7 @@ media:
 - `toggle_label`: Toggles the visibility of the label.
 - `toggle_play_pause`: Toggles between play and pause states.
 - `toggle_media_menu`: Toggles the visibility of the media menu popup.
-- `open_media_source`: Opens the the source that is playing the media.
+- `open_media_source`: Opens the source that is playing the media.
 - `do_nothing`: A placeholder callback that does nothing when triggered.
 
 ## Description of Options
@@ -188,7 +191,8 @@ media:
   - **thumbnail_size:** The size of the thumbnail in the popup.
   - **max_title_size:** The maximum size for the title in the popup.
   - **max_artist_size:** The maximum size for the artist name in the popup.
-  - **show_source:** Whether to show the media source (e.g., Spotify, FireFox) in the popup.
+  - **max_source_size:** The maximum size for the source app name in the popup.
+  - **show_source:** Whether to show the media source in the popup. The name is resolved from Windows/app metadata (e.g. Spotify, Firefox).
   - **show_volume_slider:** Whether to show the volume slider in the popup. Volume control per application.
 - **media_menu_icons:** A dictionary specifying the icons for the media menu popup. It contains
   - **play:** Icon for the play button in the popup.

--- a/src/core/utils/win32/aumid.py
+++ b/src/core/utils/win32/aumid.py
@@ -8,7 +8,8 @@ import ctypes
 import ctypes.wintypes as wt
 from ctypes import POINTER, WINFUNCTYPE, byref, c_void_p
 
-from core.utils.win32.constants import PROCESS_QUERY_LIMITED_INFORMATION
+from core.utils.win32.constants import PROCESS_QUERY_LIMITED_INFORMATION, TH32CS_SNAPPROCESS
+from core.utils.win32.structs import PROCESSENTRY32
 
 
 class GUID(ctypes.Structure):
@@ -254,16 +255,54 @@ def get_aumid_from_shortcut(shortcut_path: str) -> str | None:
             pass
     return aumid
 
-    return aumid
+
+def _pids_for_exe_tree(process_name: str) -> set[int]:
+    """PIDs whose exe basename matches process_name, plus all descendants.
+
+    Covers portable/Squirrel apps where the launcher holds the AUMID but the
+    UI window lives on a child process with a different exe name.
+    """
+    target = process_name.lower()
+    children: dict[int, list[int]] = {}
+    roots: set[int] = set()
+
+    h_snap = kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+    if h_snap == wt.HANDLE(-1).value:
+        return set()
+    try:
+        pe = PROCESSENTRY32()
+        pe.dwSize = ctypes.sizeof(PROCESSENTRY32)
+        if not kernel32.Process32FirstW(h_snap, byref(pe)):
+            return set()
+        while True:
+            pid = pe.th32ProcessID
+            children.setdefault(pe.th32ParentProcessID, []).append(pid)
+            if pe.szExeFile and pe.szExeFile.lower() == target:
+                roots.add(pid)
+            if not kernel32.Process32NextW(h_snap, byref(pe)):
+                break
+    finally:
+        CloseHandle(h_snap)
+
+    result: set[int] = set()
+    stack = list(roots)
+    while stack:
+        pid = stack.pop()
+        if pid in result:
+            continue
+        result.add(pid)
+        stack.extend(children.get(pid, []))
+    return result
 
 
 def activate_app_by_aumid(aumid: str, fallback_process_name: str | None = None) -> bool:
     """
-    Find and activate validity window for the given AUMID.
+    Find and activate a window for the given AUMID.
 
     Args:
         aumid: The App User Model ID to find.
         fallback_process_name: Optional process name (e.g. "firefox.exe") to match if AUMID fails.
+            Also matches descendant processes (portable Electron launchers).
 
     Returns:
         True if a window was found and activation was attempted, False otherwise.
@@ -271,52 +310,36 @@ def activate_app_by_aumid(aumid: str, fallback_process_name: str | None = None) 
     from core.utils.win32.window_actions import force_foreground_focus, restore_window
 
     found_hwnd = None
+    fallback_pids = _pids_for_exe_tree(fallback_process_name) if fallback_process_name else set()
 
     WNDENUMPROC = ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
 
     def enum_window_callback(hwnd, _):
         nonlocal found_hwnd
-        if user32.IsWindowVisible(hwnd):
-            # 1. Try exact AUMID match
-            curr_aumid = get_aumid_for_window(hwnd)
-            if curr_aumid == aumid:
-                found_hwnd = hwnd
-                return False  # Stop enumeration
+        if not user32.IsWindowVisible(hwnd):
+            return True
 
-            # 2. Fallback: Try process name match if provided
-            if fallback_process_name:
-                pid = wt.DWORD(0)
-                GetWindowThreadProcessId(wt.HWND(hwnd), byref(pid))
-                if pid.value:
-                    # We need to open the process to get its image name
-                    # PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-                    hProcess = OpenProcess(0x1000, False, pid.value)
-                    if hProcess:
-                        try:
-                            buf = ctypes.create_unicode_buffer(1024)
-                            size = wt.DWORD(1024)
-                            # QueryFullProcessImageNameW is in kernel32
-                            if hasattr(kernel32, "QueryFullProcessImageNameW"):
-                                if kernel32.QueryFullProcessImageNameW(hProcess, 0, buf, byref(size)):
-                                    full_path = buf.value
-                                    if full_path.lower().endswith(fallback_process_name.lower()):
-                                        found_hwnd = hwnd
-                                        return False
-                        finally:
-                            CloseHandle(hProcess)
+        # Exact AUMID match
+        if get_aumid_for_window(hwnd) == aumid:
+            found_hwnd = hwnd
+            return False
+
+        # Fallback: process (or descendant) match; skip untitled helpers
+        if fallback_pids:
+            pid = wt.DWORD(0)
+            GetWindowThreadProcessId(wt.HWND(hwnd), byref(pid))
+            if pid.value in fallback_pids and user32.GetWindowTextLengthW(hwnd) > 0:
+                found_hwnd = hwnd
+                return False
 
         return True
 
     user32.EnumWindows(WNDENUMPROC(enum_window_callback), 0)
 
     if found_hwnd:
-        # 1. Force Focus (helps switch workspace)
         force_foreground_focus(found_hwnd)
-
-        # 2. Restore if minimized (now that it's potentially active/on current workspace)
         if user32.IsIconic(found_hwnd):
             restore_window(found_hwnd)
-
         return True
 
     return False

--- a/src/core/validation/widgets/yasb/media.py
+++ b/src/core/validation/widgets/yasb/media.py
@@ -38,6 +38,7 @@ class MediaMenuConfig(CustomBaseModel):
     thumbnail_corner_radius: int = 8
     max_title_size: int = 150
     max_artist_size: int = 40
+    max_source_size: int = 16
     show_source: bool = True
     show_volume_slider: bool = False
 

--- a/src/core/widgets/services/control_center/sections/media.py
+++ b/src/core/widgets/services/control_center/sections/media.py
@@ -163,6 +163,7 @@ class MediaSectionWidget(QFrame):
                 self._current_title = ""
                 self._current_artist = ""
                 self._current_is_playing = None
+                self._cached_thumb = None
                 self.hide()
             return
 
@@ -173,17 +174,23 @@ class MediaSectionWidget(QFrame):
         session_changed = app_id != self._current_app_id
         self._current_app_id = app_id
 
-        title = session.title or "Unknown Title"
-        artist = session.artist or "Unknown Artist"
-        if title != self._current_title:
-            self._current_title = title
-            self._title_label.setText(title)
-        if artist != self._current_artist:
-            self._current_artist = artist
-            self._artist_label.setText(artist)
+        # Keep last painted title/artist/art while SMTC blips empty on same session.
+        if session.title:
+            self._current_title = session.title
+        elif session_changed:
+            self._current_title = ""
+        if session.artist:
+            self._current_artist = session.artist
+        elif session_changed:
+            self._current_artist = ""
 
-        if session_changed or force_thumbnail:
+        self._title_label.setText(self._current_title or "Unknown Title")
+        self._artist_label.setText(self._current_artist or "Unknown Artist")
+
+        if session.thumbnail is not None:
             self._apply_thumbnail(session.thumbnail)
+        elif session_changed or force_thumbnail:
+            self._apply_thumbnail(None)
 
         self._update_controls_from(session)
 

--- a/src/core/widgets/services/media/aumid_process.py
+++ b/src/core/widgets/services/media/aumid_process.py
@@ -5,16 +5,18 @@ Lookup process executable name from an AppUserModelID (AUMID).
 import ctypes
 import ctypes.wintypes as wt
 import os
-import re
 from ctypes import POINTER, byref, c_void_p
 
+import win32gui
+import win32process
+from win32com.client import Dispatch
+
+from core.utils.win32.aumid import get_aumid_for_window
 from core.utils.win32.constants import PROCESS_QUERY_LIMITED_INFORMATION, TH32CS_SNAPPROCESS
 from core.utils.win32.structs import PROCESSENTRY32
 
-# Constants and API bindings
 kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
 
-# Toolhelp snapshot
 CreateToolhelp32Snapshot = kernel32.CreateToolhelp32Snapshot
 CreateToolhelp32Snapshot.argtypes = [wt.DWORD, wt.DWORD]
 CreateToolhelp32Snapshot.restype = wt.HANDLE
@@ -35,11 +37,8 @@ OpenProcess = kernel32.OpenProcess
 OpenProcess.argtypes = [wt.DWORD, wt.BOOL, wt.DWORD]
 OpenProcess.restype = wt.HANDLE
 
-# Constants
 ERROR_INSUFFICIENT_BUFFER = 0x7A
 
-
-# GetApplicationUserModelId may be in kernel32 or shell32
 GetApplicationUserModelId = None
 for dll_name in ("kernel32", "shell32"):
     try:
@@ -51,6 +50,9 @@ for dll_name in ("kernel32", "shell32"):
         break
     except OSError:
         continue
+
+# AUMID -> (app_display_name, process_exe); negative results cached too.
+_shell_app_cache: dict[str, tuple[str | None, str | None]] = {}
 
 
 def _enum_processes():
@@ -64,64 +66,11 @@ def _enum_processes():
         if not Process32First(hSnap, ctypes.byref(pe)):
             return
         while True:
-            pid = pe.th32ProcessID
-            exe = pe.szExeFile
-            yield pid, exe
+            yield pe.th32ProcessID, pe.szExeFile
             if not Process32Next(hSnap, ctypes.byref(pe)):
                 break
     finally:
         CloseHandle(hSnap)
-
-
-def get_process_name_for_aumid(aumid: str) -> str | None:
-    """Return process executable base name for the first process whose
-    GetApplicationUserModelId() matches the provided `aumid`.
-
-    Returns None if not found.
-    """
-    if not aumid:
-        return None
-
-    # Classic Win32 players, SMTC often reports the exe name as AUMID.
-    if aumid.lower().endswith(".exe"):
-        return os.path.basename(aumid)
-
-    if GetApplicationUserModelId is None:
-        return None
-
-    for pid, exe in _enum_processes():
-        hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
-        if not hProc:
-            continue
-        try:
-            length = ctypes.c_uint32(0)
-            res = GetApplicationUserModelId(hProc, byref(length), None)
-            if res == ERROR_INSUFFICIENT_BUFFER and length.value:
-                buf = ctypes.create_unicode_buffer(length.value)
-                res = GetApplicationUserModelId(hProc, byref(length), buf)
-                if res == 0 and buf.value:
-                    if buf.value == aumid:
-                        name = os.path.basename(exe)
-                        # PWAHelper.exe is used for PWAs hosted in Edge
-                        if name.lower() == "pwahelper.exe":
-                            return "msedge.exe"
-                        return name
-        except OSError:
-            pass
-        finally:
-            try:
-                CloseHandle(hProc)
-            except OSError:
-                pass
-
-    try:
-        res = _aumid_heuristic_fallback(aumid)
-        if res:
-            return res
-    except Exception:
-        pass
-
-    return None
 
 
 def get_process_image_path(pid: int) -> str | None:
@@ -148,39 +97,108 @@ def get_process_image_path(pid: int) -> str | None:
     return None
 
 
-def _search_processes_by_vendor_name(vendor: str) -> str | None:
-    vendor_l = vendor.lower()
-    for pid, exe in _enum_processes():
-        try:
-            # check snapshot exe name
-            if exe and vendor_l in str(exe).lower():
-                return os.path.basename(str(exe))
-            # check image path
-            path = get_process_image_path(pid)
-            if path and vendor_l in path.lower():
-                return os.path.basename(path)
-        except OSError:
-            continue
-    return None
-
-
-def _aumid_heuristic_fallback(aumid: str) -> str | None:
-    """Heuristics for non-standard AUMIDs (Brave PWAs, Electron apps, etc.)."""
+def get_pid_for_window_aumid(aumid: str) -> int | None:
+    """PID of a visible window whose AppUserModelID matches (shell property store)."""
     if not aumid:
         return None
 
-    if re.match(r"^Brave\._crx_[A-Za-z0-9_-]+$", aumid, re.IGNORECASE):
-        return "brave.exe"
+    target = aumid.lower()
+    found: list[int] = []
 
-    if re.match(r"^Chrome\._crx_[A-Za-z0-9_-]+$", aumid, re.IGNORECASE):
-        return "chrome.exe"
+    def _enum(hwnd, _):
+        if not win32gui.IsWindowVisible(hwnd):
+            return True
+        wa = get_aumid_for_window(hwnd)
+        if not wa or wa.lower() != target:
+            return True
+        _, pid = win32process.GetWindowThreadProcessId(hwnd)
+        if pid:
+            found.append(pid)
+            return False
+        return True
 
-    # Electron packaged apps often use reverse domain AUMIDs like com.github.*
-    if aumid.startswith("com.") or aumid.count(".") >= 2:
-        # try to match by exe basename containing last segment
-        last = aumid.split(".")[-1]
-        res = _search_processes_by_vendor_name(last)
-        if res:
-            return res
+    win32gui.EnumWindows(_enum, None)
+    return found[0] if found else None
 
-    return None
+
+def resolve_shell_app(aumid: str) -> tuple[str | None, str | None]:
+    """Resolve AUMID via shell:AppsFolder to (app display name, process exe).
+
+    One ParseName: item.Name + System.Link.TargetParsingPath. Cached.
+    """
+    if not aumid:
+        return None, None
+
+    cached = _shell_app_cache.get(aumid)
+    if cached is not None:
+        return cached
+
+    display_name: str | None = None
+    process_exe: str | None = None
+    try:
+        folder = Dispatch("Shell.Application").NameSpace("shell:AppsFolder")
+        item = folder.ParseName(aumid) if folder else None
+        if item:
+            raw_name = item.Name
+            if raw_name:
+                display_name = str(raw_name).strip() or None
+            target = item.ExtendedProperty("System.Link.TargetParsingPath")
+            if target:
+                process_exe = os.path.basename(str(target)) or None
+    except Exception:
+        pass
+
+    _shell_app_cache[aumid] = (display_name, process_exe)
+    return display_name, process_exe
+
+
+def get_process_name_for_aumid(aumid: str) -> str | None:
+    """Resolve AUMID -> exe name the way Windows associates apps with processes.
+
+    1. SMTC sometimes uses the exe name as the AUMID
+    2. GetApplicationUserModelId(process) == aumid
+    3. Window PKEY_AppUserModel_ID == aumid -> that window's process
+    4. shell AppsFolder TargetParsingPath (when process/window AUMID missing)
+    """
+    if not aumid:
+        return None
+
+    if aumid.lower().endswith(".exe"):
+        return os.path.basename(aumid)
+
+    if GetApplicationUserModelId is not None:
+        for pid, exe in _enum_processes():
+            hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+            if not hProc:
+                continue
+            try:
+                length = ctypes.c_uint32(0)
+                res = GetApplicationUserModelId(hProc, byref(length), None)
+                if res == ERROR_INSUFFICIENT_BUFFER and length.value:
+                    buf = ctypes.create_unicode_buffer(length.value)
+                    res = GetApplicationUserModelId(hProc, byref(length), buf)
+                    if res == 0 and buf.value == aumid:
+                        name = os.path.basename(exe)
+                        # Edge PWA host process
+                        if name.lower() == "pwahelper.exe":
+                            return "msedge.exe"
+                        return name
+            except OSError:
+                pass
+            finally:
+                try:
+                    CloseHandle(hProc)
+                except OSError:
+                    pass
+
+    pid = get_pid_for_window_aumid(aumid)
+    if pid:
+        path = get_process_image_path(pid)
+        if path:
+            return os.path.basename(path)
+        for p, exe in _enum_processes():
+            if p == pid and exe:
+                return os.path.basename(str(exe))
+
+    _, process_exe = resolve_shell_app(aumid)
+    return process_exe

--- a/src/core/widgets/services/media/aumid_process.py
+++ b/src/core/widgets/services/media/aumid_process.py
@@ -82,6 +82,10 @@ def get_process_name_for_aumid(aumid: str) -> str | None:
     if not aumid:
         return None
 
+    # Classic Win32 players, SMTC often reports the exe name as AUMID.
+    if aumid.lower().endswith(".exe"):
+        return os.path.basename(aumid)
+
     if GetApplicationUserModelId is None:
         return None
 

--- a/src/core/widgets/services/media/media.py
+++ b/src/core/widgets/services/media/media.py
@@ -26,6 +26,7 @@ type MediaSession = GlobalSystemMediaTransportControlsSession
 logger = logging.getLogger("WindowsMedia")
 
 REFRESH_INTERVAL = 0.1
+SESSION_GONE_GRACE_SEC = 1.0
 
 
 class SessionState:
@@ -42,7 +43,6 @@ class SessionState:
         self.is_playing = False
         self.playback_rate = 1.0
         self.is_current = False
-        self.timeline_enabled = False
         # Snapshotted from WinRT PlaybackInfo - plain Python only (do not retain COM objects).
         self.playback_ready = False
         self.controls_prev_enabled = True
@@ -51,6 +51,8 @@ class SessionState:
         self.thumbnail: Image.Image | None = None
         self.cleanup_callbacks: list[Callable[..., None]] = []
         self.session: MediaSession | None = None
+        # After next/prev: do not invent drift until SMTC posts a newer timeline snapshot.
+        self._pause_interpolate = False
 
 
 class WindowsMedia(QObject, metaclass=QSingleton):
@@ -69,6 +71,9 @@ class WindowsMedia(QObject, metaclass=QSingleton):
 
         self._trackers: dict[str, SessionState] = {}
         self._current_session_id: str = ""
+        # Keep selected tracker until this time if SMTC drops it briefly.
+        self._hold_until: float = 0.0
+        self._hold_timer: asyncio.TimerHandle | None = None
         self._manager: SessionManager | None = None
 
         self._loop.create_task(self.run())
@@ -109,6 +114,7 @@ class WindowsMedia(QObject, metaclass=QSingleton):
     def _on_quit(self):
         """Unsubscribe all WinRT event handlers on application quit"""
         self._running = False
+        self._clear_hold()
         for state in list(self._trackers.values()):
             for cb in state.cleanup_callbacks:
                 try:
@@ -117,41 +123,90 @@ class WindowsMedia(QObject, metaclass=QSingleton):
                     pass
         self._trackers.clear()
 
-    def _apply_current_selection(self, system_id: str | None, *, follow_system: bool) -> bool:
-        """Keep _current_session_id and is_current flags aligned with live trackers.
+    def _clear_hold(self) -> None:
+        self._hold_until = 0.0
+        if self._hold_timer is not None:
+            self._hold_timer.cancel()
+            self._hold_timer = None
 
-        Returns True if the selected session id changed.
-        """
+    def _schedule_hold_expiry(self) -> None:
+        if self._hold_timer is not None:
+            self._hold_timer.cancel()
+
+        def _fire() -> None:
+            self._hold_timer = None
+            if self._hold_until <= 0 or self._manager is None:
+                return
+            self._safe_create_task(self._on_sessions_changed, self._manager)
+
+        self._hold_timer = self._loop.call_later(SESSION_GONE_GRACE_SEC + 0.05, _fire)
+
+    def _rebind_session(self, state: SessionState, session: MediaSession) -> None:
+        """Replace WinRT session handle and re-register event callbacks."""
+        for cleanup_callback in state.cleanup_callbacks:
+            try:
+                cleanup_callback()
+            except Exception:
+                pass
+        state.session = session
+        t_mp = session.add_media_properties_changed(
+            self._create_callback_bridge(self._on_media_properties_changed),
+        )
+        t_tp = session.add_timeline_properties_changed(
+            self._create_callback_bridge(self._on_timeline_properties_changed),
+        )
+        t_pi = session.add_playback_info_changed(
+            self._create_callback_bridge(self._on_playback_info_changed),
+        )
+        state.cleanup_callbacks = [
+            partial(session.remove_media_properties_changed, t_mp),
+            partial(session.remove_timeline_properties_changed, t_tp),
+            partial(session.remove_playback_info_changed, t_pi),
+        ]
+
+    def _sync_selection(self, system_id: str | None) -> bool:
+        """Keep selection sticky while present; only adopt Windows current when it is gone."""
         prev_id = self._current_session_id
 
-        if follow_system or self._current_session_id not in self._trackers:
-            # Follow Windows "current", or fall back when our selection was removed
-            # (e.g. browser tab ended while user had switched to it via scroll).
+        if self._current_session_id not in self._trackers:
             if system_id in self._trackers:
                 self._current_session_id = system_id
             elif self._trackers:
                 self._current_session_id = next(iter(self._trackers))
             else:
                 self._current_session_id = ""
-        # else: keep manual selection (still present in trackers)
 
         for tracker in self._trackers.values():
             tracker.is_current = bool(self._current_session_id) and tracker.app_id == self._current_session_id
 
         return prev_id != self._current_session_id
 
-    async def _refresh_sessions(self, manager: SessionManager, *, follow_system: bool = False) -> bool:
-        """Refresh session states from the manager.
-
-        Returns True if the selected session id changed.
-        """
+    async def _refresh_sessions(self, manager: SessionManager) -> bool:
+        """Refresh SMTC sessions. Sticky selection + brief hold if selected drops out."""
         sessions = manager.get_sessions()
         current_session = manager.get_current_session()
         current_ids = [s.source_app_user_model_id for s in sessions]
         system_id = current_session.source_app_user_model_id if current_session else None
 
-        # Cleanup old trackers
-        to_remove = [app_id for app_id in self._trackers if app_id not in current_ids]
+        selected = self._current_session_id
+        rebind_id = ""
+        hold_id = ""
+
+        if selected and selected in current_ids:
+            if self._hold_until > 0 and selected in self._trackers:
+                rebind_id = selected
+            self._clear_hold()
+        elif selected and selected not in current_ids:
+            now = time.time()
+            if self._hold_until <= 0:
+                self._hold_until = now + SESSION_GONE_GRACE_SEC
+                self._schedule_hold_expiry()
+            if now < self._hold_until:
+                hold_id = selected
+            else:
+                self._clear_hold()
+
+        to_remove = [app_id for app_id in self._trackers if app_id not in current_ids and app_id != hold_id]
         for app_id in to_remove:
             old_state = self._trackers.pop(app_id)
             for cleanup_callback in old_state.cleanup_callbacks:
@@ -160,54 +215,34 @@ class WindowsMedia(QObject, metaclass=QSingleton):
                 except Exception:
                     pass
 
-        # Create new trackers
         for session in sessions:
             app_id = session.source_app_user_model_id
             if app_id not in self._trackers:
                 self._trackers[app_id] = SessionState(app_id)
-                self._trackers[app_id].session = session
+                self._rebind_session(self._trackers[app_id], session)
+            elif app_id == rebind_id:
+                self._rebind_session(self._trackers[app_id], session)
 
-                # Add callbacks to events
-                t_mp = session.add_media_properties_changed(
-                    self._create_callback_bridge(self._on_media_properties_changed),
-                )
-                t_tp = session.add_timeline_properties_changed(
-                    self._create_callback_bridge(self._on_timeline_properties_changed),
-                )
-                t_pi = session.add_playback_info_changed(
-                    self._create_callback_bridge(self._on_playback_info_changed),
-                )
-
-                # Store callbacks for cleanup
-                self._trackers[app_id].cleanup_callbacks = [
-                    partial(session.remove_media_properties_changed, t_mp),
-                    partial(session.remove_timeline_properties_changed, t_tp),
-                    partial(session.remove_playback_info_changed, t_pi),
-                ]
-
-            self.media_data_changed.emit(self._trackers)
-
-            # Sync the session immediately
             await self._on_media_properties_changed(session)
             await self._on_timeline_properties_changed(session)
             await self._on_playback_info_changed(session)
 
-        return self._apply_current_selection(system_id, follow_system=follow_system)
+        self.media_data_changed.emit(self._trackers)
+        return self._sync_selection(system_id)
 
     async def _on_sessions_changed(self, manager: SessionManager):
         """Handle SMTC session list changes (session added/removed)."""
-        selection_changed = await self._refresh_sessions(manager, follow_system=False)
+        selection_changed = await self._refresh_sessions(manager)
         self.media_data_changed.emit(self._trackers)
         if selection_changed:
-            # e.g. selected browser session ended -> fell back to Spotify
             self.media_properties_changed.emit()
             if (session := self.current_session) is not None and session.playback_ready:
                 self.playback_info_changed.emit()
             self.current_session_changed.emit()
 
     async def _on_current_session_changed(self, manager: SessionManager):
-        """Handle Windows current-session change (follow system)."""
-        await self._refresh_sessions(manager, follow_system=True)
+        """Handle Windows current-session change (selection stays sticky if still present)."""
+        await self._refresh_sessions(manager)
         self.media_data_changed.emit(self._trackers)
         self.current_session_changed.emit()
 
@@ -225,13 +260,14 @@ class WindowsMedia(QObject, metaclass=QSingleton):
                     return
             except Exception:
                 return
-            new_title = props.title
-            state.title = new_title
-            state.artist = props.artist
+
+            state.title = (props.title or "").strip()
+            state.artist = (props.artist or "").strip()
             if tn := props.thumbnail:
                 state.thumbnail = await self._get_thumbnail_async(tn)
             else:
                 state.thumbnail = None
+
             self.media_properties_changed.emit()
         except Exception as e:
             logger.error("Error syncing session: %s", e, exc_info=True)
@@ -248,10 +284,18 @@ class WindowsMedia(QObject, metaclass=QSingleton):
             state = self._trackers[app_id]
             new_pos = timeline.position.total_seconds()
             new_update = timeline.last_updated_time.timestamp()
-            state.duration = timeline.end_time.total_seconds()
+            new_duration = timeline.end_time.total_seconds()
+
+            # Firefox/YouTube can emit pos=0,duration=0 after seek; ignore if we already have a duration.
+            if new_duration <= 0 and new_pos <= 0 and state.duration > 0:
+                return
+
             if new_update > state.last_update_time:
                 state.last_snapshot_pos = new_pos
-            state.last_update_time = new_update
+                state.last_update_time = new_update
+                state._pause_interpolate = False
+            state.duration = new_duration
+
             self.timeline_info_changed.emit()
         except Exception as e:
             logger.error("Error syncing session: %s", e, exc_info=True)
@@ -285,19 +329,16 @@ class WindowsMedia(QObject, metaclass=QSingleton):
                 prev_enabled = controls.is_previous_enabled
                 play_enabled = controls.is_play_pause_toggle_enabled
                 next_enabled = controls.is_next_enabled
-                timeline_enabled = controls.is_playback_position_enabled
             else:
                 prev_enabled = True
                 play_enabled = True
                 next_enabled = True
-                timeline_enabled = False
 
             state.is_playing = is_playing
             state.playback_rate = playback_rate
             state.controls_prev_enabled = prev_enabled
             state.controls_play_enabled = play_enabled
             state.controls_next_enabled = next_enabled
-            state.timeline_enabled = timeline_enabled
             state.playback_ready = True
             self.playback_info_changed.emit()
         except Exception as e:
@@ -308,9 +349,11 @@ class WindowsMedia(QObject, metaclass=QSingleton):
         # Update current position for each session
         for state in trackers.values():
             pos = state.last_snapshot_pos
-            if state.is_playing:
+            if state.is_playing and not state._pause_interpolate:
                 drift = time.time() - state.last_update_time
                 pos += drift * state.playback_rate
+            if state.duration > 0:
+                pos = min(pos, state.duration)
             state.current_pos = pos
 
         self.media_data_changed.emit(trackers)
@@ -385,6 +428,7 @@ class WindowsMedia(QObject, metaclass=QSingleton):
 
         next_session.is_current = True
         self._current_session_id = next_session.app_id
+        self._clear_hold()
 
         self.media_data_changed.emit(self._trackers)
 
@@ -402,11 +446,21 @@ class WindowsMedia(QObject, metaclass=QSingleton):
         except Exception as e:
             logger.error("Error playing/pausing: %s", e)
 
+    def _reset_timeline_for_skip(self, state: SessionState) -> None:
+        """Show 0 and hold interpolate until SMTC posts a newer timeline snapshot."""
+        state.last_snapshot_pos = 0.0
+        state.current_pos = 0.0
+        state.last_update_time = time.time()
+        state._pause_interpolate = True
+        self._interpolate_and_emit(self._trackers)
+        self.playback_info_changed.emit()
+
     @asyncSlot()
     async def prev(self):
         """Skip to previous track"""
         try:
             if self.current_session and self.current_session.session is not None:
+                self._reset_timeline_for_skip(self.current_session)
                 await self.current_session.session.try_skip_previous_async()
         except Exception as e:
             logger.error("Error skipping previous: %s", e)
@@ -416,6 +470,7 @@ class WindowsMedia(QObject, metaclass=QSingleton):
         """Skip to next track"""
         try:
             if self.current_session and self.current_session.session is not None:
+                self._reset_timeline_for_skip(self.current_session)
                 await self.current_session.session.try_skip_next_async()
         except Exception as e:
             logger.error("Error skipping next: %s", e)
@@ -428,6 +483,7 @@ class WindowsMedia(QObject, metaclass=QSingleton):
                 await self.current_session.session.try_change_playback_position_async(position_in_100ns)
                 self.current_session.last_snapshot_pos = position
                 self.current_session.last_update_time = time.time()
+                self.current_session._pause_interpolate = False
                 self._interpolate_and_emit(self._trackers)
         except Exception as e:
             logger.error("Error seeking to position: %s", e)

--- a/src/core/widgets/services/media/media.py
+++ b/src/core/widgets/services/media/media.py
@@ -387,7 +387,6 @@ class WindowsMedia(QObject, metaclass=QSingleton):
         self._current_session_id = next_session.app_id
 
         self.media_data_changed.emit(self._trackers)
-        self.media_properties_changed.emit()
 
         if next_session.playback_ready:
             self.playback_info_changed.emit()

--- a/src/core/widgets/services/media/source_apps.py
+++ b/src/core/widgets/services/media/source_apps.py
@@ -1,189 +1,186 @@
 """
-Media source applications mapping.
-
-This file contains the mapping of source application identifiers to their
-display names for the media widget.
-
-For complex applications that have different process names than their AUMID,
-use dictionary format:
-    "aumid": {"name": "Display Name", "process": "executable.exe"}
-
-For simple applications where AUMID matching is sufficient, use string format:
-    "aumid": "Display Name"
+Resolve SMTC SourceAppUserModelId to a display name for the media widget.
 """
 
-from typing import Any
+import os
+from pathlib import Path
 
-MEDIA_SOURCE_APPS = {
-    # Audio Players
-    "AIMP.exe": "AIMP",
-    "winamp.exe": "Winamp",
-    "foobar2000.exe": "Foobar2000",
-    "MusicBee.exe": "MusicBee",
-    "mpv.exe": "NSMusicS",
-    "PotPlayerMini64.exe": "PotPlayer",
-    # Streaming Services
-    "SpotifyAB.SpotifyMusic_zpdnekdrzrea0!Spotify": "Spotify",
-    "Spotify.exe": "Spotify",
-    "AppleInc.AppleMusicWin_nzyj5cx40ttqa!App": "Apple Music",
-    "com.badmanners.murglar": {
-        "name": "Murglar",
-        "process": "Murglar.exe",
-    },
-    "com.squirrel.TIDAL.TIDAL": {
-        "name": "Tidal",
-        "process": "TIDAL.exe",
-    },
-    "com.squirrel.Qobuz.Qobuz": {
-        "name": "Qobuz",
-        "process": "Qobuz.exe",
-    },
-    "com.squirrel.youtube_music_desktop_app.youtube-music-desktop-app": {
-        "name": "YouTube Music",
-        "process": "youtube-music-desktop-app.exe",
-    },
-    "com.github.th-ch.youtube-music": {
-        "name": "YouTube Music",
-        "process": "YouTube Music.exe",
-    },
-    # Web Browsers
-    "308046B0AF4A39CB": {
-        "name": "FireFox",
-        "process": "firefox.exe",
-    },
-    "CA9422711AE1A81C": {
-        "name": "FireFox",  # Firefox Developer Edition
-        "process": "firefox.exe",
-    },
-    "firefox.exe": "FireFox",
-    "F0DC299D809B9700": {
-        "name": "Zen",
-        "process": "zen.exe",
-    },
-    "A5B78042B5B03693": {
-        "name": "Zen",
-        "process": "zen.exe",
-    },
-    "zen.exe": "Zen",
-    "MSEdge": {
-        "name": "Edge",
-        "process": "msedge.exe",
-    },
-    "msedge.exe": "Edge",
-    "Chrome": {
-        "name": "Chrome",
-        "process": "chrome.exe",
-    },
-    "chrome.exe": "Chrome",
-    "opera.exe": "Opera",
-    "Brave": {
-        "name": "Brave",
-        "process": "brave.exe",
-    },
-    "Brave.Q2QWMKZ4RMMIMDZ2JQ2NKBXFT4": {
-        "name": "Brave",
-        "process": "brave.exe",
-    },
-    # System Media Players
-    "Microsoft.ZuneMusic_8wekyb3d8bbwe!Microsoft.ZuneMusic": "Media Player",
-    # Message Apps
-    "Telegram.TelegramDesktop.7e5c2711fcd4e083548c717cc0ca86f4": {
-        "name": "Telegram",  # materialgram
-        "process": "materialgram.exe",
-    },
-}
+import win32gui
+import win32process
+from winrt.windows.applicationmodel import AppInfo
+
+from core.utils.win32.aumid import get_aumid_for_window, get_aumid_from_shortcut
+from core.utils.win32.utils import get_app_name_from_aumid, get_app_name_from_pid
+from core.widgets.services.media.aumid_process import _enum_processes, get_process_name_for_aumid
+
+_PWA_KNOWN_FOLDERS = ("Chrome Apps", "Brave Apps", "Edge Apps", "Firefox Web Apps")
+
+_name_cache: dict[str, str] = {}
+_pwa_shortcuts: dict[str, str] | None = None
 
 
-def _match_aumid_by_regex(source_app_id: str) -> dict[str, str | None] | None:
-    """
-    Attempt to match common AUMID patterns using regex when an exact
-    dictionary lookup fails.
+def _humanize(aumid: str) -> str:
+    if aumid.lower().endswith(".exe"):
+        return os.path.splitext(os.path.basename(aumid))[0]
+    if "!" in aumid:
+        return aumid.split("!")[-1]
+    last = aumid.split(".")[-1] if "." in aumid else aumid
+    return last.replace("-", " ").replace("_", " ")
 
-    Returns a mapping dict with 'name' and optional 'process', or None.
-    """
-    import re
 
-    if not source_app_id:
+def _appinfo_name(aumid: str) -> str | None:
+    try:
+        name = AppInfo.get_from_app_user_model_id(aumid).display_info.display_name
+        return name.strip() if name else None
+    except Exception:
         return None
 
-    if re.match(r"^music\.youtube\.com-[^!]+!App$", source_app_id, re.IGNORECASE):
-        return {"name": "YouTube Music", "process": "msedge.exe"}
 
-    if re.match(r"^(?:www\.)?youtube\.com-[^!]+!App$", source_app_id, re.IGNORECASE):
-        return {"name": "YouTube", "process": "msedge.exe"}
+def _load_pwa_shortcuts() -> dict[str, str]:
+    """Start Menu PWA .lnk files: aumid -> shortcut name."""
+    global _pwa_shortcuts
+    if _pwa_shortcuts is not None:
+        return _pwa_shortcuts
 
-    if re.match(r"^Brave\._crx_[A-Za-z0-9_-]+$", source_app_id, re.IGNORECASE):
-        return {"name": "Brave", "process": "brave.exe"}
+    mapping: dict[str, str] = {}
+    programs = Path(os.environ.get("APPDATA", "")) / "Microsoft/Windows/Start Menu/Programs"
+    for folder in _PWA_KNOWN_FOLDERS:
+        path = programs / folder
+        if not path.is_dir():
+            continue
+        try:
+            for lnk in path.glob("*.lnk"):
+                aumid = get_aumid_from_shortcut(str(lnk))
+                if aumid:
+                    mapping[aumid] = lnk.stem
+        except OSError:
+            continue
+    _pwa_shortcuts = mapping
+    return mapping
 
-    if re.match(r"^Chrome\._crx_[A-Za-z0-9_-]+$", source_app_id, re.IGNORECASE):
-        return {"name": "Chrome", "process": "chrome.exe"}
 
-    # Match Opera and Opera GX with version numbers
-    # Examples: OperaSoftware.OperaStable.12345, OperaSoftware.OperaGXStable.67890
-    #           OperaSoftware.OperaGXWebBrowser.1759345670
-    if re.match(r"^OperaSoftware\.Opera(?:GX|Stable|WebBrowser)", source_app_id, re.IGNORECASE):
-        if "GX" in source_app_id:
-            return {"name": "Opera GX", "process": "opera.exe"}
-        return {"name": "Opera", "process": "opera.exe"}
+def _find_pwa(aumid: str, title: str | None = None) -> tuple[str, str] | None:
+    """
+    Find an installed browser PWA for this SMTC session.
 
+    Returns (pwa_aumid, display_name) or None.
+
+    Chromium reports the PWA AUMID on the session (matches the .lnk).
+    Firefox reports the browser AUMID, then match media title to an open
+    window that carries the PWA AUMID.
+    """
+    shortcuts = _load_pwa_shortcuts()
+    if not shortcuts:
+        return None
+
+    if aumid in shortcuts:
+        return aumid, shortcuts[aumid]
+
+    needle = (title or "").strip().lower()
+    if not needle:
+        return None
+
+    prefix = needle[:32] if len(needle) >= 8 else None
+    found: list[tuple[str, str]] = []
+
+    def _enum(hwnd, _):
+        if not win32gui.IsWindowVisible(hwnd):
+            return True
+        wa = get_aumid_for_window(hwnd)
+        if not wa or wa not in shortcuts:
+            return True
+        wt = win32gui.GetWindowText(hwnd)
+        if not wt:
+            return True
+        wtl = wt.lower()
+        if needle in wtl or (prefix and prefix in wtl):
+            found.append((wa, shortcuts[wa]))
+            return False
+        return True
+
+    win32gui.EnumWindows(_enum, None)
+    return found[0] if found else None
+
+
+def _pwa_name(aumid: str, title: str | None = None) -> str | None:
+    match = _find_pwa(aumid, title)
+    return match[1] if match else None
+
+
+def resolve_activate_aumid(aumid: str, *, title: str | None = None) -> str:
+    """AUMID to focus for open_media_source (PWA window when applicable)."""
+    match = _find_pwa(aumid, title)
+    return match[0] if match else aumid
+
+
+def _pid_for_exe(exe_name: str) -> int | None:
+    target = exe_name.lower()
+    for pid, exe in _enum_processes():
+        if exe and os.path.basename(str(exe)).lower() == target:
+            return pid
     return None
 
 
-def get_source_app_display_name(source_app_id: str) -> str:
-    """
-    Get the display name for a source application ID.
-
-    Args:
-        source_app_id: The source application identifier
-
-    Returns:
-        The display name for the app, or None if not found
-    """
-    entry = MEDIA_SOURCE_APPS.get(source_app_id)
-    if isinstance(entry, dict):
-        return entry.get("name")
-    if isinstance(entry, str):
-        return entry
-
-    fallback = _match_aumid_by_regex(source_app_id)
-    if fallback:
-        return fallback.get("name")
-    return None
+def _name_from_process(aumid: str) -> str | None:
+    """Process AUMID / Electron heuristics -> FileDescription."""
+    proc = get_process_name_for_aumid(aumid)
+    if not proc:
+        return None
+    pid = _pid_for_exe(proc)
+    if pid:
+        name = get_app_name_from_pid(pid)
+        if name:
+            return name
+    return os.path.splitext(proc)[0]
 
 
-def get_source_app_mapping(source_app_id: str) -> dict[str, Any] | None:
-    """
-    Get the complete mapping information for a source application ID.
+def _name_from_window(aumid: str) -> str | None:
+    """Window AppUserModelID (Firefox/Zen hashes) -> FileDescription."""
+    result: list[int] = []
 
-    Args:
-        source_app_id: The source application identifier
+    def _enum(hwnd, _):
+        if not win32gui.IsWindowVisible(hwnd):
+            return True
+        if get_aumid_for_window(hwnd) != aumid:
+            return True
+        _, pid = win32process.GetWindowThreadProcessId(hwnd)
+        if pid:
+            result.append(pid)
+            return False
+        return True
 
-    Returns:
-        Dictionary with 'name' and 'process' keys, or None if not found
-    """
-    entry = MEDIA_SOURCE_APPS.get(source_app_id)
-    if isinstance(entry, dict):
-        return entry
-    elif isinstance(entry, str):
-        return {"name": entry, "process": None}
-
-    fallback = _match_aumid_by_regex(source_app_id)
-    if fallback:
-        return fallback
-
-    return None
+    win32gui.EnumWindows(_enum, None)
+    return get_app_name_from_pid(result[0]) if result else None
 
 
-def get_source_app_class_name(display_name: str) -> str:
-    """
-    Get a CSS-friendly class name from a display name.
+def resolve_source_app_name(aumid: str, *, title: str | None = None) -> str | None:
+    """Resolve AUMID to display name. Cached per AUMID (PWA title matches are not cached)."""
+    if not aumid:
+        return None
 
-    Args:
-        display_name: The display name of the app
+    name = _pwa_name(aumid, title)
+    if name:
+        return name
 
-    Returns:
-        A CSS-friendly class name (lowercase, spaces replaced with hyphens)
-    """
+    cached = _name_cache.get(aumid)
+    if cached is not None:
+        return cached
+
+    name = _appinfo_name(aumid)
+    if not name and "!" in aumid:
+        name = get_app_name_from_aumid(aumid)
+    if not name:
+        name = _name_from_process(aumid)
+    if not name:
+        name = _name_from_window(aumid)
+    if not name:
+        name = _humanize(aumid)
+
+    _name_cache[aumid] = name
+    return name
+
+
+def get_source_app_class_name(display_name: str) -> str | None:
     if display_name:
         return display_name.lower().replace(" ", "-")
     return None

--- a/src/core/widgets/services/media/source_apps.py
+++ b/src/core/widgets/services/media/source_apps.py
@@ -3,20 +3,18 @@ Resolve SMTC SourceAppUserModelId to a display name for the media widget.
 """
 
 import os
-from pathlib import Path
 
-import win32gui
-import win32process
 from winrt.windows.applicationmodel import AppInfo
 
-from core.utils.win32.aumid import get_aumid_for_window, get_aumid_from_shortcut
 from core.utils.win32.utils import get_app_name_from_aumid, get_app_name_from_pid
-from core.widgets.services.media.aumid_process import _enum_processes, get_process_name_for_aumid
-
-_PWA_KNOWN_FOLDERS = ("Chrome Apps", "Brave Apps", "Edge Apps", "Firefox Web Apps")
+from core.widgets.services.media.aumid_process import (
+    _enum_processes,
+    get_pid_for_window_aumid,
+    get_process_name_for_aumid,
+    resolve_shell_app,
+)
 
 _name_cache: dict[str, str] = {}
-_pwa_shortcuts: dict[str, str] | None = None
 
 
 def _humanize(aumid: str) -> str:
@@ -36,83 +34,6 @@ def _appinfo_name(aumid: str) -> str | None:
         return None
 
 
-def _load_pwa_shortcuts() -> dict[str, str]:
-    """Start Menu PWA .lnk files: aumid -> shortcut name."""
-    global _pwa_shortcuts
-    if _pwa_shortcuts is not None:
-        return _pwa_shortcuts
-
-    mapping: dict[str, str] = {}
-    programs = Path(os.environ.get("APPDATA", "")) / "Microsoft/Windows/Start Menu/Programs"
-    for folder in _PWA_KNOWN_FOLDERS:
-        path = programs / folder
-        if not path.is_dir():
-            continue
-        try:
-            for lnk in path.glob("*.lnk"):
-                aumid = get_aumid_from_shortcut(str(lnk))
-                if aumid:
-                    mapping[aumid] = lnk.stem
-        except OSError:
-            continue
-    _pwa_shortcuts = mapping
-    return mapping
-
-
-def _find_pwa(aumid: str, title: str | None = None) -> tuple[str, str] | None:
-    """
-    Find an installed browser PWA for this SMTC session.
-
-    Returns (pwa_aumid, display_name) or None.
-
-    Chromium reports the PWA AUMID on the session (matches the .lnk).
-    Firefox reports the browser AUMID, then match media title to an open
-    window that carries the PWA AUMID.
-    """
-    shortcuts = _load_pwa_shortcuts()
-    if not shortcuts:
-        return None
-
-    if aumid in shortcuts:
-        return aumid, shortcuts[aumid]
-
-    needle = (title or "").strip().lower()
-    if not needle:
-        return None
-
-    prefix = needle[:32] if len(needle) >= 8 else None
-    found: list[tuple[str, str]] = []
-
-    def _enum(hwnd, _):
-        if not win32gui.IsWindowVisible(hwnd):
-            return True
-        wa = get_aumid_for_window(hwnd)
-        if not wa or wa not in shortcuts:
-            return True
-        wt = win32gui.GetWindowText(hwnd)
-        if not wt:
-            return True
-        wtl = wt.lower()
-        if needle in wtl or (prefix and prefix in wtl):
-            found.append((wa, shortcuts[wa]))
-            return False
-        return True
-
-    win32gui.EnumWindows(_enum, None)
-    return found[0] if found else None
-
-
-def _pwa_name(aumid: str, title: str | None = None) -> str | None:
-    match = _find_pwa(aumid, title)
-    return match[1] if match else None
-
-
-def resolve_activate_aumid(aumid: str, *, title: str | None = None) -> str:
-    """AUMID to focus for open_media_source (PWA window when applicable)."""
-    match = _find_pwa(aumid, title)
-    return match[0] if match else aumid
-
-
 def _pid_for_exe(exe_name: str) -> int | None:
     target = exe_name.lower()
     for pid, exe in _enum_processes():
@@ -122,7 +43,7 @@ def _pid_for_exe(exe_name: str) -> int | None:
 
 
 def _name_from_process(aumid: str) -> str | None:
-    """Process AUMID / Electron heuristics -> FileDescription."""
+    """Process / shell exe -> FileDescription."""
     proc = get_process_name_for_aumid(aumid)
     if not proc:
         return None
@@ -136,31 +57,14 @@ def _name_from_process(aumid: str) -> str | None:
 
 def _name_from_window(aumid: str) -> str | None:
     """Window AppUserModelID (Firefox/Zen hashes) -> FileDescription."""
-    result: list[int] = []
-
-    def _enum(hwnd, _):
-        if not win32gui.IsWindowVisible(hwnd):
-            return True
-        if get_aumid_for_window(hwnd) != aumid:
-            return True
-        _, pid = win32process.GetWindowThreadProcessId(hwnd)
-        if pid:
-            result.append(pid)
-            return False
-        return True
-
-    win32gui.EnumWindows(_enum, None)
-    return get_app_name_from_pid(result[0]) if result else None
+    pid = get_pid_for_window_aumid(aumid)
+    return get_app_name_from_pid(pid) if pid else None
 
 
-def resolve_source_app_name(aumid: str, *, title: str | None = None) -> str | None:
-    """Resolve AUMID to display name. Cached per AUMID (PWA title matches are not cached)."""
+def resolve_source_app_name(aumid: str) -> str | None:
+    """Resolve AUMID to display name. Cached per AUMID."""
     if not aumid:
         return None
-
-    name = _pwa_name(aumid, title)
-    if name:
-        return name
 
     cached = _name_cache.get(aumid)
     if cached is not None:
@@ -169,6 +73,10 @@ def resolve_source_app_name(aumid: str, *, title: str | None = None) -> str | No
     name = _appinfo_name(aumid)
     if not name and "!" in aumid:
         name = get_app_name_from_aumid(aumid)
+    # Shell app name before process lookup so PWAs are not labeled as the browser.
+    # Skip .exe SMTC ids process path is enough.
+    if not name and not aumid.lower().endswith(".exe"):
+        name, _ = resolve_shell_app(aumid)
     if not name:
         name = _name_from_process(aumid)
     if not name:

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -9,8 +9,8 @@ from PIL.ImageDraw import ImageDraw
 from PIL.ImageQt import ImageQt
 from pycaw.pycaw import AudioUtilities
 from PyQt6 import QtCore
-from PyQt6.QtCore import QEvent, QObject, Qt, QTimer, pyqtSlot
-from PyQt6.QtGui import QMouseEvent, QPixmap, QWheelEvent
+from PyQt6.QtCore import QEvent, QObject, QRectF, Qt, pyqtSlot
+from PyQt6.QtGui import QMouseEvent, QPainter, QPainterPath, QPaintEvent, QPixmap, QWheelEvent
 from PyQt6.QtWidgets import (
     QFrame,
     QGridLayout,
@@ -23,6 +23,7 @@ from PyQt6.QtWidgets import (
 )
 from qasync import asyncSlot  # type: ignore
 
+from core.utils.qobject import is_valid_qobject
 from core.utils.utilities import (
     PopupWidget,
     ScrollingLabel,
@@ -42,8 +43,8 @@ from core.widgets.services.media.aumid_process import get_process_name_for_aumid
 from core.widgets.services.media.media import MediaSession, SessionState, WindowsMedia
 from core.widgets.services.media.source_apps import (
     get_source_app_class_name,
-    get_source_app_display_name,
-    get_source_app_mapping,
+    resolve_activate_aumid,
+    resolve_source_app_name,
 )
 from core.widgets.services.media.tokenizer import clean_string
 
@@ -51,7 +52,7 @@ logger = logging.getLogger("MediaWidget")
 
 MAX_TIMLINE_DURATION = 604800  # 7 days
 
-type FieldTypes = Literal["default", "popup_title", "popup_artist"]
+type FieldTypes = Literal["default", "popup_title", "popup_artist", "popup_source"]
 
 
 class ProgressBarAlignment(StrEnum):
@@ -195,6 +196,20 @@ class MediaWidget(BaseWidget):
         self._app_volume_session = None
         self._is_playing = False
         self._app_is_muted = False
+        self.dialog: PopupWidget | None = None
+        self._media_content_frame: QFrame | None = None
+        self._no_media_label: QLabel | None = None
+        self._popup_source_label: QLabel | None = None
+        self._vol_container: QFrame | None = None
+        self._time_slider_container: QFrame | None = None
+        self._progress_slider: QSlider | None = None
+        self._popup_current_time_label: QLabel | None = None
+        self._popup_total_time_label: QLabel | None = None
+        self._popup_thumbnail_label = None
+        self._popup_title_label = None
+        self._popup_artist_label = None
+        self._seeking = False
+        self._wheel_filter: WheelEventFilter | None = None
 
     @pyqtSlot(dict)
     def _on_media_data_changed(self, data: dict[str, SessionState]):
@@ -204,200 +219,174 @@ class MediaWidget(BaseWidget):
 
         self._update_interpolated_position()
 
-        # If the session has changed, trigger property/playback updates to sync UI
-        if self.current_session and (old_session is None or self.current_session.app_id != old_session.app_id):
-            self._on_media_properties_changed()
-            self._on_playback_info_changed()
+        session_changed = (self.current_session is None) != (old_session is None) or (
+            self.current_session is not None
+            and old_session is not None
+            and self.current_session.app_id != old_session.app_id
+        )
+        if session_changed:
+            if self.current_session is not None or old_session is not None:
+                self._on_media_properties_changed()
+            if self.current_session is not None and (
+                old_session is None or self.current_session.app_id != old_session.app_id
+            ):
+                self._on_playback_info_changed()
 
     def _toggle_media_menu(self):
-        self.show_menu()
+        if is_valid_qobject(self.dialog) and self.dialog.isVisible():
+            self.dialog.hide_animated()
+        else:
+            self.show_menu()
 
     def show_menu(self):
+        if not is_valid_qobject(self.dialog):
+            self._create_media_popup()
+
+        self._refresh_popup_content()
+        self.dialog.adjustSize()
+        self.dialog.setPosition(
+            alignment=self.config.media_menu.alignment,
+            direction=self.config.media_menu.direction,
+            offset_left=self.config.media_menu.offset_left,
+            offset_top=self.config.media_menu.offset_top,
+        )
+        self.dialog.show()
+
+    def _create_media_popup(self):
         self.dialog = PopupWidget(
             self,
             self.config.media_menu.blur,
             self.config.media_menu.round_corners,
             self.config.media_menu.round_corners_type,
             self.config.media_menu.border_color,
+            persistent=True,
         )
-
         self.dialog.setProperty("class", "media-menu")
 
-        # Create main layout for the popup dialog
         main_layout = QVBoxLayout(self.dialog)
         main_layout.setContentsMargins(12, 12, 12, 12)
         main_layout.setSpacing(0)
 
-        content_layout = QHBoxLayout()
+        self._media_content_frame = QFrame(self.dialog)
+        content_layout = QHBoxLayout(self._media_content_frame)
+        content_layout.setContentsMargins(0, 0, 0, 0)
         content_layout.setSpacing(0)
 
-        if self.current_session is not None:
-            # Create thumbnail label
-            self._popup_thumbnail_label = QLabel()
-            self._popup_thumbnail_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            self._popup_thumbnail_label.setProperty("class", "thumbnail")
-            self._popup_thumbnail_label.setContentsMargins(0, 0, 0, 0)
-            self._popup_thumbnail_label.setFixedSize(
-                self.config.media_menu.thumbnail_size,
-                self.config.media_menu.thumbnail_size,
-            )
+        self._popup_thumbnail_label = RoundedClickableLabel(self, radius=self.config.media_menu.thumbnail_corner_radius)
+        self._popup_thumbnail_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._popup_thumbnail_label.setProperty("class", "thumbnail")
+        self._popup_thumbnail_label.setContentsMargins(0, 0, 0, 0)
+        self._popup_thumbnail_label.data = self._open_media_source
+        self._popup_thumbnail_label.setFixedSize(
+            self.config.media_menu.thumbnail_size,
+            self.config.media_menu.thumbnail_size,
+        )
+        content_layout.addWidget(self._popup_thumbnail_label, alignment=Qt.AlignmentFlag.AlignTop)
+
+        text_layout = QVBoxLayout()
+        text_layout.setContentsMargins(0, 0, 0, 0)
+        text_layout.setSpacing(0)
+
+        self._popup_title_label = QLabel("")
+        self._popup_title_label.setContentsMargins(0, 0, 0, 0)
+        self._popup_title_label.setProperty("class", "title")
+        self._popup_title_label.setWordWrap(True)
+        self._popup_title_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Maximum)
+
+        self._popup_artist_label = QLabel("")
+        self._popup_artist_label.setContentsMargins(0, 0, 0, 0)
+        self._popup_artist_label.setProperty("class", "artist")
+        self._popup_artist_label.setWordWrap(True)
+        self._popup_artist_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Maximum)
+        text_layout.addWidget(self._popup_title_label, alignment=Qt.AlignmentFlag.AlignTop)
+        text_layout.addWidget(self._popup_artist_label, alignment=Qt.AlignmentFlag.AlignTop)
+        text_layout.addStretch(1)
+
+        control_layout = QHBoxLayout()
+        control_layout.setSpacing(0)
+
+        prev_button = ClickableLabel(self)
+        prev_button.setProperty("class", "btn prev")
+        prev_button.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        prev_button.setText(self.config.media_menu_icons.prev_track)
+        prev_button.data = self.media.prev
+        self._popup_prev_label = prev_button
+
+        play_button = ClickableLabel(self)
+        play_button.setProperty("class", "btn play")
+        play_button.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        play_button.setText(self.config.media_menu_icons.play)
+        play_button.data = self.media.play_pause
+        self._popup_play_button = play_button
+
+        next_button = ClickableLabel(self)
+        next_button.setProperty("class", "btn next")
+        next_button.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        next_button.setText(self.config.media_menu_icons.next_track)
+        next_button.data = self.media.next
+        self._popup_next_label = next_button
+
+        control_layout.addWidget(prev_button)
+        control_layout.addWidget(play_button)
+        control_layout.addWidget(next_button)
+        control_layout.addStretch(1)
+
+        if self.config.media_menu.show_source:
+            self._popup_source_label = QLabel("")
+            self._popup_source_label.setProperty("class", "source")
+            self._popup_source_label.hide()
+            control_layout.addWidget(self._popup_source_label, 0, Qt.AlignmentFlag.AlignVCenter)
+
+        text_layout.addLayout(control_layout)
+        content_layout.addLayout(text_layout)
+
+        if self.config.media_menu.show_volume_slider:
             try:
-                # Use thumbnail if available, otherwise create a default one
-                if self.current_session.thumbnail is not None:
-                    popup_pixmap = self._create_thumbnail_for_popup(self.current_session.thumbnail)
-                else:
-                    # Create default thumbnail
-                    popup_pixmap = self._create_empty_thumbnail()
+                self._vol_container = QFrame()
+                self._vol_container.setProperty("class", "app-volume-container")
+                vol_layout = QVBoxLayout(self._vol_container)
+                vol_layout.setContentsMargins(0, 0, 0, 0)
+                vol_layout.setSpacing(0)
 
-                if popup_pixmap:
-                    self._popup_thumbnail_label.setPixmap(popup_pixmap)
-                    content_layout.addWidget(self._popup_thumbnail_label, alignment=Qt.AlignmentFlag.AlignTop)
+                self.app_volume_slider = QSlider(Qt.Orientation.Vertical)
+                self.app_volume_slider.setProperty("class", "volume-slider")
+                self.app_volume_slider.setMinimum(0)
+                self.app_volume_slider.setMaximum(100)
+                self.app_volume_slider.valueChanged.connect(self._on_app_volume_slider_changed)
+                vol_layout.addWidget(self.app_volume_slider, 0, Qt.AlignmentFlag.AlignCenter)
 
-                # Create layout for text information (title, artist, slider, controls)
-                text_layout = QVBoxLayout()
-                text_layout.setContentsMargins(0, 0, 0, 0)
-                text_layout.setSpacing(0)
-
-                title_text = (
-                    self._format_max_field_size(self.current_session.title, "popup_title")
-                    if self.current_session.title
-                    else "Unknown Title"
-                )
-                self._popup_title_label = QLabel(title_text)
-                self._popup_title_label.setContentsMargins(0, 0, 0, 0)
-                self._popup_title_label.setProperty("class", "title")
-                self._popup_title_label.setWordWrap(True)
-                self._popup_title_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Minimum)
-
-                artist_text = (
-                    self._format_max_field_size(self.current_session.artist, "popup_artist")
-                    if self.current_session.artist
-                    else ""
-                )
-                self._popup_artist_label = QLabel(artist_text)
-                self._popup_artist_label.setContentsMargins(0, 0, 0, 0)
-                self._popup_artist_label.setProperty("class", "artist")
-                self._popup_artist_label.setWordWrap(True)
-                self._popup_artist_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Minimum)
-                text_layout.addWidget(self._popup_title_label, alignment=Qt.AlignmentFlag.AlignTop)
-                text_layout.addWidget(self._popup_artist_label, alignment=Qt.AlignmentFlag.AlignTop)
-
-                # Add control buttons directly below the slider in the text layout
-                control_layout = QHBoxLayout()
-                control_layout.setSpacing(0)
-
-                # Create clickable buttons using the same method as main widget
-                prev_button = ClickableLabel(self)
-                prev_button.setProperty("class", "btn prev")
-                prev_button.setAlignment(Qt.AlignmentFlag.AlignCenter)
-                prev_button.setText(self.config.media_menu_icons.prev_track)
-                prev_button.data = self.media.prev
-                self._popup_prev_label = prev_button
-
-                play_button = ClickableLabel(self)
-                play_button.setProperty("class", "btn play")
-                play_button.setAlignment(Qt.AlignmentFlag.AlignCenter)
-                play_icon = (
-                    self.config.media_menu_icons.pause if self._is_playing else self.config.media_menu_icons.play
-                )
-                play_button.setText(play_icon)
-                play_button.data = self.media.play_pause
-                self._popup_play_button = play_button
-
-                next_button = ClickableLabel(self)
-                next_button.setProperty("class", "btn next")
-                next_button.setAlignment(Qt.AlignmentFlag.AlignCenter)
-                next_button.setText(self.config.media_menu_icons.next_track)
-                next_button.data = self.media.next
-                self._popup_next_label = next_button
-
-                control_layout.addWidget(prev_button)
-                control_layout.addWidget(play_button)
-                control_layout.addWidget(next_button)
-
-                control_layout.addStretch(1)
-
-                source_name, source_class_name = self._get_source_app_name()
-                if source_name is not None and self.config.media_menu.show_source:
-                    self._popup_source_label = QLabel(source_name)
-                    self._popup_source_label.setContentsMargins(0, 0, 0, 0)
-                    self._popup_source_label.setProperty("class", f"source {source_class_name}")
-                    self._popup_source_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-                    control_layout.addWidget(self._popup_source_label, 0, Qt.AlignmentFlag.AlignVCenter)
-
-                # Add control layout to the text layout
-                text_layout.addLayout(control_layout)
-
-                # Add the text layout to the top layout
-                content_layout.addLayout(text_layout)
-
-                # Per-app vertical volume slider
-                if self.config.media_menu.show_volume_slider:
-                    try:
-                        self._vol_container = QFrame()
-                        self._vol_container.setProperty("class", "app-volume-container")
-                        vol_layout = QVBoxLayout(self._vol_container)
-                        vol_layout.setContentsMargins(0, 0, 0, 0)
-                        vol_layout.setSpacing(0)
-
-                        self.app_volume_slider = QSlider(Qt.Orientation.Vertical)
-                        self.app_volume_slider.setProperty("class", "volume-slider")
-                        self.app_volume_slider.setMinimum(0)
-                        self.app_volume_slider.setMaximum(100)
-                        self.app_volume_slider.valueChanged.connect(self._on_app_volume_slider_changed)
-
-                        vol_layout.addWidget(self.app_volume_slider, 0, Qt.AlignmentFlag.AlignCenter)
-
-                        # Add mute/unmute button below the volume slider
-                        self._app_mute_button = ClickableLabel(self)
-                        self._app_mute_button.setAlignment(Qt.AlignmentFlag.AlignCenter)
-                        self._app_mute_button.setProperty("class", "mute-button")
-                        self._app_mute_button.data = self._toggle_app_mute
-
-                        vol_layout.addWidget(self._app_mute_button, 0, Qt.AlignmentFlag.AlignCenter)
-                        content_layout.addWidget(self._vol_container, 0, Qt.AlignmentFlag.AlignRight)
-
-                        # Bind slider to the current media app session and set initial value
-                        self._bind_app_volume_session()
-                        self._updateapp_volume_slider()
-                        self._update_app_mute_button()
-                    except Exception as e:
-                        logger.error("Error creating app volume slider: %s", e)
-
+                self._app_mute_button = ClickableLabel(self)
+                self._app_mute_button.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                self._app_mute_button.setProperty("class", "mute-button")
+                self._app_mute_button.data = self._toggle_app_mute
+                vol_layout.addWidget(self._app_mute_button, 0, Qt.AlignmentFlag.AlignCenter)
+                content_layout.addWidget(self._vol_container, 0, Qt.AlignmentFlag.AlignRight)
             except Exception as e:
-                logger.error("Error setting thumbnail in menu: %s", e)
-        else:
-            # No media playing message
-            no_media_label = QLabel("No media playing")
-            no_media_label.setProperty("class", "no-media")
-            no_media_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-            content_layout.addWidget(no_media_label)
+                logger.error("Error creating app volume slider: %s", e)
 
-        # Add top layout to main layout
-        main_layout.addLayout(content_layout)
+        self._no_media_label = QLabel("No media playing")
+        self._no_media_label.setProperty("class", "no-media")
+        self._no_media_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        # Create horizontal layout for slider and time labels
+        main_layout.addWidget(self._media_content_frame)
+        main_layout.addWidget(self._no_media_label)
+
         self._time_slider_container = QFrame()
         self._time_slider_container.setProperty("class", "media-timeline-container")
         self._time_slider_container.setContentsMargins(0, 0, 0, 0)
-
-        # Use a vertical layout for the container instead of horizontal
         time_slider_layout = QVBoxLayout(self._time_slider_container)
         time_slider_layout.setContentsMargins(0, 0, 0, 0)
-        time_slider_layout.setSpacing(0)  # Add spacing between slider and time labels
+        time_slider_layout.setSpacing(0)
 
-        # Create and configure the slider
         self._progress_slider = QSlider(Qt.Orientation.Horizontal)
         self._progress_slider.setProperty("class", "progress-slider")
         self._progress_slider.setMinimum(0)
-        self._progress_slider.setMaximum(1000)  # We use 1000 for better precision
+        self._progress_slider.setMaximum(1000)
 
-        # Create a horizontal layout for the time labels
         time_labels_layout = QHBoxLayout()
         time_labels_layout.setContentsMargins(0, 0, 0, 0)
         time_labels_layout.setSpacing(0)
 
-        # Create time labels for current and total time
         self._popup_current_time_label = QLabel("00:00")
         self._popup_current_time_label.setProperty("class", "playback-time current")
         self._popup_current_time_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
@@ -406,77 +395,113 @@ class MediaWidget(BaseWidget):
         self._popup_total_time_label.setProperty("class", "playback-time total")
         self._popup_total_time_label.setAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
 
-        # Initialize with current times if available
-        if self.current_session is not None:
-            self._popup_current_time_label.setText(self._format_time(self.current_session.current_pos))
-            self._popup_total_time_label.setText(self._format_time(self.current_session.duration))
-
-        # Add time labels to the horizontal layout with stretch to push them apart
         time_labels_layout.addWidget(self._popup_current_time_label)
-        time_labels_layout.addStretch(1)  # This pushes the labels to opposite sides
+        time_labels_layout.addStretch(1)
         time_labels_layout.addWidget(self._popup_total_time_label)
-
-        # Add the time labels layout to the main vertical layout
         time_slider_layout.addLayout(time_labels_layout)
         time_slider_layout.addWidget(self._progress_slider)
-
-        # Add the time-slider layout to the main layout instead of just the slider
         main_layout.addWidget(self._time_slider_container)
 
-        # Initialize slider position
-        if self.current_session is not None and self.current_session.duration > 0:
-            percent = min(
-                1000,
-                int((self.current_session.current_pos / self.current_session.duration) * 1000),
-            )
-            self._progress_slider.setValue(percent)
-        else:
-            self._progress_slider.setValue(0)
-
-        # Connect slider events
         self._progress_slider.sliderPressed.connect(self._on_slider_pressed)
         self._progress_slider.sliderReleased.connect(self._on_slider_released)
         self._progress_slider.valueChanged.connect(self._on_slider_value_changed)
-
-        # Initialize seeking flag
         self._seeking = False
 
-        if not (
-            self.current_session
-            and self.current_session.timeline_enabled
-            and (0 < self.current_session.duration < MAX_TIMLINE_DURATION)  # hide timeline if duration is too long
-        ):
-            self._time_slider_container.setVisible(False)
-            QTimer.singleShot(0, self.dialog.adjustSize)
-
-        self.dialog.adjustSize()
-        self.dialog.setPosition(
-            alignment=self.config.media_menu.alignment,
-            direction=self.config.media_menu.direction,
-            offset_left=self.config.media_menu.offset_left,
-            offset_top=self.config.media_menu.offset_top,
-        )
-        self._update_popup_menu_buttons()
-        self.dialog.show()
-
-        # Create and install the filter
         self._wheel_filter = WheelEventFilter(self)
         self.dialog.installEventFilter(self._wheel_filter)
 
-        if self.config.media_menu.show_volume_slider:
-            self._updateapp_volume_slider()
-            self._update_app_mute_button()
+    def _refresh_popup_content(self):
+        """Update persistent popup widgets from current_session."""
+        if not is_valid_qobject(self.dialog):
+            return
+
+        has_session = self.current_session is not None
+        if is_valid_qobject(self._media_content_frame):
+            self._media_content_frame.setVisible(has_session)
+        if is_valid_qobject(self._no_media_label):
+            self._no_media_label.setVisible(not has_session)
+
+        if not has_session:
+            if is_valid_qobject(self._time_slider_container):
+                self._time_slider_container.setVisible(False)
+            return
+
+        try:
+            title = (
+                self._format_max_field_size(self.current_session.title, "popup_title")
+                if self.current_session.title
+                else "Unknown Title"
+            )
+            artist = (
+                self._format_max_field_size(self.current_session.artist, "popup_artist")
+                if self.current_session.artist
+                else ""
+            )
+            if is_valid_qobject(self._popup_title_label):
+                self._popup_title_label.setText(title)
+            if is_valid_qobject(self._popup_artist_label):
+                self._popup_artist_label.setText(artist)
+
+            if is_valid_qobject(self._popup_thumbnail_label):
+                if self.current_session.thumbnail is not None:
+                    popup_pixmap = self._create_thumbnail_for_popup(self.current_session.thumbnail)
+                else:
+                    popup_pixmap = self._create_empty_thumbnail()
+                self._popup_thumbnail_label.setPixmap(popup_pixmap or QPixmap())
+
+            if is_valid_qobject(self._popup_source_label):
+                source_name, source_class_name = self._get_source_app_name()
+                if source_name is not None:
+                    self._popup_source_label.setText(source_name)
+                    self._popup_source_label.setProperty("class", f"source {source_class_name}")
+                    refresh_widget_style(self._popup_source_label)
+                    self._popup_source_label.show()
+                else:
+                    self._popup_source_label.hide()
+
+            if is_valid_qobject(self._popup_current_time_label):
+                self._popup_current_time_label.setText(self._format_time(self.current_session.current_pos))
+            if is_valid_qobject(self._popup_total_time_label):
+                self._popup_total_time_label.setText(self._format_time(self.current_session.duration))
+
+            show_timeline = bool(
+                self.current_session.timeline_enabled and (0 < self.current_session.duration < MAX_TIMLINE_DURATION)
+            )
+            if is_valid_qobject(self._time_slider_container):
+                self._time_slider_container.setVisible(show_timeline)
+            if is_valid_qobject(self._progress_slider):
+                if self.current_session.duration > 0:
+                    percent = min(
+                        1000,
+                        int((self.current_session.current_pos / self.current_session.duration) * 1000),
+                    )
+                    self._progress_slider.setValue(percent)
+                else:
+                    self._progress_slider.setValue(0)
+
+            if self.config.media_menu.show_volume_slider:
+                self._bind_app_volume_session()
+                self._updateapp_volume_slider()
+                self._update_app_mute_button()
+
+            self._update_popup_menu_buttons()
+        except Exception as e:
+            logger.error("Error refreshing popup content: %s", e)
 
     def _get_source_app_name(self):
-        """Get formatted source app name from media info or session."""
+        """Resolve source app display name from the current session AUMID."""
         if not self.current_session or not (source_app := self.current_session.app_id):
             return None, None
         try:
-            # Direct lookup
-            source_name = get_source_app_display_name(source_app)
+            source_name = resolve_source_app_name(
+                source_app,
+                title=self.current_session.title or None,
+            )
             if source_name:
-                return source_name, get_source_app_class_name(source_name)
-            logger.debug("Unknown source app in session: '%s' - consider adding to source_apps.py", source_app)
+                return (
+                    self._format_max_field_size(source_name, "popup_source"),
+                    get_source_app_class_name(source_name),
+                )
         except Exception:
             logger.exception("Error getting media source")
         return None, None
@@ -540,13 +565,12 @@ class MediaWidget(BaseWidget):
 
     def _open_media_source(self):
         if self.current_session and self.current_session.app_id:
-            # Try to get process name from mapping for fallback
-            fallback_process = None
-            mapping = get_source_app_mapping(self.current_session.app_id)
-            if mapping and isinstance(mapping, dict):
-                fallback_process = mapping.get("process")
-
-            activate_app_by_aumid(self.current_session.app_id, fallback_process_name=fallback_process)
+            aumid = resolve_activate_aumid(
+                self.current_session.app_id,
+                title=self.current_session.title or None,
+            )
+            fallback_process = get_process_name_for_aumid(aumid)
+            activate_app_by_aumid(aumid, fallback_process_name=fallback_process)
 
     def _on_timeline_properties_changed(self):
         """Handle timeline property updates."""
@@ -587,7 +611,7 @@ class MediaWidget(BaseWidget):
                 self._progress_bar.setHidden(True)
 
             # Skip updates if user is currently seeking or dialog isn't visible
-            if not (hasattr(self, "dialog") and self.dialog.isVisible()):
+            if not (is_valid_qobject(self.dialog) and self.dialog.isVisible()):
                 return
             if self._seeking:
                 return
@@ -595,12 +619,12 @@ class MediaWidget(BaseWidget):
             duration = self.current_session.duration
 
             # Update UI with estimated position
-            if hasattr(self, "_popup_current_time_label") and self._popup_current_time_label:
+            if is_valid_qobject(self._popup_current_time_label):
                 position_str = self._format_time(position)
                 self._popup_current_time_label.setText(position_str)
 
             # Smoother slider updates - only update if the difference is significant
-            if hasattr(self, "_progress_slider") and self._progress_slider and duration > 0:
+            if is_valid_qobject(self._progress_slider) and duration > 0:
                 # Calculate percentage position
                 new_percent = min(1000, int((position / duration) * 1000))
                 current_percent = self._progress_slider.value()
@@ -611,12 +635,7 @@ class MediaWidget(BaseWidget):
                     self._progress_slider.setValue(new_percent)
 
         except RuntimeError:
-            # The label or progress bar has been deleted (dialog closed)
-            # Clear references to prevent future errors
-            if hasattr(self, "_popup_current_time_label"):
-                self._popup_current_time_label = None
-            if hasattr(self, "_progress_slider"):
-                self._progress_slider = None
+            pass
         except Exception as e:
             logger.error("Error updating interpolated position: %s", e)
 
@@ -687,7 +706,7 @@ class MediaWidget(BaseWidget):
 
         # Update popup if it's currently open
         try:
-            if hasattr(self, "dialog") and self.dialog.isVisible():
+            if is_valid_qobject(self.dialog) and self.dialog.isVisible():
                 play_icon_popup = (
                     self.config.media_menu_icons.pause if is_playing else self.config.media_menu_icons.play
                 )
@@ -706,48 +725,16 @@ class MediaWidget(BaseWidget):
                     self._popup_next_label.setProperty("class", f"btn next {'disabled' if not is_next_enabled else ''}")
                     refresh_widget_style(self._popup_next_label)
         except RuntimeError:
-            self._popup_play_button = None
-            self._popup_prev_label = None
-            self._popup_next_label = None
+            pass
         except Exception as e:
             logger.error("Error updating popup button: %s", e)
-            self._popup_play_button = None
-            self._popup_prev_label = None
-            self._popup_next_label = None
 
     @pyqtSlot()
     def _on_media_properties_changed(self):
         try:
-            if self.current_session is not None and hasattr(self, "dialog") and self.dialog.isVisible():
-                try:
-                    if (
-                        hasattr(self, "_popup_title_label")
-                        and hasattr(self, "_popup_artist_label")
-                        and hasattr(self, "_popup_thumbnail_label")
-                    ):
-                        self._popup_title_label.setText(
-                            self._format_max_field_size(self.current_session.title, "popup_title")
-                        )
-                        self._popup_artist_label.setText(
-                            self._format_max_field_size(self.current_session.artist, "popup_artist")
-                        )
-
-                        if self.current_session.thumbnail is not None:
-                            popup_pixmap = self._create_thumbnail_for_popup(self.current_session.thumbnail)
-                        else:
-                            popup_pixmap = self._create_empty_thumbnail()
-                        self._popup_thumbnail_label.setPixmap(popup_pixmap or QPixmap())
-
-                    if hasattr(self, "_popup_source_label"):
-                        source_name, source_class_name = self._get_source_app_name()
-                        if source_name is not None:
-                            self._popup_source_label.setText(source_name)
-                            self._popup_source_label.setProperty("class", f"source {source_class_name}")
-
-                            refresh_widget_style(self._popup_source_label)
-
-                except Exception as e:
-                    logger.error("Error updating popup content: %s", e)
+            if is_valid_qobject(self.dialog) and self.dialog.isVisible():
+                self._refresh_popup_content()
+                self.dialog.adjustSize()
         except RuntimeError:
             pass
         except Exception as e:
@@ -813,7 +800,6 @@ class MediaWidget(BaseWidget):
         """Create a default thumbnail with an eighth note icon."""
         try:
             size = self.config.media_menu.thumbnail_size
-            corner_radius = self.config.media_menu.thumbnail_corner_radius
             # Create base image with dark background
             large_size = size * 2  # Create at higher resolution for better quality
             large_img = Image.new("RGBA", (large_size, large_size), (0, 0, 0, 255))
@@ -871,15 +857,6 @@ class MediaWidget(BaseWidget):
 
             # Resize down to target size with high quality anti-aliasing
             img = large_img.resize((size, size), Image.LANCZOS)
-
-            # Add rounded corners
-            mask = Image.new("L", (size, size), 0)
-            mask_draw = ImageDraw(mask)
-            mask_draw.rounded_rectangle(((0, 0), (size, size)), corner_radius, fill=150)
-
-            # Apply mask for rounded corners
-            img.putalpha(mask)
-
             return QPixmap.fromImage(ImageQt(img))
 
         except Exception as e:
@@ -887,11 +864,9 @@ class MediaWidget(BaseWidget):
             return None
 
     def _create_thumbnail_for_popup(self, img: Image.Image):
-        """Process image thumbnail into a square with rounded corners for popup display."""
+        """Process image thumbnail into a square for popup display."""
         try:
             square_size = self.config.media_menu.thumbnail_size
-            # Increase corner radius for more visible rounded corners (25% instead of 15%)
-            corner_radius = self.config.media_menu.thumbnail_corner_radius
 
             # Calculate aspect ratio
             aspect = img.width / img.height
@@ -915,29 +890,9 @@ class MediaWidget(BaseWidget):
             else:
                 square_img = resized.resize((square_size, square_size), Image.LANCZOS)
 
-            # Ensure image is RGBA
             if square_img.mode != "RGBA":
                 square_img = square_img.convert("RGBA")
 
-            # Create much higher-resolution mask for better anti-aliasing (12x size)
-            scale = 4  # Significantly increased for smoother corners
-            hr_size = square_size * scale
-            hr_radius = corner_radius * scale
-
-            # Create the mask
-            mask = Image.new("L", (hr_size, hr_size), color=0)
-            draw = ImageDraw(mask)
-
-            # Draw rounded rectangle with smoother corners
-            draw.rounded_rectangle(((0, 0), (hr_size, hr_size)), radius=hr_radius, fill=255)
-
-            # Resize mask back down with high-quality anti-aliasing
-            mask = mask.resize((square_size, square_size), Image.LANCZOS)
-
-            # Apply the mask to create rounded corners
-            square_img.putalpha(mask)
-
-            # Convert to QPixmap
             return QPixmap.fromImage(ImageQt(square_img))
         except Exception as e:
             logger.error("Error creating square thumbnail: %s", e)
@@ -1045,6 +1000,8 @@ class MediaWidget(BaseWidget):
             max_size = self.config.media_menu.max_title_size
         elif field_type == "popup_artist":
             max_size = self.config.media_menu.max_artist_size
+        elif field_type == "popup_source":
+            max_size = self.config.media_menu.max_source_size
         else:
             # If we are using scrolling labels, return the original text without formatting
             if self.config.scrolling_label.enabled:
@@ -1156,27 +1113,6 @@ class MediaWidget(BaseWidget):
 
         return None
 
-    def _match_session_by_mapping(self, sessions: list[MediaSession], aumid: str) -> MediaSession | None:
-        """Match session using source app mapping."""
-        if not aumid:
-            return None
-
-        mapping = get_source_app_mapping(aumid)
-        if not mapping:
-            return None
-
-        process_name = mapping.get("process")
-        if process_name:
-            for session in sessions:
-                try:
-                    proc = getattr(session, "Process", None)
-                    if proc and proc.name().lower() == process_name.lower():
-                        return session
-                except Exception:
-                    continue
-
-        return None
-
     def _match_session_by_aumid(self, sessions: list[MediaSession], aumid: str):
         """Match session by process AUMID."""
         target_aumid = aumid.lower()
@@ -1217,9 +1153,6 @@ class MediaWidget(BaseWidget):
             sessions = cast(list[MediaSession], AudioUtilities.GetAllSessions())
             candidate = None
             if aumid:
-                candidate = self._match_session_by_mapping(sessions, aumid)
-
-            if not candidate and aumid:
                 candidate = self._match_session_by_aumid(sessions, aumid)
 
             if not candidate and identifier:
@@ -1249,7 +1182,8 @@ class MediaWidget(BaseWidget):
 
         volume_interface = self._get_volume_interface()
         if not volume_interface:
-            self._vol_container.hide()
+            if self._vol_container is not None:
+                self._vol_container.hide()
             self.app_volume_slider.setEnabled(False)
             return
 
@@ -1261,6 +1195,8 @@ class MediaWidget(BaseWidget):
             self.app_volume_slider.setValue(level)
             self.app_volume_slider.blockSignals(False)
             self.app_volume_slider.setEnabled(True)
+            if self._vol_container is not None:
+                self._vol_container.show()
 
         except Exception as e:
             logger.error("Failed to read app volume: %s", e)
@@ -1350,6 +1286,31 @@ class ClickableLabel(QLabel):
         ev.accept()
 
 
+class RoundedClickableLabel(ClickableLabel):
+    """Pixmap label that clips to rounded corners at paint time."""
+
+    def __init__(self, parent: MediaWidget | None = None, radius: int = 0):
+        super().__init__(parent)
+        self._corner_radius = max(0, radius)
+
+    def paintEvent(self, a0: QPaintEvent | None):
+        pix = self.pixmap()
+        if pix is None or pix.isNull() or self._corner_radius <= 0:
+            super().paintEvent(a0)
+            return
+
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        # painter.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform, True)
+        rect = QRectF(self.contentsRect())
+        radius = min(float(self._corner_radius), min(rect.width(), rect.height()) / 2.0)
+        path = QPainterPath()
+        path.addRoundedRect(rect, radius, radius)
+        painter.setClipPath(path)
+        painter.drawPixmap(self.contentsRect(), pix, pix.rect())
+        painter.end()
+
+
 class WheelEventFilter(QObject):
     """
     Install event filter to capture wheel events in the popup to handle wheel events for media session switching.
@@ -1364,6 +1325,8 @@ class WheelEventFilter(QObject):
         if event.type() == QEvent.Type.Wheel:
             event = cast(QWheelEvent, event)
             dialog = self.media_widget.dialog
+            if not is_valid_qobject(dialog):
+                return False
             if not dialog.geometry().contains(event.globalPosition().toPoint()):
                 return False
 
@@ -1375,14 +1338,9 @@ class WheelEventFilter(QObject):
                 if slider_global_rect.contains(event.globalPosition().toPoint()):
                     return False
 
-            old_session = self.media_widget.current_session
             if event.angleDelta().y() > 0:
                 self.media_widget.media.switch_current_session(+1)
             elif event.angleDelta().y() < 0:
                 self.media_widget.media.switch_current_session(-1)
-            new_session = self.media_widget.current_session
-            if new_session != old_session:
-                self.media_widget.dialog.hide()
-                self.media_widget.show_menu()
             return True
         return False

--- a/src/core/widgets/yasb/media.py
+++ b/src/core/widgets/yasb/media.py
@@ -1,5 +1,7 @@
 import ctypes
+import io
 import logging
+import os
 from collections.abc import Callable
 from enum import StrEnum
 from typing import Any, Literal, cast
@@ -43,10 +45,10 @@ from core.widgets.services.media.aumid_process import get_process_name_for_aumid
 from core.widgets.services.media.media import MediaSession, SessionState, WindowsMedia
 from core.widgets.services.media.source_apps import (
     get_source_app_class_name,
-    resolve_activate_aumid,
     resolve_source_app_name,
 )
 from core.widgets.services.media.tokenizer import clean_string
+from settings import SCRIPT_PATH
 
 logger = logging.getLogger("MediaWidget")
 
@@ -86,6 +88,7 @@ class MediaWidget(BaseWidget):
 
         # Get media manager
         self.media = WindowsMedia()
+        self._empty_thumb: QPixmap | None = self._build_empty_thumbnail()
 
         # Make a grid box to overlay the text and thumbnail
         self.thumbnail_stack = QGridLayout()
@@ -203,6 +206,7 @@ class MediaWidget(BaseWidget):
         self._vol_container: QFrame | None = None
         self._time_slider_container: QFrame | None = None
         self._progress_slider: QSlider | None = None
+        self._popup_timeline_session_id: str = ""
         self._popup_current_time_label: QLabel | None = None
         self._popup_total_time_label: QLabel | None = None
         self._popup_thumbnail_label = None
@@ -243,7 +247,6 @@ class MediaWidget(BaseWidget):
             self._create_media_popup()
 
         self._refresh_popup_content()
-        self.dialog.adjustSize()
         self.dialog.setPosition(
             alignment=self.config.media_menu.alignment,
             direction=self.config.media_menu.direction,
@@ -291,15 +294,17 @@ class MediaWidget(BaseWidget):
         self._popup_title_label.setContentsMargins(0, 0, 0, 0)
         self._popup_title_label.setProperty("class", "title")
         self._popup_title_label.setWordWrap(True)
-        self._popup_title_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Maximum)
+        self._popup_title_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Minimum)
+        self._popup_title_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
 
         self._popup_artist_label = QLabel("")
         self._popup_artist_label.setContentsMargins(0, 0, 0, 0)
         self._popup_artist_label.setProperty("class", "artist")
         self._popup_artist_label.setWordWrap(True)
-        self._popup_artist_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Maximum)
-        text_layout.addWidget(self._popup_title_label, alignment=Qt.AlignmentFlag.AlignTop)
-        text_layout.addWidget(self._popup_artist_label, alignment=Qt.AlignmentFlag.AlignTop)
+        self._popup_artist_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Minimum)
+        self._popup_artist_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
+        text_layout.addWidget(self._popup_title_label)
+        text_layout.addWidget(self._popup_artist_label)
         text_layout.addStretch(1)
 
         control_layout = QHBoxLayout()
@@ -334,11 +339,12 @@ class MediaWidget(BaseWidget):
         if self.config.media_menu.show_source:
             self._popup_source_label = QLabel("")
             self._popup_source_label.setProperty("class", "source")
+            self._popup_source_label.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Minimum)
             self._popup_source_label.hide()
             control_layout.addWidget(self._popup_source_label, 0, Qt.AlignmentFlag.AlignVCenter)
 
         text_layout.addLayout(control_layout)
-        content_layout.addLayout(text_layout)
+        content_layout.addLayout(text_layout, 1)
 
         if self.config.media_menu.show_volume_slider:
             try:
@@ -360,7 +366,9 @@ class MediaWidget(BaseWidget):
                 self._app_mute_button.setProperty("class", "mute-button")
                 self._app_mute_button.data = self._toggle_app_mute
                 vol_layout.addWidget(self._app_mute_button, 0, Qt.AlignmentFlag.AlignCenter)
-                content_layout.addWidget(self._vol_container, 0, Qt.AlignmentFlag.AlignRight)
+                content_layout.addWidget(
+                    self._vol_container, 0, Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignTop
+                )
             except Exception as e:
                 logger.error("Error creating app volume slider: %s", e)
 
@@ -415,22 +423,34 @@ class MediaWidget(BaseWidget):
         if not is_valid_qobject(self.dialog):
             return
 
-        has_session = self.current_session is not None
-        if is_valid_qobject(self._media_content_frame):
-            self._media_content_frame.setVisible(has_session)
-        if is_valid_qobject(self._no_media_label):
-            self._no_media_label.setVisible(not has_session)
+        if self.current_session is None:
+            if not self.all_sessions:
+                if is_valid_qobject(self._media_content_frame):
+                    self._media_content_frame.setVisible(False)
+                if is_valid_qobject(self._no_media_label):
+                    self._no_media_label.setVisible(True)
+                if is_valid_qobject(self._time_slider_container):
+                    self._time_slider_container.setVisible(False)
+                return
 
-        if not has_session:
-            if is_valid_qobject(self._time_slider_container):
-                self._time_slider_container.setVisible(False)
+            if is_valid_qobject(self._media_content_frame):
+                self._media_content_frame.setVisible(True)
+            if is_valid_qobject(self._no_media_label):
+                self._no_media_label.setVisible(False)
+            if is_valid_qobject(self._progress_slider):
+                self._progress_slider.setEnabled(False)
             return
+
+        if is_valid_qobject(self._media_content_frame):
+            self._media_content_frame.setVisible(True)
+        if is_valid_qobject(self._no_media_label):
+            self._no_media_label.setVisible(False)
 
         try:
             title = (
                 self._format_max_field_size(self.current_session.title, "popup_title")
                 if self.current_session.title
-                else "Unknown Title"
+                else ""
             )
             artist = (
                 self._format_max_field_size(self.current_session.artist, "popup_artist")
@@ -442,11 +462,8 @@ class MediaWidget(BaseWidget):
             if is_valid_qobject(self._popup_artist_label):
                 self._popup_artist_label.setText(artist)
 
-            if is_valid_qobject(self._popup_thumbnail_label):
-                if self.current_session.thumbnail is not None:
-                    popup_pixmap = self._create_thumbnail_for_popup(self.current_session.thumbnail)
-                else:
-                    popup_pixmap = self._create_empty_thumbnail()
+            if is_valid_qobject(self._popup_thumbnail_label) and self.current_session.thumbnail is not None:
+                popup_pixmap = self._create_thumbnail_for_popup(self.current_session.thumbnail)
                 self._popup_thumbnail_label.setPixmap(popup_pixmap or QPixmap())
 
             if is_valid_qobject(self._popup_source_label):
@@ -461,23 +478,27 @@ class MediaWidget(BaseWidget):
 
             if is_valid_qobject(self._popup_current_time_label):
                 self._popup_current_time_label.setText(self._format_time(self.current_session.current_pos))
-            if is_valid_qobject(self._popup_total_time_label):
+            if is_valid_qobject(self._popup_total_time_label) and self.current_session.duration > 0:
                 self._popup_total_time_label.setText(self._format_time(self.current_session.duration))
 
-            show_timeline = bool(
-                self.current_session.timeline_enabled and (0 < self.current_session.duration < MAX_TIMLINE_DURATION)
-            )
+            show_timeline = bool(0 < self.current_session.duration < MAX_TIMLINE_DURATION)
             if is_valid_qobject(self._time_slider_container):
-                self._time_slider_container.setVisible(show_timeline)
+                # Only hide when leaving this session or truly no timeline not on blips.
+                if show_timeline:
+                    self._time_slider_container.setVisible(True)
+                elif self._popup_timeline_session_id != self.current_session.app_id:
+                    self._time_slider_container.setVisible(False)
             if is_valid_qobject(self._progress_slider):
-                if self.current_session.duration > 0:
+                if show_timeline:
+                    self._progress_slider.setEnabled(True)
                     percent = min(
                         1000,
                         int((self.current_session.current_pos / self.current_session.duration) * 1000),
                     )
                     self._progress_slider.setValue(percent)
-                else:
-                    self._progress_slider.setValue(0)
+                elif self._popup_timeline_session_id != self.current_session.app_id:
+                    self._progress_slider.setEnabled(False)
+            self._popup_timeline_session_id = self.current_session.app_id
 
             if self.config.media_menu.show_volume_slider:
                 self._bind_app_volume_session()
@@ -485,6 +506,7 @@ class MediaWidget(BaseWidget):
                 self._update_app_mute_button()
 
             self._update_popup_menu_buttons()
+
         except Exception as e:
             logger.error("Error refreshing popup content: %s", e)
 
@@ -493,10 +515,7 @@ class MediaWidget(BaseWidget):
         if not self.current_session or not (source_app := self.current_session.app_id):
             return None, None
         try:
-            source_name = resolve_source_app_name(
-                source_app,
-                title=self.current_session.title or None,
-            )
+            source_name = resolve_source_app_name(source_app)
             if source_name:
                 return (
                     self._format_max_field_size(source_name, "popup_source"),
@@ -520,6 +539,9 @@ class MediaWidget(BaseWidget):
                 is_prev_enabled = True
                 is_next_enabled = True
                 is_play_enabled = True
+            if self.current_session is not None and self.current_session._pause_interpolate:
+                is_prev_enabled = False
+                is_next_enabled = False
 
             # Update popup button states
             if self._popup_play_button:
@@ -565,10 +587,7 @@ class MediaWidget(BaseWidget):
 
     def _open_media_source(self):
         if self.current_session and self.current_session.app_id:
-            aumid = resolve_activate_aumid(
-                self.current_session.app_id,
-                title=self.current_session.title or None,
-            )
+            aumid = self.current_session.app_id
             fallback_process = get_process_name_for_aumid(aumid)
             activate_app_by_aumid(aumid, fallback_process_name=fallback_process)
 
@@ -585,12 +604,22 @@ class MediaWidget(BaseWidget):
             try:
                 if hasattr(self, "_popup_current_time_label") and self._popup_current_time_label:
                     self._popup_current_time_label.setText(self._format_time(position_sec))
-                if hasattr(self, "_popup_total_time_label") and self._popup_total_time_label:
+                if hasattr(self, "_popup_total_time_label") and self._popup_total_time_label and duration_sec > 0:
                     self._popup_total_time_label.setText(self._format_time(duration_sec))
             except RuntimeError:
                 # Labels were deleted when popup closed
                 self._popup_current_time_label = None
                 self._popup_total_time_label = None
+
+            # Duration can arrive after popup open (YouTube before first interaction).
+            if is_valid_qobject(self.dialog) and self.dialog.isVisible():
+                show_timeline = bool(0 < duration_sec < MAX_TIMLINE_DURATION)
+                if is_valid_qobject(self._time_slider_container) and show_timeline:
+                    self._time_slider_container.setVisible(True)
+                if is_valid_qobject(self._progress_slider) and show_timeline:
+                    self._progress_slider.setEnabled(True)
+
+            self._on_playback_info_changed()
 
         except Exception as e:
             logger.error("Error updating timeline: %s", e)
@@ -600,15 +629,15 @@ class MediaWidget(BaseWidget):
             return
         try:
             # Update widget progress bar first (hide progress bar if duration is too long)
-            if self.current_session.timeline_enabled and (0 < self.current_session.duration < MAX_TIMLINE_DURATION):
+            duration = self.current_session.duration
+            if 0 < duration < MAX_TIMLINE_DURATION:
                 self._progress_bar.setHidden(False)
                 new_pos = min(
                     1000,
-                    int((self.current_session.current_pos / self.current_session.duration) * 1000),
+                    int((self.current_session.current_pos / duration) * 1000),
                 )
                 self._progress_bar.setValue(new_pos)
-            else:
-                self._progress_bar.setHidden(True)
+            # Do not hide on duration==0 blips; session clear handles hide.
 
             # Skip updates if user is currently seeking or dialog isn't visible
             if not (is_valid_qobject(self.dialog) and self.dialog.isVisible()):
@@ -616,7 +645,6 @@ class MediaWidget(BaseWidget):
             if self._seeking:
                 return
             position = self.current_session.current_pos
-            duration = self.current_session.duration
 
             # Update UI with estimated position
             if is_valid_qobject(self._popup_current_time_label):
@@ -682,6 +710,9 @@ class MediaWidget(BaseWidget):
         is_prev_enabled = self.current_session.controls_prev_enabled
         is_play_enabled = self.current_session.controls_play_enabled
         is_next_enabled = self.current_session.controls_next_enabled
+        if self.current_session._pause_interpolate:
+            is_prev_enabled = False
+            is_next_enabled = False
         self._is_playing = is_playing
 
         if not self.config.controls_hide:
@@ -734,7 +765,6 @@ class MediaWidget(BaseWidget):
         try:
             if is_valid_qobject(self.dialog) and self.dialog.isVisible():
                 self._refresh_popup_content()
-                self.dialog.adjustSize()
         except RuntimeError:
             pass
         except Exception as e:
@@ -749,43 +779,44 @@ class MediaWidget(BaseWidget):
 
         # Process label content
         if self.current_session is not None:
-            try:
-                items = (
-                    ("title", self.current_session.title),
-                    ("artist", self.current_session.artist),
-                )
-                formatted_info: dict[str, str] = {"s": self.config.separator}
-                for k, v in items:
-                    formatted_info[k] = self._format_max_field_size(v)
+            # Empty title/artist during SMTC blips: keep the label as-is.
+            if self.current_session.title or self.current_session.artist:
+                try:
+                    items = (
+                        ("title", self.current_session.title),
+                        ("artist", self.current_session.artist),
+                    )
+                    formatted_info: dict[str, str] = {"s": self.config.separator}
+                    for k, v in items:
+                        formatted_info[k] = self._format_max_field_size(v)
 
-                # Clean the label content from any empty placeholders or dangling separators
-                cleaned_content = clean_string(active_label_content, formatted_info)
+                    # Clean the label content from any empty placeholders or dangling separators
+                    cleaned_content = clean_string(active_label_content, formatted_info)
 
-                # Replace the remaining placeholders and separators
-                formatted_label = cleaned_content.format_map(formatted_info)
+                    # Replace the remaining placeholders and separators
+                    formatted_label = cleaned_content.format_map(formatted_info)
 
-                # Finally, truncate the label if necessary
-                if self.config.max_field_size.truncate_whole_label:
-                    formatted_label = self._format_max_field_size(formatted_label)
-            except Exception as e:
-                logger.error("Error formatting label: %s", e, exc_info=True)
-                if self.current_session and self.current_session.title:
-                    formatted_label = self._format_max_field_size(self.current_session.title)
-                else:
-                    formatted_label = "No media"
-            active_label.setText(formatted_label)
+                    # Finally, truncate the label if necessary
+                    if self.config.max_field_size.truncate_whole_label:
+                        formatted_label = self._format_max_field_size(formatted_label)
+                except Exception as e:
+                    logger.error("Error formatting label: %s", e, exc_info=True)
+                    if self.current_session.title:
+                        formatted_label = self._format_max_field_size(self.current_session.title)
+                    else:
+                        return
+                active_label.setText(formatted_label)
 
         # If we don't want the thumbnail, stop here
         if not self.config.show_thumbnail:
             return
 
-        # If no media in session, hide thumbnail and stop here
-        if self.current_session and self.current_session.thumbnail is None:
-            self._thumbnail_label.hide()
+        # Missing thumb during blip: keep last pixmap (only clear when session is gone).
+        if self.current_session is None or self.current_session.thumbnail is None:
             return
-        # Only update the thumbnail if the title/artist changes or if we did a toggle (resize)
+
         try:
-            if self.current_session and self.current_session.title and self.current_session.thumbnail:
+            if self.current_session.title and self.current_session.thumbnail:
                 thumbnail = self._crop_thumbnail(self.current_session.thumbnail, active_label.sizeHint().width())
                 pixmap = QPixmap.fromImage(ImageQt(thumbnail))
                 self._thumbnail_label.setPixmap(pixmap)
@@ -796,69 +827,23 @@ class MediaWidget(BaseWidget):
         else:
             self._thumbnail_label.show()
 
-    def _create_empty_thumbnail(self):
-        """Create a default thumbnail with an eighth note icon."""
+    def _build_empty_thumbnail(self) -> QPixmap | None:
+        """Load app icon once as the popup fallback when session has no art."""
         try:
+            icon_path = os.path.join(SCRIPT_PATH, "assets", "images", "app_icon.png")
+            if not os.path.exists(icon_path):
+                return None
             size = self.config.media_menu.thumbnail_size
-            # Create base image with dark background
-            large_size = size * 2  # Create at higher resolution for better quality
-            large_img = Image.new("RGBA", (large_size, large_size), (0, 0, 0, 255))
-            draw = ImageDraw(large_img)
-
-            # Use white color for the note
-            note_color = (255, 255, 255, 255)
-
-            # Scale all elements relative to image size
-            center_x = large_size // 2
-            center_y = large_size // 2
-
-            # Calculate note head dimensions - make it large like in the image
-            head_radius = int(large_size * 0.14)  # Note head is about 44% of width
-
-            # Calculate position of the note head (centered horizontally, lower half vertically)
-            head_x = center_x - int(large_size * 0.1)  # Slightly left of center
-            head_y = center_y + int(large_size * 0.12)  # Lower half
-
-            # Calculate stem dimensions
-            stem_width = int(large_size * 0.05)
-            stem_height = int(large_size * 0.4)
-
-            # Calculate flag dimensions
-            flag_width = int(large_size * 0.15)
-            flag_height = int(large_size * 0.3)
-
-            # Draw the note stem (vertical line)
-            stem_x = head_x + head_radius - stem_width  # Stem attaches to right side of note head
-            stem_top_y = head_y - stem_height
-            draw.rectangle(
-                (
-                    (stem_x, stem_top_y),  # Top-left
-                    (stem_x + stem_width, head_y),  # Bottom-right
-                ),
-                fill=note_color,
-            )
-
-            # Draw the note head (circle)
-            draw.ellipse(
-                [
-                    (head_x - head_radius, head_y - head_radius),
-                    (head_x + head_radius, head_y + head_radius),
-                ],
-                fill=note_color,
-            )
-
-            draw.rectangle(
-                (
-                    (stem_x + stem_width - 1, stem_top_y),
-                    (stem_x + stem_width + flag_width, stem_top_y + flag_height // 3),
-                ),
-                fill=note_color,
-            )
-
-            # Resize down to target size with high quality anti-aliasing
-            img = large_img.resize((size, size), Image.LANCZOS)
-            return QPixmap.fromImage(ImageQt(img))
-
+            with Image.open(icon_path) as image:
+                if image.mode != "RGBA":
+                    image = image.convert("RGBA")
+                resized = image.resize((size, size), Image.LANCZOS)
+                buf = io.BytesIO()
+                resized.save(buf, format="PNG")
+                source = QPixmap()
+                if not source.loadFromData(buf.getvalue()):
+                    return QPixmap(size, size)
+                return source
         except Exception as e:
             logger.error("Error creating default thumbnail: %s", e)
             return None
@@ -1057,14 +1042,11 @@ class MediaWidget(BaseWidget):
             return
         value = self._progress_slider.value()
         if self.current_session and self.current_session.duration > 0:
-            # Convert percentage to seconds
             position = (value / 1000.0) * self.current_session.duration
             try:
-                # Seek to the position
                 await self.media.seek_to_position(position)
             except Exception as e:
                 logger.error("Error seeking to position: %s", e)
-        # Resume automatic updates
         self._seeking = False
 
     def _on_slider_value_changed(self, value: int):
@@ -1072,13 +1054,11 @@ class MediaWidget(BaseWidget):
         if not self._seeking:
             return
 
-        # Update time labels to reflect potential new position
         if self.current_session and self.current_session.duration > 0:
             position = (value / 1000.0) * self.current_session.duration
             position_str = self._format_time(position)
             duration_str = self._format_time(self.current_session.duration)
 
-            # Update both time labels
             if self._popup_current_time_label is not None:
                 self._popup_current_time_label.setText(position_str)
             if self._popup_total_time_label is not None:
@@ -1146,25 +1126,19 @@ class MediaWidget(BaseWidget):
         """Locate and bind the audio session corresponding to current media app."""
         self._app_volume_session = None
         aumid = self._get_current_app_identifier()
-        identifier = (aumid or "").lower()
+        if not aumid:
+            return
 
         try:
             # pycaw handles COM initialization internally
             sessions = cast(list[MediaSession], AudioUtilities.GetAllSessions())
-            candidate = None
-            if aumid:
-                candidate = self._match_session_by_aumid(sessions, aumid)
-
-            if not candidate and identifier:
-                candidate = self._match_session_by_executable(sessions, identifier)
-
-            if not candidate and aumid:
+            candidate = self._match_session_by_aumid(sessions, aumid)
+            if not candidate:
+                # Resolves browsers/Electron via window AUMID (no hardcoded map).
                 proc_name = get_process_name_for_aumid(aumid)
                 if proc_name:
                     candidate = self._match_session_by_executable(sessions, proc_name)
-
             self._app_volume_session = candidate
-
         except Exception as e:
             logger.error("Failed to bind app volume session: %s", e)
             self._app_volume_session = None
@@ -1280,6 +1254,10 @@ class ClickableLabel(QLabel):
 
     def mouseReleaseEvent(self, ev: QMouseEvent | None):
         if ev is None:
+            return
+        classes = (self.property("class") or "").split()
+        if "disabled" in classes:
+            ev.accept()
             return
         if ev.button() == Qt.MouseButton.LeftButton and self.data and self.parent_widget:
             self.parent_widget.execute_code(self.data)


### PR DESCRIPTION
- Replace hardcoded MEDIA_SOURCE_APPS with cached AUMID resolver
- Keep media popup alive and refresh content in place
- Improve open-source activate for PWAs, portable Electron, and .exe AUMIDs
- Clip popup thumbnail corners at paint time
- Add media_menu.max_source_size for source label truncation