### PR TITLE
feat(taskbar): add CSS classes for minimized, and visible windows

### DIFF
--- a/docs/widgets/(Widget)-Taskbar.md
+++ b/docs/widgets/(Widget)-Taskbar.md
@@ -75,6 +75,7 @@ taskbar:
 > Note:
 > When **preview** is enabled **tooltip** are automatically disabled to avoid overlap.
 
+
 ## Style
 ```css
 .taskbar-widget {} /* Main container for the taskbar widget */
@@ -83,7 +84,9 @@ taskbar:
 .taskbar-widget .app-container {} /* container for each app */
 .taskbar-widget .app-container.foreground {} /* container for the focused app */
 .taskbar-widget .app-container.flashing {} /* flashing container for the app (window is flashing) */
-.taskbar-widget .app-container.running {} /* container for running apps (not focused) */
+.taskbar-widget .app-container.running {} /* container for running apps (not focused)*/
+.taskbar-widget .app-container.not-focused {} /* visible, non-minimized app on the current desktop that is not focused */
+.taskbar-widget .app-container.minimized {} /* app minimized to the taskbar */
 .taskbar-widget .app-container .app-icon {} /* Icon inside the container */
 .taskbar-widget .app-container .app-title {} /* Label inside the container */
 /* Taskbar preview popup is very limited in styling options, do not use margins/paddings here */
@@ -92,6 +95,8 @@ taskbar:
 .taskbar-preview .header .title {}
 .taskbar-preview .close-button {} /* Close button on the preview */
 ```
+> Note:
+> **.taskbar-widget .app-container.running** is the base class for all running not-focused applications. Both **.not-focused** and **.minimized** also have the **.running** class, so if either selector is not defined, the **.running** styles will be applied automatically.
 
 ## Style Example
 ```css
@@ -107,6 +112,13 @@ taskbar:
     background-color: rgba(255, 106, 106, 0.63);
 }
 .taskbar-widget .app-container.running {
+    background-color: rgba(255, 255, 255, 0.25);
+}
+.taskbar-widget .app-container.minimized {
+    opacity: 0.4;
+    background-color: transparent;
+}
+.taskbar-widget .app-container.not-focused {
     background-color: rgba(255, 255, 255, 0.25);
 }
 .taskbar-widget .app-container:hover {

--- a/src/core/widgets/services/taskbar/application_window.py
+++ b/src/core/widgets/services/taskbar/application_window.py
@@ -109,12 +109,28 @@ class ApplicationWindow:
             "is_active": self.is_active,
             "is_flashing": self.is_flashing,
             "is_cloaked": self._is_cloaked(),
+            "is_minimized": self.is_minimized(),
+            "is_on_screen": self.is_on_screen(),
             "monitor_handle": monitor_handle,
             "process_name": self.process_name,
             "process_pid": self.process_pid,
             "process_path": self.process_path,
             "can_minimize": self.can_minimize(),
         }
+
+    def is_on_screen(self) -> bool:
+        """Return whether this window is currently visible on the active desktop."""
+        try:
+            return bool(win32gui.IsWindowVisible(self.hwnd)) and not self.is_minimized() and not self._is_cloaked()
+        except Exception:
+            return False
+
+    def is_minimized(self) -> bool:
+        """Return whether this window is minimized to the taskbar."""
+        try:
+            return bool(win32gui.IsIconic(self.hwnd))
+        except Exception:
+            return False
 
     def _refresh_process_info(self) -> None:
         """Refresh cached process information for this window."""

--- a/src/core/widgets/yasb/taskbar.py
+++ b/src/core/widgets/yasb/taskbar.py
@@ -1802,20 +1802,38 @@ class TaskbarWidget(BaseWidget):
         if hasattr(self, "_task_manager") and self._task_manager and hwnd in self._task_manager._windows:
             app_window = self._task_manager._windows[hwnd]
 
-            # Check for flashing state first (flashing takes priority over active)
-            if hasattr(app_window, "is_flashing") and app_window.is_flashing:
-                return f"{base_class} flashing"
-
-            # Then check for active state
+            # The focused window is never considered not-focused, even if it is flashing.
             if hasattr(app_window, "is_active") and app_window.is_active:
                 return f"{base_class} foreground"
+
+            return self._get_non_foreground_container_class(hwnd, app_window)
 
         # Fallback to GetForegroundWindow check
         if hwnd == win32gui.GetForegroundWindow():
             return f"{base_class} foreground"
 
-        # Not active, not flashing - just running
-        return f"{base_class} running"
+        return self._get_non_foreground_container_class(hwnd)
+
+    @staticmethod
+    def _get_non_foreground_container_class(hwnd: int, app_window=None) -> str:
+        """Get the CSS class for a taskbar window that is not in the foreground."""
+        base_class = "app-container"
+        if app_window is not None:
+            is_flashing = bool(getattr(app_window, "is_flashing", False))
+            is_minimized = bool(app_window.is_minimized())
+            is_on_screen = bool(app_window.is_on_screen())
+        else:
+            is_flashing = False
+            try:
+                is_minimized = bool(win32gui.IsIconic(hwnd))
+                is_on_screen = bool(win32gui.IsWindowVisible(hwnd)) and not is_minimized
+            except Exception:
+                is_minimized = False
+                is_on_screen = False
+
+        state_class = "flashing" if is_flashing else "running"
+        visibility_class = " minimized" if is_minimized else " not-focused" if is_on_screen else ""
+        return f"{base_class} {state_class}{visibility_class}"
 
     def _get_app_icon(self, hwnd: int, title: str) -> QPixmap | None:
         """Return a QPixmap for the given window handle, using a DPI-aware cache."""
@@ -1986,17 +2004,14 @@ class TaskbarWidget(BaseWidget):
                 if hwnd and hwnd < 0:
                     continue
 
-                # Base class for running apps
-                new_cls = "app-container running"
-
-                # Preserve flashing if manager reports it
+                app_window = None
                 try:
                     if hasattr(self, "_task_manager") and self._task_manager and hwnd in self._task_manager._windows:
-                        aw = self._task_manager._windows[hwnd]
-                        if getattr(aw, "is_flashing", False):
-                            new_cls = "app-container flashing"
+                        app_window = self._task_manager._windows[hwnd]
                 except Exception:
                     pass
+
+                new_cls = self._get_non_foreground_container_class(hwnd, app_window)
 
                 # Target gets 'foreground' (manager usually clears flashing on activation)
                 if target_hwnd is not None and hwnd == target_hwnd:


### PR DESCRIPTION
Added CSS classes to distinguish visible background windows from minimized Taskbar windows.

- Visible, non-focused windows receive `.not-focused`
- Minimized windows receive `.minimized`
- Existing `.running`, `.foreground`, and `.flashing` classes remains as it is

Previously, visible background windows and minimized windows shared the same **.running** class, making it impossible to style them differently. This lets user to further control the look of taskbar icons. **.running** has become a superset of **.minimized** and **.not-focused**.

## Example

```css
.taskbar-widget .app-container.minimized {
    opacity: 0.4;
    background-color: transparent;
}
.taskbar-widget .app-container.not-focused {
    background-color: rgba(255, 255, 255, 0.25);
}
```
<img width="1917" height="1015" alt="image" src="https://github.com/user-attachments/assets/259903ae-0956-4462-86fd-2823b8db149a" />

Here, In the above image, File explorer has cyan grayish background and vscode has gray background while other running apps which are minimized, grayed out.