### PR TITLE
fix(systray): prevent icons getting squashed if other widgets use all the space

### DIFF
--- a/src/core/widgets/services/systray/systray_widget.py
+++ b/src/core/widgets/services/systray/systray_widget.py
@@ -252,6 +252,13 @@ class DropWidget(QFrame):
         self.dragged_button: IconWidget | None = None
         self._hover_btn: IconWidget | None = None
 
+    def update_content_width(self) -> None:
+        """Keep enough horizontal space for every visible tray icon."""
+        visible_icons = [icon for icon in self._get_all_icons() if not icon.isHidden()]
+        width = sum(icon.sizeHint().width() for icon in visible_icons)
+        width += max(0, len(visible_icons) - 1) * self.main_layout.spacing()
+        self.setMinimumWidth(width)
+
     @staticmethod
     def _set_class(widget: QWidget, name: str, add: bool):
         """Add or remove a CSS class and refresh the widget style."""
@@ -335,6 +342,7 @@ class DropWidget(QFrame):
 
         self.main_layout.insertWidget(insert_index, source)
         source.show()
+        self.update_content_width()
         self.dragged_button = None
         a0.acceptProposedAction()
         self.drag_ended.emit()

--- a/src/core/widgets/yasb/systray.py
+++ b/src/core/widgets/yasb/systray.py
@@ -352,7 +352,7 @@ class SystrayWidget(BaseWidget):
 
         # Clear drop-target indicator and restore min width
         self.pinned_widget.set_drop_target_style(False)
-        self.pinned_widget.setMinimumWidth(16)
+        self.pinned_widget.update_content_width()
         self.update_pinned_widget_visibility()
 
     def _is_hidden_icon(self, data: IconData) -> bool:
@@ -389,6 +389,7 @@ class SystrayWidget(BaseWidget):
             icon.is_pinned = saved_data.is_pinned
             if saved_data.is_pinned:
                 self.pinned_layout.addWidget(icon)
+                self.pinned_widget.update_content_width()
             else:
                 self._add_icon_to_unpinned(icon)
 
@@ -398,6 +399,8 @@ class SystrayWidget(BaseWidget):
         icon.update_icon()
         was_hidden = icon.isHidden()
         icon.setHidden(data.uFlags & NIF_STATE != 0 and data.dwState == 1)
+        if icon.is_pinned:
+            self.pinned_widget.update_content_width()
         if self.config.show_in_popup and was_hidden != icon.isHidden():
             self._relayout_popup_grid()
         self.pinned_vis_check_timer.start(300)
@@ -410,6 +413,7 @@ class SystrayWidget(BaseWidget):
             self.icons.remove(icon)
             icon.hide()
             icon.deleteLater()
+            self.pinned_widget.update_content_width()
             if self.config.show_in_popup:
                 self._relayout_popup_grid()
             self.pinned_vis_check_timer.start(300)
@@ -420,6 +424,7 @@ class SystrayWidget(BaseWidget):
         if not icon.is_pinned:
             self.pinned_layout.addWidget(icon)
             icon.is_pinned = True
+            self.pinned_widget.update_content_width()
         else:
             self._add_icon_to_unpinned(icon)
             icon.is_pinned = False


### PR DESCRIPTION
Prevent icons in the systray getting squashed if other widgets use all the space