### PR TITLE
refactor(windows-desktops): replace pyvda with an in-tree virtual desktop layer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pycaw==20251023",
     "pillow==12.3.0",
     "qasync==0.28.0",
-    "pyvda @ git+https://github.com/amnweb/pyvda@master",
+    "comtypes==1.4.16",
     "python-dotenv==1.2.3",
     "tzdata==2026.3",
     "winrt.windows.foundation==3.2.1",

--- a/src/core/log.py
+++ b/src/core/log.py
@@ -59,7 +59,6 @@ def _suppress_third_party_warnings():
     """Suppress noisy warnings and logs from third-party libraries."""
     logging.getLogger("asyncio").setLevel(logging.WARNING)
     logging.getLogger("comtypes").setLevel(logging.ERROR)
-    logging.getLogger("pyvda").setLevel(logging.WARNING)
     warnings.filterwarnings("ignore", category=UserWarning, module="pycaw")
 
 

--- a/src/core/utils/win32/com_base.py
+++ b/src/core/utils/win32/com_base.py
@@ -1,0 +1,126 @@
+"""Generic COM and WinRT primitives shared by the win32 binding modules.
+
+The service provider used to reach shell singletons, the object array those
+singletons return, and the WinRT string type used by newer shell interfaces.
+
+https://learn.microsoft.com/en-us/windows/win32/api/objectarray/nn-objectarray-iobjectarray
+https://learn.microsoft.com/en-us/windows/win32/winrt/hstring
+"""
+
+import ctypes
+import weakref
+from collections.abc import Iterator
+from ctypes import HRESULT, POINTER
+from ctypes.wintypes import LPVOID, UINT, WCHAR
+from typing import Any
+
+from comtypes import COMMETHOD, GUID, STDMETHOD, IUnknown
+
+PWSTR = POINTER(WCHAR)
+REFGUID = POINTER(GUID)
+REFIID = POINTER(GUID)
+
+
+class IServiceProvider(IUnknown):
+    """Used to query the Immersive Shell for its internal service singletons."""
+
+    _iid_ = GUID("{6D5140C1-7436-11CE-8034-00AA006009FA}")
+    _methods_ = [
+        STDMETHOD(HRESULT, "QueryService", (REFGUID, REFIID, POINTER(LPVOID))),
+    ]
+
+
+class IObjectArray(IUnknown):
+    """A homogeneous array of COM objects, returned by several shell interfaces."""
+
+    _iid_ = GUID("{92CA9DCD-5622-4BBA-A805-5E9F541BD8C9}")
+    _methods_ = [
+        COMMETHOD([], HRESULT, "GetCount", (["out"], POINTER(UINT), "pcObjects")),
+        STDMETHOD(HRESULT, "GetAt", (UINT, REFIID, POINTER(LPVOID))),
+    ]
+
+    def get_at(self, index: int, cls: Any) -> Any:
+        """Return the item at index, cast to interface cls."""
+        item = POINTER(cls)()
+        self.GetAt(index, cls._iid_, item)  # type: ignore[attr-defined]
+        return item
+
+    def iter(self, cls: Any) -> Iterator[Any]:
+        """Iterate the array as instances of cls."""
+        for i in range(self.GetCount()):  # type: ignore[attr-defined]
+            yield self.get_at(i, cls)
+
+
+# WinRT string support.
+#
+# Adapted from https://github.com/ninthDevilHAUNSTER/ArknightsAutoHelper (MIT).
+# The newer virtual desktop interfaces take and return desktop names and
+# wallpaper paths as HSTRINGs rather than plain wide strings.
+
+E_NOTIMPL = -2147467263  # 0x80004001
+E_NOINTERFACE = -2147467262  # 0x80004002
+E_BOUNDS = -2147483637  # 0x8000000B
+
+
+def check_hresult(hr: int) -> int:
+    """Raise an appropriate exception when hr is a failure code.
+
+    Used as a ctypes restype so failures raise at the call site rather than
+    returning silently as negative integers.
+    """
+    if (hr & 0x80000000) == 0:
+        return hr
+    if hr == E_NOTIMPL:
+        raise NotImplementedError
+    if hr == E_NOINTERFACE:
+        raise TypeError("E_NOINTERFACE")
+    if hr == E_BOUNDS:
+        raise IndexError
+    error = OSError(f"[HRESULT 0x{hr & 0xFFFFFFFF:08X}] {ctypes.FormatError(hr)}")
+    error.winerror = hr & 0xFFFFFFFF
+    raise error
+
+
+_combase = ctypes.windll.LoadLibrary("combase.dll")
+
+_WindowsCreateString = _combase.WindowsCreateString
+_WindowsCreateString.argtypes = (ctypes.c_void_p, ctypes.c_uint32, ctypes.POINTER(ctypes.c_void_p))
+_WindowsCreateString.restype = check_hresult
+
+_WindowsDeleteString = _combase.WindowsDeleteString
+_WindowsDeleteString.argtypes = (ctypes.c_void_p,)
+_WindowsDeleteString.restype = check_hresult
+
+_WindowsGetStringRawBuffer = _combase.WindowsGetStringRawBuffer
+_WindowsGetStringRawBuffer.argtypes = (ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint32))
+_WindowsGetStringRawBuffer.restype = ctypes.c_void_p
+
+
+class HSTRING(ctypes.c_void_p):
+    """A WinRT string.
+
+    Constructing one from a Python string allocates a WinRT string, freed when
+    this object is collected. Instances received from COM calls are not owned by
+    us, so no finalizer is attached to those.
+    """
+
+    def __init__(self, value: str | None = None):
+        super().__init__()
+        if not value:
+            self.value = None
+            return
+        encoded = value.encode("utf-16-le") + b"\x00\x00"
+        length = (len(encoded) // 2) - 1
+        _WindowsCreateString(encoded, ctypes.c_uint32(length), ctypes.byref(self))
+        # Only registered when we allocated the string ourselves.
+        self._finalizer = weakref.finalize(self, _WindowsDeleteString, self.value)
+
+    def __str__(self) -> str:
+        if self.value is None:
+            return ""
+        length = ctypes.c_uint32()
+        buffer = _WindowsGetStringRawBuffer(self, ctypes.byref(length))
+        return ctypes.wstring_at(buffer, length.value)
+
+    def __repr__(self) -> str:
+        return f"HSTRING({str(self)!r})"

--- a/src/core/widgets/services/windows_desktops/com.py
+++ b/src/core/widgets/services/windows_desktops/com.py
@@ -1,0 +1,333 @@
+"""COM plumbing for the virtual desktop service.
+
+Wraps the raw interfaces from core.widgets.services.windows_desktops.interfaces in an API
+that speaks plain Python values, so nothing above this layer holds a COM pointer.
+
+Desktops are addressed by GUID rather than position. Resolving a GUID is a single
+FindDesktop call, while resolving a position means enumerating every desktop.
+list_desktops is the only call that enumerates, returning positions and names in
+one pass.
+
+COM objects are created on first use and held per thread, as apartment rules
+require.
+"""
+
+import logging
+import sys
+import threading
+from ctypes import POINTER
+from dataclasses import dataclass
+from typing import Any
+
+import comtypes
+from comtypes import GUID, COMError
+
+from core.utils.win32.bindings.user32 import AllowSetForegroundWindow
+from core.utils.win32.com_base import HSTRING, IServiceProvider
+from core.widgets.services.windows_desktops.interfaces import (
+    TIER_21313,
+    CLSID_ImmersiveShell,
+    CLSID_VirtualDesktopManagerInternal,
+    CLSID_VirtualDesktopNotificationService,
+    CLSID_VirtualDesktopPinnedApps,
+    DesktopInterfaces,
+    IApplicationViewCollection,
+    IVirtualDesktop2,
+    IVirtualDesktopNotificationService,
+    IVirtualDesktopPinnedApps,
+    VirtualDesktopUnsupportedError,
+    get_interfaces,
+)
+
+logger = logging.getLogger("windows_desktop_service")
+
+# Passing this to AllowSetForegroundWindow lets any process take the
+# foreground, which stops focus lingering on the old desktop after a switch.
+# See https://github.com/Ciantic/VirtualDesktopAccessor/issues/4
+ASFW_ANY = 0xFFFFFFFF
+
+
+class VirtualDesktopError(RuntimeError):
+    """A virtual desktop operation failed."""
+
+
+@dataclass(frozen=True)
+class DesktopInfo:
+    """One virtual desktop, as of the moment it was read."""
+
+    number: int  # 1-based, matching the order shown in Task View
+    guid: str
+    name: str
+
+
+class _ComObjects(threading.local):
+    """Per-thread COM interface pointers, created on first access.
+
+    A pointer acquired in one apartment cannot be used from another without
+    marshaling, so each thread gets its own set.
+    """
+
+    def __init__(self):
+        self.interfaces: DesktopInterfaces | None = None
+        self.manager: Any = None
+        self.manager2: Any = None
+        self.views: Any = None
+        self.pinned: Any = None
+
+
+def _init_com() -> None:
+    """Join the thread to a COM apartment if it is not already in one."""
+    try:
+        comtypes.CoInitializeEx()
+    except (OSError, COMError) as e:
+        # Usually means the thread is already in a multi-threaded apartment,
+        # which is fine for our purposes.
+        logger.debug("CoInitializeEx declined: %s", e)
+
+
+class VirtualDesktopApi:
+    """Plain-value wrapper over the shell's virtual desktop interfaces."""
+
+    def __init__(self):
+        self._com = _ComObjects()
+
+    def _provider(self) -> Any:
+        return comtypes.CoCreateInstance(CLSID_ImmersiveShell, IServiceProvider, comtypes.CLSCTX_LOCAL_SERVER)
+
+    def _query(self, provider: Any, cls: Any, clsid: GUID | None = None) -> Any:
+        pointer = POINTER(cls)()
+        provider.QueryService(clsid or cls._iid_, cls._iid_, pointer)
+        return pointer
+
+    def _ensure(self) -> _ComObjects:
+        """Create this thread's COM objects if it does not have them yet."""
+        com = self._com
+        if com.manager is not None:
+            return com
+
+        _init_com()
+        interfaces = get_interfaces()
+        provider = self._provider()
+
+        com.interfaces = interfaces
+        com.manager = self._query(
+            provider, interfaces.IVirtualDesktopManagerInternal, CLSID_VirtualDesktopManagerInternal
+        )
+        com.views = self._query(provider, IApplicationViewCollection)
+        com.pinned = self._query(provider, IVirtualDesktopPinnedApps, CLSID_VirtualDesktopPinnedApps)
+
+        # Windows 10 only. 19041 added desktop renaming through this derived
+        # interface; 21313 moved SetName onto the manager above and dropped it.
+        com.manager2 = None
+        if interfaces.tier < TIER_21313:
+            try:
+                com.manager2 = self._query(
+                    provider, interfaces.IVirtualDesktopManagerInternal2, CLSID_VirtualDesktopManagerInternal
+                )
+            except COMError:
+                logger.debug("IVirtualDesktopManagerInternal2 unavailable; desktops cannot be renamed")
+
+        logger.info("Virtual desktop COM ready (tier %d, build %d)", interfaces.tier, sys.getwindowsversion().build)
+        return com
+
+    @property
+    def interfaces(self) -> DesktopInterfaces:
+        return self._ensure().interfaces
+
+    @property
+    def supports_names(self) -> bool:
+        """Can desktops be named and renamed on this build?"""
+        return self.interfaces.supports_names
+
+    @property
+    def supports_wallpaper(self) -> bool:
+        """Can per-desktop wallpapers be set on this build? Windows 11 only."""
+        return self.interfaces.supports_wallpaper
+
+    def available(self) -> bool:
+        """Is the virtual desktop API usable at all on this machine?"""
+        try:
+            self._ensure()
+        except VirtualDesktopUnsupportedError, COMError, OSError, AttributeError:
+            logger.warning("Virtual desktop API unavailable", exc_info=True)
+            return False
+        return True
+
+    def _find(self, guid: str) -> Any:
+        """Resolve a desktop GUID to its COM object without enumerating."""
+        com = self._ensure()
+        try:
+            return com.manager.FindDesktop(GUID(guid))
+        except (COMError, OSError, ValueError) as e:
+            raise VirtualDesktopError(f"No desktop with id {guid}") from e
+
+    def list_desktops(self) -> list[DesktopInfo]:
+        """Enumerate every desktop in Task View order, with names.
+
+        The only call that enumerates. 21313 and later expose GetName on the
+        desktop itself; earlier builds reach it through IVirtualDesktop2.
+        """
+        com = self._ensure()
+        interfaces = com.interfaces
+        array = com.manager.get_all_desktops()
+
+        if interfaces.tier >= TIER_21313:
+            return [
+                DesktopInfo(number=i, guid=str(d.GetID()), name=str(d.GetName()).strip())
+                for i, d in enumerate(array.iter(interfaces.IVirtualDesktop), 1)
+            ]
+
+        if interfaces.supports_names:
+            return [
+                DesktopInfo(number=i, guid=str(d.GetID()), name=str(d.GetName()).strip())
+                for i, d in enumerate(array.iter(IVirtualDesktop2), 1)
+            ]
+
+        return [
+            DesktopInfo(number=i, guid=str(d.GetID()), name="")
+            for i, d in enumerate(array.iter(interfaces.IVirtualDesktop), 1)
+        ]
+
+    def current_guid(self) -> str:
+        """The GUID of the desktop currently in view."""
+        com = self._ensure()
+        return str(com.manager.get_current_desktop().GetID())
+
+    def count(self) -> int:
+        """How many desktops exist, without building the full list."""
+        com = self._ensure()
+        return com.manager.get_all_desktops().GetCount()
+
+    def switch_to(self, guid: str) -> None:
+        """Switch to the desktop with this GUID."""
+        com = self._ensure()
+        AllowSetForegroundWindow(ASFW_ANY)
+        com.manager.switch_desktop(self._find(guid))
+
+    def create(self) -> str:
+        """Create a desktop and return its GUID."""
+        com = self._ensure()
+        return str(com.manager.create_desktop().GetID())
+
+    def remove(self, guid: str, fallback_guid: str | None = None) -> None:
+        """Delete a desktop, moving to `fallback_guid` if it was in view."""
+        com = self._ensure()
+        if fallback_guid is None:
+            desktops = self.list_desktops()
+            fallback = next((d for d in desktops if d.guid != guid), None)
+            if fallback is None:
+                raise VirtualDesktopError("Cannot remove the only remaining desktop")
+            fallback_guid = fallback.guid
+        com.manager.RemoveDesktop(self._find(guid), self._find(fallback_guid))
+
+    def rename(self, guid: str, name: str) -> None:
+        """Rename a desktop.
+
+        SetName lives on the manager from 21313 onward. Before that it is only
+        reachable through the derived Windows 10 interface.
+        """
+        com = self._ensure()
+        if not self.supports_names:
+            raise VirtualDesktopError("Renaming desktops requires Windows 10 build 19041 or later")
+        target = com.manager if com.interfaces.tier >= TIER_21313 else com.manager2
+        if target is None:
+            raise VirtualDesktopError("This build reports no interface that can rename desktops")
+        target.SetName(self._find(guid), HSTRING(name))
+
+    def set_wallpaper(self, guid: str, path: str) -> None:
+        """Set one desktop's wallpaper."""
+        com = self._ensure()
+        if not self.supports_wallpaper:
+            raise VirtualDesktopError("Per-desktop wallpapers require Windows 11")
+        com.manager.SetWallpaper(self._find(guid), HSTRING(path))
+
+    def set_wallpaper_all(self, path: str) -> None:
+        """Set the wallpaper on every desktop."""
+        com = self._ensure()
+        if not self.supports_wallpaper:
+            raise VirtualDesktopError("Per-desktop wallpapers require Windows 11")
+        com.manager.SetWallpaperForAllDesktops(HSTRING(path))
+
+    def view_for_hwnd(self, hwnd: int) -> Any:
+        """Get the shell's view object for a window handle."""
+        com = self._ensure()
+        return com.views.GetViewForHwnd(hwnd)
+
+    def try_view_for_hwnd(self, hwnd: int) -> Any | None:
+        """Like `view_for_hwnd`, but None when the shell tracks no view.
+
+        Many windows have no application view: the desktop, menus and popups,
+        tooltips, and most non-application shell surfaces. The shell reports that
+        as "element not found", which is an answer rather than a fault.
+        """
+        try:
+            return self.view_for_hwnd(hwnd)
+        except COMError:
+            # Callers that care log this with context; a bare handle here
+            # would only be noise.
+            return None
+
+    def is_shown_in_switchers(self, view: Any) -> bool:
+        """Does this window appear in alt-tab? Filters out shell surfaces."""
+        return bool(view.GetShowInSwitchers())
+
+    def move_view(self, view: Any, guid: str) -> None:
+        """Move a window to the desktop with this GUID."""
+        com = self._ensure()
+        com.manager.MoveViewToDesktop(view, self._find(guid))
+
+    def is_view_pinned(self, view: Any) -> bool:
+        return bool(self._ensure().pinned.IsViewPinned(view))
+
+    def pin_view(self, view: Any) -> None:
+        self._ensure().pinned.PinView(view)
+
+    def unpin_view(self, view: Any) -> None:
+        self._ensure().pinned.UnpinView(view)
+
+    def _app_id(self, view: Any) -> Any:
+        """A view's app id, or None.
+
+        Some windows, typically shell surfaces pinned above normal windows, have
+        no app id and raise instead of returning one. The Windows UI does nothing
+        for those, so None is reported and callers skip.
+        """
+        try:
+            return view.GetAppUserModelId()
+        except COMError:
+            logger.debug("Window has no app user model id")
+            return None
+
+    def is_app_pinned(self, view: Any) -> bool:
+        app_id = self._app_id(view)
+        if app_id is None:
+            return False
+        return bool(self._ensure().pinned.IsAppIdPinned(app_id))
+
+    def pin_app(self, view: Any) -> None:
+        app_id = self._app_id(view)
+        if app_id is not None:
+            self._ensure().pinned.PinAppID(app_id)
+
+    def unpin_app(self, view: Any) -> None:
+        app_id = self._app_id(view)
+        if app_id is not None:
+            self._ensure().pinned.UnpinAppID(app_id)
+
+    def notification_service(self) -> Any:
+        """Acquire the service that desktop change callbacks register with."""
+        self._ensure()
+        return self._query(
+            self._provider(), IVirtualDesktopNotificationService, CLSID_VirtualDesktopNotificationService
+        )
+
+
+_api: VirtualDesktopApi | None = None
+
+
+def get_api() -> VirtualDesktopApi:
+    """The process-wide API instance. COM work is still deferred to first use."""
+    global _api
+    if _api is None:
+        _api = VirtualDesktopApi()
+    return _api

--- a/src/core/widgets/services/windows_desktops/interfaces.py
+++ b/src/core/widgets/services/windows_desktops/interfaces.py
@@ -1,0 +1,906 @@
+"""COM interfaces for the undocumented Windows virtual desktop API.
+
+The shell exposes virtual desktop control through IVirtualDesktopManagerInternal,
+whose GUID and vtable layout changed several times across Windows 10 and 11.
+Interfaces are therefore built per build tier, resolved on first use.
+
+Below build 26100 the tier is resolved by asking the shell which interface GUID it
+supports. Build numbers alone are not reliable: 22H2 received newer shell
+interfaces through Moment updates without a build change. 26100 and above always
+expose the 24H2 interface and skip the probe.
+
+Importing this module performs no COM calls.
+
+Interfaces and GUIDs from https://github.com/Ciantic/VirtualDesktopAccessor
+"""
+
+import logging
+import sys
+from ctypes import HRESULT, POINTER, c_ulonglong, c_void_p
+from ctypes.wintypes import BOOL, DWORD, HWND, INT, LPCWSTR, LPVOID, RECT, SIZE, UINT, ULONG
+from dataclasses import dataclass
+from typing import Any
+
+from comtypes import CLSCTX_LOCAL_SERVER, COMMETHOD, GUID, STDMETHOD, CoCreateInstance, COMError, IUnknown
+
+from core.utils.win32.com_base import HSTRING, PWSTR, REFGUID, REFIID, IObjectArray, IServiceProvider
+
+logger = logging.getLogger("virtual_desktop")
+
+CLSID_ImmersiveShell = GUID("{C2F03A33-21F5-47FA-B4BB-156362A2F239}")
+CLSID_VirtualDesktopManagerInternal = GUID("{C5E0CDCA-7B6E-41B2-9FC4-D93975CC467B}")
+CLSID_VirtualDesktopPinnedApps = GUID("{B5A399E7-1C87-46B8-88E9-FC5747B171BD}")
+CLSID_VirtualDesktopNotificationService = GUID("{A501FDEC-4A09-464C-AE4E-1B9C21B84918}")
+
+GUID_IVirtualDesktop_26100 = GUID("{3F07F4BE-B107-441A-AF0F-39D82529072C}")
+GUID_IVirtualDesktop_22631 = GUID("{3F07F4BE-B107-441A-AF0F-39D82529072C}")
+GUID_IVirtualDesktop_22621 = GUID("{3F07F4BE-B107-441A-AF0F-39D82529072C}")
+GUID_IVirtualDesktop_21313 = GUID("{536D3495-B208-4CC9-AE26-DE8111275BF8}")
+GUID_IVirtualDesktop_20231 = GUID("{62FDF88B-11CA-4AFB-8BD8-2296DFAE49E2}")
+GUID_IVirtualDesktop_9000 = GUID("{FF72FFDD-BE7E-43FC-9C03-AD81681E88E4}")
+
+GUID_IVirtualDesktopManagerInternal_26100 = GUID("{53F5CA0B-158F-4124-900C-057158060B27}")
+GUID_IVirtualDesktopManagerInternal_22631 = GUID("{4970BA3D-FD4E-4647-BEA3-D89076EF4B9C}")
+GUID_IVirtualDesktopManagerInternal_22621 = GUID("{A3175F2D-239C-4BD2-8AA0-EEBA8B0B138E}")
+GUID_IVirtualDesktopManagerInternal_21313 = GUID("{B2F925B9-5A0F-4D2E-9F4D-2B1507593C10}")
+GUID_IVirtualDesktopManagerInternal_20231 = GUID("{094AFE11-44F2-4BA0-976F-29A97E263EE0}")
+GUID_IVirtualDesktopManagerInternal_9000 = GUID("{F31574D6-B682-4CDC-BD56-1827860ABEC6}")
+
+GUID_IVirtualDesktopManagerInternal2 = GUID("{0F3A72B0-4566-487E-9A33-4ED302F6D6CE}")
+GUID_IVirtualDesktop2 = GUID("{31EBDE3F-6EC3-4CBD-B9FB-0EF6D09B41F4}")
+
+GUID_IVirtualDesktopNotification_22631 = GUID("{B9E5E94D-233E-49AB-AF5C-2B4541C3AADE}")
+GUID_IVirtualDesktopNotification_22621 = GUID("{B287FA1C-7771-471A-A2DF-9B6B21F0D675}")
+GUID_IVirtualDesktopNotification_20231 = GUID("{CD403E52-DEED-4C13-B437-B98380F2B1E8}")
+GUID_IVirtualDesktopNotification_9000 = GUID("{C179334C-4295-40D3-BEA1-C654D965605A}")
+GUID_IVirtualDesktopNotification2 = GUID("{1BA7CF30-3591-43FA-ABFA-4AAF7ABEEDB7}")
+
+# Stable across every build.
+GUID_IVirtualDesktopNotificationService = GUID("{0CD45E71-D927-4F15-8B0A-8FEF525337BF}")
+
+# Interfaces we never call into. Declared as opaque so the vtable slots that
+# reference them keep their correct positions.
+IAsyncCallback = UINT
+IImmersiveMonitor = UINT
+APPLICATION_VIEW_COMPATIBILITY_POLICY = UINT
+IApplicationViewOperation = UINT
+APPLICATION_VIEW_CLOAK_TYPE = UINT
+IApplicationViewPosition = UINT
+IImmersiveApplication = UINT
+IApplicationViewChangeListener = UINT
+TrustLevel = INT
+AdjacentDesktop = UINT
+
+
+# Each tier is the build its interface set first appeared in, so comparisons
+# against them read as "is this build at least X". The oldest set predates every
+# build we care about, so it has no meaningful threshold and sorts below all of
+# them.
+TIER_WIN10 = 0
+TIER_20231 = 20231
+TIER_21313 = 21313
+TIER_22449 = 22449
+TIER_22621 = 22621
+TIER_22631 = 22631
+TIER_26100 = 26100
+
+MANAGER_GUID_BY_TIER: dict[int, GUID] = {
+    TIER_26100: GUID_IVirtualDesktopManagerInternal_26100,
+    TIER_22631: GUID_IVirtualDesktopManagerInternal_22631,
+    TIER_22621: GUID_IVirtualDesktopManagerInternal_22621,
+    TIER_22449: GUID_IVirtualDesktopManagerInternal_21313,
+    TIER_21313: GUID_IVirtualDesktopManagerInternal_21313,
+    TIER_20231: GUID_IVirtualDesktopManagerInternal_20231,
+    TIER_WIN10: GUID_IVirtualDesktopManagerInternal_9000,
+}
+
+# Probe order, newest first. 22449 is absent because it shares the 21313 GUID
+# and is distinguished by build number once that probe succeeds.
+PROBE_ORDER = (TIER_22631, TIER_22621, TIER_21313, TIER_20231, TIER_WIN10)
+
+# Desktop naming and renaming arrived in 19041. Unlike the vtable tiers this
+# is a genuine OS capability gate, so the build number is the right key.
+BUILD_DESKTOP_NAMES = 19041
+
+
+def supports_desktop_names(tier: int) -> bool:
+    """Can desktops be named and renamed on this tier?"""
+    if tier >= TIER_20231:
+        return True
+    return sys.getwindowsversion().build >= BUILD_DESKTOP_NAMES
+
+
+def supports_wallpaper(tier: int) -> bool:
+    """Can per-desktop wallpapers be set on this tier? Windows 11 only."""
+    return tier >= TIER_21313
+
+
+class IApplicationView(IUnknown):
+    """A window as the shell sees it. Only a few of these methods are called."""
+
+    _iid_ = GUID("{372E1D3B-38D3-42E4-A15B-8AB2B178F513}")
+
+
+IApplicationView._methods_ = [
+    # IInspectable
+    STDMETHOD(HRESULT, "GetIids", (POINTER(ULONG), POINTER(POINTER(GUID)))),
+    STDMETHOD(HRESULT, "GetRuntimeClassName", (POINTER(HSTRING),)),
+    STDMETHOD(HRESULT, "GetTrustLevel", (POINTER(TrustLevel),)),
+    # IApplicationView
+    STDMETHOD(HRESULT, "SetFocus", ()),
+    STDMETHOD(HRESULT, "SwitchTo", ()),
+    STDMETHOD(HRESULT, "TryInvokeBack", (POINTER(IAsyncCallback),)),
+    COMMETHOD([], HRESULT, "GetThumbnailWindow", (["out"], POINTER(HWND), "hwnd")),
+    STDMETHOD(HRESULT, "GetMonitor", (POINTER(POINTER(IImmersiveMonitor)),)),
+    COMMETHOD([], HRESULT, "GetVisibility", (["out"], POINTER(UINT), "pVisible")),
+    STDMETHOD(HRESULT, "SetCloak", (APPLICATION_VIEW_CLOAK_TYPE, UINT)),
+    STDMETHOD(HRESULT, "GetPosition", (REFIID, POINTER(LPVOID))),
+    STDMETHOD(HRESULT, "SetPosition", (POINTER(IApplicationViewPosition),)),
+    STDMETHOD(HRESULT, "InsertAfterWindow", (HWND,)),
+    STDMETHOD(HRESULT, "GetExtendedFramePosition", (POINTER(RECT),)),
+    COMMETHOD([], HRESULT, "GetAppUserModelId", (["out"], POINTER(PWSTR), "pId")),
+    STDMETHOD(HRESULT, "SetAppUserModelId", (LPCWSTR,)),
+    STDMETHOD(HRESULT, "IsEqualByAppUserModelId", (LPCWSTR, POINTER(UINT))),
+    STDMETHOD(HRESULT, "GetViewState", (POINTER(UINT),)),
+    STDMETHOD(HRESULT, "SetViewState", (UINT,)),
+    STDMETHOD(HRESULT, "GetNeediness", (POINTER(UINT),)),
+    COMMETHOD([], HRESULT, "GetLastActivationTimestamp", (["out"], POINTER(c_ulonglong), "pGuid")),
+    STDMETHOD(HRESULT, "SetLastActivationTimestamp", (c_ulonglong,)),
+    COMMETHOD([], HRESULT, "GetVirtualDesktopId", (["out"], POINTER(GUID), "pGuid")),
+    STDMETHOD(HRESULT, "SetVirtualDesktopId", (REFGUID,)),
+    COMMETHOD([], HRESULT, "GetShowInSwitchers", (["out"], POINTER(UINT), "pShown")),
+    STDMETHOD(HRESULT, "SetShowInSwitchers", (UINT,)),
+    STDMETHOD(HRESULT, "GetScaleFactor", (POINTER(UINT),)),
+    STDMETHOD(HRESULT, "CanReceiveInput", (POINTER(BOOL),)),
+    STDMETHOD(HRESULT, "GetCompatibilityPolicyType", (POINTER(APPLICATION_VIEW_COMPATIBILITY_POLICY),)),
+    STDMETHOD(HRESULT, "SetCompatibilityPolicyType", (APPLICATION_VIEW_COMPATIBILITY_POLICY,)),
+    STDMETHOD(HRESULT, "GetSizeConstraints", (POINTER(IImmersiveMonitor), POINTER(SIZE), POINTER(SIZE))),
+    STDMETHOD(HRESULT, "GetSizeConstraintsForDpi", (UINT, POINTER(SIZE), POINTER(SIZE))),
+    STDMETHOD(HRESULT, "SetSizeConstraintsForDpi", (POINTER(UINT), POINTER(SIZE), POINTER(SIZE))),
+    STDMETHOD(HRESULT, "OnMinSizePreferencesUpdated", (HWND,)),
+    STDMETHOD(HRESULT, "ApplyOperation", (POINTER(IApplicationViewOperation),)),
+    STDMETHOD(HRESULT, "IsTray", (POINTER(BOOL),)),
+    STDMETHOD(HRESULT, "IsInHighZOrderBand", (POINTER(BOOL),)),
+    STDMETHOD(HRESULT, "IsSplashScreenPresented", (POINTER(BOOL),)),
+    STDMETHOD(HRESULT, "Flash", ()),
+    STDMETHOD(HRESULT, "GetRootSwitchableOwner", (POINTER(POINTER(IApplicationView)),)),
+    STDMETHOD(HRESULT, "EnumerateOwnershipTree", (POINTER(POINTER(IObjectArray)),)),
+    STDMETHOD(HRESULT, "GetEnterpriseId", (POINTER(PWSTR),)),
+    STDMETHOD(HRESULT, "IsMirrored", (POINTER(BOOL),)),
+    STDMETHOD(HRESULT, "GetFrameworkViewType", (POINTER(UINT),)),
+    STDMETHOD(HRESULT, "GetCanTab", (POINTER(UINT),)),
+    STDMETHOD(HRESULT, "SetCanTab", (UINT,)),
+    STDMETHOD(HRESULT, "GetIsTabbed", (POINTER(UINT),)),
+    STDMETHOD(HRESULT, "SetIsTabbed", (UINT,)),
+    STDMETHOD(HRESULT, "RefreshCanTab", ()),
+    STDMETHOD(HRESULT, "GetIsOccluded", (POINTER(UINT),)),
+    STDMETHOD(HRESULT, "SetIsOccluded", (UINT,)),
+    STDMETHOD(HRESULT, "UpdateEngagementFlags", (UINT, UINT)),
+    STDMETHOD(HRESULT, "SetForceActiveWindowAppearance", (UINT,)),
+    STDMETHOD(HRESULT, "GetLastActivationFILETIME", (POINTER(SIZE),)),
+    STDMETHOD(HRESULT, "GetPersistingStateName", (POINTER(PWSTR),)),
+]
+
+
+class IVirtualDesktop2(IUnknown):
+    """Pre-21313 route to a desktop's name, read via the desktop array."""
+
+    _iid_ = GUID_IVirtualDesktop2
+    _methods_ = [
+        STDMETHOD(HRESULT, "IsViewVisible", (POINTER(IApplicationView), POINTER(UINT))),
+        COMMETHOD([], HRESULT, "GetID", (["out"], POINTER(GUID), "pGuid")),
+        COMMETHOD([], HRESULT, "GetName", (["out"], POINTER(HSTRING), "pName")),
+    ]
+
+
+class IVirtualDesktopPinnedApps(IUnknown):
+    """Pinning of windows and apps across all desktops."""
+
+    _iid_ = GUID("{4CE81583-1E4C-4632-A621-07A53543148F}")
+    _methods_ = [
+        COMMETHOD([], HRESULT, "IsAppIdPinned", (["in"], LPCWSTR, "appId"), (["out"], POINTER(BOOL), "isPinned")),
+        STDMETHOD(HRESULT, "PinAppID", (LPCWSTR,)),
+        STDMETHOD(HRESULT, "UnpinAppID", (LPCWSTR,)),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "IsViewPinned",
+            (["in"], POINTER(IApplicationView), "pView"),
+            (["out"], POINTER(BOOL), "isPinned"),
+        ),
+        STDMETHOD(HRESULT, "PinView", (POINTER(IApplicationView),)),
+        STDMETHOD(HRESULT, "UnpinView", (POINTER(IApplicationView),)),
+    ]
+
+
+class IApplicationViewCollection(IUnknown):
+    """Maps window handles to `IApplicationView` objects."""
+
+    _iid_ = GUID("{1841C6D7-4F9D-42C0-AF41-8747538F10E5}")
+    _methods_ = [
+        STDMETHOD(HRESULT, "GetViews", (POINTER(POINTER(IObjectArray)),)),
+        COMMETHOD([], HRESULT, "GetViewsByZOrder", (["out"], POINTER(POINTER(IObjectArray)), "array")),
+        STDMETHOD(HRESULT, "GetViewsByAppUserModelId", (LPCWSTR, POINTER(POINTER(IObjectArray)))),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "GetViewForHwnd",
+            (["in"], HWND, "hwnd"),
+            (["out"], POINTER(POINTER(IApplicationView)), "pView"),
+        ),
+        STDMETHOD(
+            HRESULT, "GetViewForApplication", (POINTER(IImmersiveApplication), POINTER(POINTER(IApplicationView)))
+        ),
+        STDMETHOD(HRESULT, "GetViewForAppUserModelId", (LPCWSTR, POINTER(POINTER(IApplicationView)))),
+        COMMETHOD([], HRESULT, "GetViewInFocus", (["out"], POINTER(POINTER(IApplicationView)), "view")),
+        STDMETHOD(HRESULT, "Unknown1", (POINTER(POINTER(IApplicationView)),)),
+        STDMETHOD(HRESULT, "RefreshCollection", ()),
+        STDMETHOD(
+            HRESULT, "RegisterForApplicationViewChanges", (POINTER(IApplicationViewChangeListener), POINTER(DWORD))
+        ),
+        STDMETHOD(HRESULT, "UnregisterForApplicationViewChanges", (DWORD,)),
+    ]
+
+
+class IVirtualDesktopNotificationService(IUnknown):
+    """Registration point for desktop change callbacks. Stable across builds."""
+
+    _iid_ = GUID_IVirtualDesktopNotificationService
+    _methods_ = [
+        COMMETHOD(
+            [],
+            HRESULT,
+            "Register",
+            (["in"], LPVOID, "pNotification"),
+            (["out"], POINTER(DWORD), "pdwCookie"),
+        ),
+        COMMETHOD([], HRESULT, "Unregister", (["in"], DWORD, "dwCookie")),
+    ]
+
+
+def _make_virtual_desktop(tier: int) -> type[IUnknown]:
+    """Build `IVirtualDesktop` for `tier`.
+
+    22621 and later reordered the trailing methods, and everything before
+    21313 has neither a name nor a wallpaper.
+    """
+    if tier >= TIER_26100:
+        iid = GUID_IVirtualDesktop_26100
+    elif tier >= TIER_22631:
+        iid = GUID_IVirtualDesktop_22631
+    elif tier >= TIER_22621:
+        iid = GUID_IVirtualDesktop_22621
+    elif tier >= TIER_21313:
+        iid = GUID_IVirtualDesktop_21313
+    elif tier >= TIER_20231:
+        iid = GUID_IVirtualDesktop_20231
+    else:
+        iid = GUID_IVirtualDesktop_9000
+
+    if tier >= TIER_22621:
+        methods = [
+            STDMETHOD(HRESULT, "IsViewVisible", (POINTER(IApplicationView), POINTER(UINT))),
+            COMMETHOD([], HRESULT, "GetID", (["out"], POINTER(GUID), "pGuid")),
+            COMMETHOD([], HRESULT, "GetName", (["out"], POINTER(HSTRING), "pName")),
+            COMMETHOD([], HRESULT, "GetWallpaperPath", (["out"], POINTER(HSTRING), "pPath")),
+            COMMETHOD([], HRESULT, "IsRemote", (["out"], POINTER(HWND), "pW")),
+        ]
+    elif tier >= TIER_21313:
+        methods = [
+            STDMETHOD(HRESULT, "IsViewVisible", (POINTER(IApplicationView), POINTER(UINT))),
+            COMMETHOD([], HRESULT, "GetID", (["out"], POINTER(GUID), "pGuid")),
+            COMMETHOD([], HRESULT, "IsRemote", (["out"], POINTER(HWND), "pW")),
+            COMMETHOD([], HRESULT, "GetName", (["out"], POINTER(HSTRING), "pName")),
+            COMMETHOD([], HRESULT, "GetWallpaperPath", (["out"], POINTER(HSTRING), "pPath")),
+        ]
+    else:
+        methods = [
+            STDMETHOD(HRESULT, "IsViewVisible", (POINTER(IApplicationView), POINTER(UINT))),
+            COMMETHOD([], HRESULT, "GetID", (["out"], POINTER(GUID), "pGuid")),
+        ]
+
+    return type("IVirtualDesktop", (IUnknown,), {"_iid_": iid, "_methods_": methods})
+
+
+def _manager_methods(tier: int, desktop: type[IUnknown]) -> list[Any]:
+    """Build the `IVirtualDesktopManagerInternal` vtable for `tier`.
+
+    Every tier here is a distinct layout that shipped in the wild. The
+    pre-22621 tiers take an extra leading HWND on several methods, and 22449
+    inserted `GetAllCurrentDesktops` without changing the interface GUID.
+    """
+    if tier >= TIER_26100:
+        return [
+            COMMETHOD([], HRESULT, "GetCount", (["out"], POINTER(UINT), "pCount")),
+            STDMETHOD(HRESULT, "MoveViewToDesktop", (POINTER(IApplicationView), POINTER(desktop))),
+            STDMETHOD(HRESULT, "CanViewMoveDesktops", (POINTER(IApplicationView), POINTER(UINT))),
+            COMMETHOD([], HRESULT, "GetCurrentDesktop", (["out"], POINTER(POINTER(desktop)), "pDesktop")),
+            COMMETHOD([], HRESULT, "GetDesktops", (["out"], POINTER(POINTER(IObjectArray)), "array")),
+            STDMETHOD(HRESULT, "GetAdjacentDesktop", (POINTER(desktop), AdjacentDesktop, POINTER(POINTER(desktop)))),
+            STDMETHOD(HRESULT, "SwitchDesktop", (POINTER(desktop),)),
+            STDMETHOD(HRESULT, "SwitchDesktopAndMoveForegroundView", (POINTER(desktop),)),
+            COMMETHOD([], HRESULT, "CreateDesktopW", (["out"], POINTER(POINTER(desktop)), "pDesktop")),
+            STDMETHOD(HRESULT, "MoveDesktop", (POINTER(desktop), UINT)),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "RemoveDesktop",
+                (["in"], POINTER(desktop), "destroyDesktop"),
+                (["in"], POINTER(desktop), "fallbackDesktop"),
+            ),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "FindDesktop",
+                (["in"], POINTER(GUID), "pGuid"),
+                (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+            ),
+            STDMETHOD(
+                HRESULT,
+                "GetDesktopSwitchIncludeExcludeViews",
+                (POINTER(desktop), POINTER(POINTER(IObjectArray)), POINTER(POINTER(IObjectArray))),
+            ),
+            COMMETHOD([], HRESULT, "SetName", (["in"], POINTER(desktop), "pDesktop"), (["in"], HSTRING, "name")),
+            COMMETHOD([], HRESULT, "SetWallpaper", (["in"], POINTER(desktop), "pDesktop"), (["in"], HSTRING, "path")),
+            COMMETHOD([], HRESULT, "SetWallpaperForAllDesktops", (["in"], HSTRING, "path")),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "CopyDesktopState",
+                (["in"], POINTER(IApplicationView), "pView0"),
+                (["in"], POINTER(IApplicationView), "pView1"),
+            ),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "CreateRemoteDesktop",
+                (["in"], HSTRING, "a1"),
+                (["out"], POINTER(POINTER(desktop)), "out"),
+            ),
+            STDMETHOD(HRESULT, "pDesktop", (POINTER(desktop),)),
+            STDMETHOD(HRESULT, "SwitchRemoteDesktop", (POINTER(desktop), UINT)),
+            STDMETHOD(HRESULT, "SwitchDesktopWithAnimation", (POINTER(desktop),)),
+            COMMETHOD([], HRESULT, "GetLastActiveDesktop", (["out"], POINTER(POINTER(desktop)), "pDesktop")),
+            STDMETHOD(HRESULT, "WaitForAnimationToComplete"),
+        ]
+
+    if tier >= TIER_22631:
+        return [
+            COMMETHOD([], HRESULT, "GetCount", (["out"], POINTER(UINT), "pCount")),
+            STDMETHOD(HRESULT, "MoveViewToDesktop", (POINTER(IApplicationView), POINTER(desktop))),
+            STDMETHOD(HRESULT, "CanViewMoveDesktops", (POINTER(IApplicationView), POINTER(UINT))),
+            COMMETHOD([], HRESULT, "GetCurrentDesktop", (["out"], POINTER(POINTER(desktop)), "pDesktop")),
+            COMMETHOD([], HRESULT, "GetDesktops", (["out"], POINTER(POINTER(IObjectArray)), "array")),
+            STDMETHOD(HRESULT, "GetAdjacentDesktop", (POINTER(desktop), AdjacentDesktop, POINTER(POINTER(desktop)))),
+            STDMETHOD(HRESULT, "SwitchDesktop", (POINTER(desktop),)),
+            COMMETHOD([], HRESULT, "CreateDesktopW", (["out"], POINTER(POINTER(desktop)), "pDesktop")),
+            STDMETHOD(HRESULT, "MoveDesktop", (POINTER(desktop), UINT)),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "RemoveDesktop",
+                (["in"], POINTER(desktop), "destroyDesktop"),
+                (["in"], POINTER(desktop), "fallbackDesktop"),
+            ),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "FindDesktop",
+                (["in"], POINTER(GUID), "pGuid"),
+                (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+            ),
+            STDMETHOD(
+                HRESULT,
+                "GetDesktopSwitchIncludeExcludeViews",
+                (POINTER(desktop), POINTER(POINTER(IObjectArray)), POINTER(POINTER(IObjectArray))),
+            ),
+            COMMETHOD([], HRESULT, "SetName", (["in"], POINTER(desktop), "pDesktop"), (["in"], HSTRING, "name")),
+            COMMETHOD([], HRESULT, "SetWallpaper", (["in"], POINTER(desktop), "pDesktop"), (["in"], HSTRING, "path")),
+            COMMETHOD([], HRESULT, "SetWallpaperForAllDesktops", (["in"], HSTRING, "path")),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "CopyDesktopState",
+                (["in"], POINTER(IApplicationView), "pView0"),
+                (["in"], POINTER(IApplicationView), "pView1"),
+            ),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "CreateRemoteDesktop",
+                (["in"], HSTRING, "a1"),
+                (["out"], POINTER(POINTER(desktop)), "out"),
+            ),
+            STDMETHOD(HRESULT, "pDesktop", (POINTER(desktop),)),
+            STDMETHOD(HRESULT, "SwitchRemoteDesktop", (POINTER(desktop), UINT)),
+            STDMETHOD(HRESULT, "SwitchDesktopWithAnimation", (POINTER(desktop),)),
+            COMMETHOD([], HRESULT, "GetLastActiveDesktop", (["out"], POINTER(POINTER(desktop)), "pDesktop")),
+            STDMETHOD(HRESULT, "WaitForAnimationToComplete"),
+        ]
+
+    if tier >= TIER_22621:
+        return [
+            COMMETHOD([], HRESULT, "GetCount", (["out"], POINTER(UINT), "pCount")),
+            STDMETHOD(HRESULT, "MoveViewToDesktop", (POINTER(IApplicationView), POINTER(desktop))),
+            STDMETHOD(HRESULT, "CanViewMoveDesktops", (POINTER(IApplicationView), POINTER(UINT))),
+            COMMETHOD([], HRESULT, "GetCurrentDesktop", (["out"], POINTER(POINTER(desktop)), "pDesktop")),
+            COMMETHOD([], HRESULT, "GetDesktops", (["out"], POINTER(POINTER(IObjectArray)), "array")),
+            STDMETHOD(HRESULT, "GetAdjacentDesktop", (POINTER(desktop), AdjacentDesktop, POINTER(POINTER(desktop)))),
+            STDMETHOD(HRESULT, "SwitchDesktop", (POINTER(desktop),)),
+            COMMETHOD([], HRESULT, "CreateDesktopW", (["out"], POINTER(POINTER(desktop)), "pDesktop")),
+            STDMETHOD(HRESULT, "MoveDesktop", (POINTER(desktop), HWND, INT)),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "RemoveDesktop",
+                (["in"], POINTER(desktop), "destroyDesktop"),
+                (["in"], POINTER(desktop), "fallbackDesktop"),
+            ),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "FindDesktop",
+                (["in"], POINTER(GUID), "pGuid"),
+                (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+            ),
+            STDMETHOD(
+                HRESULT,
+                "Unknown",
+                (POINTER(desktop), POINTER(POINTER(IObjectArray)), POINTER(POINTER(IObjectArray))),
+            ),
+            COMMETHOD([], HRESULT, "SetName", (["in"], POINTER(desktop), "pDesktop"), (["in"], HSTRING, "name")),
+            COMMETHOD([], HRESULT, "SetWallpaper", (["in"], POINTER(desktop), "pDesktop"), (["in"], HSTRING, "path")),
+            COMMETHOD([], HRESULT, "SetWallpaperForAllDesktops", (["in"], HSTRING, "path")),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "CopyDesktopState",
+                (["in"], POINTER(IApplicationView), "pView0"),
+                (["in"], POINTER(IApplicationView), "pView1"),
+            ),
+            COMMETHOD([], HRESULT, "GetDesktopPerMonitor", (["out"], POINTER(BOOL), "state")),
+            COMMETHOD([], HRESULT, "SetDesktopPerMonitor", (["in"], BOOL, "state")),
+        ]
+
+    if tier >= TIER_22449:
+        return [
+            COMMETHOD([], HRESULT, "GetCount", (["in"], HWND, "hwnd"), (["out"], POINTER(UINT), "pCount")),
+            STDMETHOD(HRESULT, "MoveViewToDesktop", (POINTER(IApplicationView), POINTER(desktop))),
+            STDMETHOD(HRESULT, "CanViewMoveDesktops", (POINTER(IApplicationView), POINTER(UINT))),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "GetCurrentDesktop",
+                (["in"], HWND, "hwnd"),
+                (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+            ),
+            # Added in 22449 without a GUID change.
+            COMMETHOD([], HRESULT, "GetAllCurrentDesktops", (["out"], POINTER(POINTER(IObjectArray)), "array")),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "GetDesktops",
+                (["in"], HWND, "hwnd"),
+                (["out"], POINTER(POINTER(IObjectArray)), "array"),
+            ),
+            STDMETHOD(HRESULT, "GetAdjacentDesktop", (POINTER(desktop), AdjacentDesktop, POINTER(POINTER(desktop)))),
+            STDMETHOD(HRESULT, "SwitchDesktop", (HWND, POINTER(desktop))),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "CreateDesktopW",
+                (["in"], HWND, "hwnd"),
+                (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+            ),
+            STDMETHOD(HRESULT, "MoveDesktop", (POINTER(desktop), HWND, INT)),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "RemoveDesktop",
+                (["in"], POINTER(desktop), "destroyDesktop"),
+                (["in"], POINTER(desktop), "fallbackDesktop"),
+            ),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "FindDesktop",
+                (["in"], POINTER(GUID), "pGuid"),
+                (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+            ),
+            STDMETHOD(
+                HRESULT,
+                "Unknown",
+                (POINTER(desktop), POINTER(POINTER(IObjectArray)), POINTER(POINTER(IObjectArray))),
+            ),
+            COMMETHOD([], HRESULT, "SetName", (["in"], POINTER(desktop), "pDesktop"), (["in"], HSTRING, "name")),
+            COMMETHOD([], HRESULT, "SetWallpaper", (["in"], POINTER(desktop), "pDesktop"), (["in"], HSTRING, "path")),
+            COMMETHOD([], HRESULT, "SetWallpaperForAllDesktops", (["in"], HSTRING, "path")),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "CopyDesktopState",
+                (["in"], POINTER(IApplicationView), "pView0"),
+                (["in"], POINTER(IApplicationView), "pView1"),
+            ),
+            COMMETHOD([], HRESULT, "GetDesktopPerMonitor", (["out"], POINTER(BOOL), "state")),
+            COMMETHOD([], HRESULT, "SetDesktopPerMonitor", (["in"], BOOL, "state")),
+        ]
+
+    if tier >= TIER_21313:
+        return [
+            COMMETHOD([], HRESULT, "GetCount", (["in"], HWND, "hwnd"), (["out"], POINTER(UINT), "pCount")),
+            STDMETHOD(HRESULT, "MoveViewToDesktop", (POINTER(IApplicationView), POINTER(desktop))),
+            STDMETHOD(HRESULT, "CanViewMoveDesktops", (POINTER(IApplicationView), POINTER(UINT))),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "GetCurrentDesktop",
+                (["in"], HWND, "hwnd"),
+                (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+            ),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "GetDesktops",
+                (["in"], HWND, "hwnd"),
+                (["out"], POINTER(POINTER(IObjectArray)), "array"),
+            ),
+            STDMETHOD(HRESULT, "GetAdjacentDesktop", (POINTER(desktop), AdjacentDesktop, POINTER(POINTER(desktop)))),
+            STDMETHOD(HRESULT, "SwitchDesktop", (HWND, POINTER(desktop))),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "CreateDesktopW",
+                (["in"], HWND, "hwnd"),
+                (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+            ),
+            STDMETHOD(HRESULT, "MoveDesktop", (POINTER(desktop), HWND, INT)),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "RemoveDesktop",
+                (["in"], POINTER(desktop), "destroyDesktop"),
+                (["in"], POINTER(desktop), "fallbackDesktop"),
+            ),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "FindDesktop",
+                (["in"], POINTER(GUID), "pGuid"),
+                (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+            ),
+            STDMETHOD(
+                HRESULT,
+                "Unknown",
+                (POINTER(desktop), POINTER(POINTER(IObjectArray)), POINTER(POINTER(IObjectArray))),
+            ),
+            COMMETHOD([], HRESULT, "SetName", (["in"], POINTER(desktop), "pDesktop"), (["in"], HSTRING, "name")),
+            COMMETHOD([], HRESULT, "SetWallpaper", (["in"], POINTER(desktop), "pDesktop"), (["in"], HSTRING, "path")),
+            COMMETHOD([], HRESULT, "SetWallpaperForAllDesktops", (["in"], HSTRING, "path")),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "CopyDesktopState",
+                (["in"], POINTER(IApplicationView), "pView0"),
+                (["in"], POINTER(IApplicationView), "pView1"),
+            ),
+            COMMETHOD([], HRESULT, "GetDesktopPerMonitor", (["out"], POINTER(BOOL), "state")),
+            COMMETHOD([], HRESULT, "SetDesktopPerMonitor", (["in"], BOOL, "state")),
+        ]
+
+    if tier >= TIER_20231:
+        return [
+            COMMETHOD([], HRESULT, "GetCount", (["in"], HWND, "hwnd"), (["out"], POINTER(UINT), "pCount")),
+            STDMETHOD(HRESULT, "MoveViewToDesktop", (POINTER(IApplicationView), POINTER(desktop))),
+            STDMETHOD(HRESULT, "CanViewMoveDesktops", (POINTER(IApplicationView), POINTER(UINT))),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "GetCurrentDesktop",
+                (["in"], HWND, "hwnd"),
+                (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+            ),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "GetDesktops",
+                (["in"], HWND, "hwnd"),
+                (["out"], POINTER(POINTER(IObjectArray)), "array"),
+            ),
+            STDMETHOD(HRESULT, "GetAdjacentDesktop", (POINTER(desktop), AdjacentDesktop, POINTER(POINTER(desktop)))),
+            STDMETHOD(HRESULT, "SwitchDesktop", (HWND, POINTER(desktop))),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "CreateDesktopW",
+                (["in"], HWND, "hwnd"),
+                (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+            ),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "RemoveDesktop",
+                (["in"], POINTER(desktop), "destroyDesktop"),
+                (["in"], POINTER(desktop), "fallbackDesktop"),
+            ),
+            COMMETHOD(
+                [],
+                HRESULT,
+                "FindDesktop",
+                (["in"], POINTER(GUID), "pGuid"),
+                (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+            ),
+        ]
+
+    return [
+        COMMETHOD([], HRESULT, "GetCount", (["out"], POINTER(UINT), "pCount")),
+        STDMETHOD(HRESULT, "MoveViewToDesktop", (POINTER(IApplicationView), POINTER(desktop))),
+        STDMETHOD(HRESULT, "CanViewMoveDesktops", (POINTER(IApplicationView), POINTER(UINT))),
+        COMMETHOD([], HRESULT, "GetCurrentDesktop", (["out"], POINTER(POINTER(desktop)), "pDesktop")),
+        COMMETHOD([], HRESULT, "GetDesktops", (["out"], POINTER(POINTER(IObjectArray)), "array")),
+        STDMETHOD(HRESULT, "GetAdjacentDesktop", (POINTER(desktop), AdjacentDesktop, POINTER(POINTER(desktop)))),
+        STDMETHOD(HRESULT, "SwitchDesktop", (POINTER(desktop),)),
+        COMMETHOD([], HRESULT, "CreateDesktopW", (["out"], POINTER(POINTER(desktop)), "pDesktop")),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "RemoveDesktop",
+            (["in"], POINTER(desktop), "destroyDesktop"),
+            (["in"], POINTER(desktop), "fallbackDesktop"),
+        ),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "FindDesktop",
+            (["in"], POINTER(GUID), "pGuid"),
+            (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+        ),
+    ]
+
+
+def _make_manager_internal(tier: int, desktop: type[IUnknown]) -> type[IUnknown]:
+    """Build `IVirtualDesktopManagerInternal` for `tier`.
+
+    The wrapper methods hide the fact that pre-22621 builds take a leading
+    HWND (always passed as 0, meaning "all monitors") on the calls we make.
+    """
+    takes_hwnd = TIER_20231 <= tier < TIER_22621
+
+    def get_all_desktops(self):
+        return self.GetDesktops(0) if takes_hwnd else self.GetDesktops()
+
+    def get_current_desktop(self):
+        return self.GetCurrentDesktop(0) if takes_hwnd else self.GetCurrentDesktop()
+
+    def create_desktop(self):
+        return self.CreateDesktopW(0) if takes_hwnd else self.CreateDesktopW()
+
+    def switch_desktop(self, target):
+        return self.SwitchDesktop(0, target) if takes_hwnd else self.SwitchDesktop(target)
+
+    return type(
+        "IVirtualDesktopManagerInternal",
+        (IUnknown,),
+        {
+            "_iid_": MANAGER_GUID_BY_TIER[tier],
+            "_methods_": _manager_methods(tier, desktop),
+            "get_all_desktops": get_all_desktops,
+            "get_current_desktop": get_current_desktop,
+            "create_desktop": create_desktop,
+            "switch_desktop": switch_desktop,
+        },
+    )
+
+
+def _make_manager_internal2(desktop: type[IUnknown]) -> type[IUnknown]:
+    """Build `IVirtualDesktopManagerInternal2`, the 19041-era rename route."""
+    return type(
+        "IVirtualDesktopManagerInternal2",
+        (IUnknown,),
+        {
+            "_iid_": GUID_IVirtualDesktopManagerInternal2,
+            "_methods_": [
+                COMMETHOD([], HRESULT, "GetCount", (["out"], POINTER(UINT), "pCount")),
+                STDMETHOD(HRESULT, "MoveViewToDesktop", (POINTER(IApplicationView), POINTER(desktop))),
+                STDMETHOD(HRESULT, "CanViewMoveDesktops", (POINTER(IApplicationView), POINTER(UINT))),
+                COMMETHOD([], HRESULT, "GetCurrentDesktop", (["out"], POINTER(POINTER(desktop)), "pDesktop")),
+                COMMETHOD([], HRESULT, "GetDesktops", (["out"], POINTER(POINTER(IObjectArray)), "array")),
+                STDMETHOD(
+                    HRESULT, "GetAdjacentDesktop", (POINTER(desktop), AdjacentDesktop, POINTER(POINTER(desktop)))
+                ),
+                STDMETHOD(HRESULT, "SwitchDesktop", (POINTER(desktop),)),
+                COMMETHOD([], HRESULT, "CreateDesktopW", (["out"], POINTER(POINTER(desktop)), "pDesktop")),
+                COMMETHOD(
+                    [],
+                    HRESULT,
+                    "RemoveDesktop",
+                    (["in"], POINTER(desktop), "destroyDesktop"),
+                    (["in"], POINTER(desktop), "fallbackDesktop"),
+                ),
+                COMMETHOD(
+                    [],
+                    HRESULT,
+                    "FindDesktop",
+                    (["in"], POINTER(GUID), "pGuid"),
+                    (["out"], POINTER(POINTER(desktop)), "pDesktop"),
+                ),
+                STDMETHOD(
+                    HRESULT,
+                    "Unknown",
+                    (POINTER(desktop), POINTER(POINTER(IObjectArray)), POINTER(POINTER(IObjectArray))),
+                ),
+                COMMETHOD([], HRESULT, "SetName", (["in"], POINTER(desktop), "pDesktop"), (["in"], HSTRING, "name")),
+            ],
+        },
+    )
+
+
+# Notification vtables. Parameters are declared opaque because the sink never
+# inspects them; state is re-queried through the manager instead.
+_NOTIFICATION_METHODS_WIN10 = [
+    ("VirtualDesktopCreated", 1),
+    ("VirtualDesktopDestroyBegin", 2),
+    ("VirtualDesktopDestroyFailed", 2),
+    ("VirtualDesktopDestroyed", 2),
+    ("ViewVirtualDesktopChanged", 1),
+    ("CurrentVirtualDesktopChanged", 2),
+]
+
+_NOTIFICATION_METHODS_21H2 = [
+    ("VirtualDesktopCreated", 2),
+    ("VirtualDesktopDestroyBegin", 3),
+    ("VirtualDesktopDestroyFailed", 3),
+    ("VirtualDesktopDestroyed", 3),
+    ("Proc7", 1),
+    ("VirtualDesktopMoved", 4),
+    ("VirtualDesktopRenamed", 2),
+    ("ViewVirtualDesktopChanged", 1),
+    ("CurrentVirtualDesktopChanged", 3),
+    ("VirtualDesktopWallpaperChanged", 2),
+]
+
+_NOTIFICATION_METHODS_23H2 = [
+    ("VirtualDesktopCreated", 1),
+    ("VirtualDesktopDestroyBegin", 2),
+    ("VirtualDesktopDestroyFailed", 2),
+    ("VirtualDesktopDestroyed", 2),
+    ("VirtualDesktopMoved", 3),
+    ("VirtualDesktopRenamed", 2),
+    ("ViewVirtualDesktopChanged", 1),
+    ("CurrentVirtualDesktopChanged", 2),
+    ("VirtualDesktopWallpaperChanged", 2),
+    ("VirtualDesktopSwitched", 1),
+    ("RemoteVirtualDesktopConnected", 1),
+]
+
+
+def _make_notification(iid: GUID, spec: list[tuple[str, int]], name: str) -> type[IUnknown]:
+    """Build a notification sink interface from a (method, arity) spec."""
+    methods = [
+        COMMETHOD([], HRESULT, method, *[(["in"], c_void_p, f"p{i}") for i in range(arity)]) for method, arity in spec
+    ]
+    return type(name, (IUnknown,), {"_iid_": iid, "_methods_": methods})
+
+
+def _make_notification_ifaces(tier: int) -> tuple[type[IUnknown], type[IUnknown]]:
+    """Build the notification sink interfaces for `tier`.
+
+    The second interface is a 19041-era derived one. The shell there reports
+    renames by calling QueryInterface for it rather than using the primary
+    sink, so it is registered unconditionally. Its layout does not vary.
+    """
+    if tier >= TIER_22631:
+        iid, spec = GUID_IVirtualDesktopNotification_22631, _NOTIFICATION_METHODS_23H2
+    elif tier >= TIER_22621:
+        iid, spec = GUID_IVirtualDesktopNotification_22621, _NOTIFICATION_METHODS_23H2
+    elif tier >= TIER_20231:
+        iid, spec = GUID_IVirtualDesktopNotification_20231, _NOTIFICATION_METHODS_21H2
+    else:
+        iid, spec = GUID_IVirtualDesktopNotification_9000, _NOTIFICATION_METHODS_WIN10
+
+    primary = _make_notification(iid, spec, "IVirtualDesktopNotification")
+    secondary = _make_notification(
+        GUID_IVirtualDesktopNotification2,
+        _NOTIFICATION_METHODS_WIN10 + [("VirtualDesktopRenamed", 2)],
+        "IVirtualDesktopNotification2",
+    )
+    return primary, secondary
+
+
+@dataclass(frozen=True)
+class DesktopInterfaces:
+    """The interface set matching one Windows build tier."""
+
+    tier: int
+    IVirtualDesktop: type[IUnknown]
+    IVirtualDesktopManagerInternal: type[IUnknown]
+    IVirtualDesktopManagerInternal2: type[IUnknown]
+    IVirtualDesktopNotification: type[IUnknown]
+    IVirtualDesktopNotification2: type[IUnknown]
+
+    @property
+    def supports_names(self) -> bool:
+        return supports_desktop_names(self.tier)
+
+    @property
+    def supports_wallpaper(self) -> bool:
+        return supports_wallpaper(self.tier)
+
+
+class VirtualDesktopUnsupportedError(RuntimeError):
+    """Raised when no known virtual desktop interface is available."""
+
+
+def _service_provider() -> Any:
+    """Create the Immersive Shell service provider."""
+    return CoCreateInstance(CLSID_ImmersiveShell, IServiceProvider, CLSCTX_LOCAL_SERVER)
+
+
+def _manager_available(provider: Any, iid: GUID) -> bool:
+    """Does the shell hand out the desktop manager under this interface GUID?"""
+    pointer = POINTER(IUnknown)()
+    try:
+        provider.QueryService(CLSID_VirtualDesktopManagerInternal, iid, pointer)
+    except COMError:
+        return False
+    return True
+
+
+def resolve_tier() -> int:
+    """Determine which interface tier this machine speaks.
+
+    Only the Windows 11 range is ambiguous, because 22H2 gained newer shell
+    interfaces through Moment updates without a build change. Builds outside
+    that range are decided by build number alone; inside it the shell is asked
+    directly, trying each candidate GUID from newest to oldest.
+    """
+    build = sys.getwindowsversion().build
+    if build >= TIER_26100:
+        logger.debug("Virtual desktop tier %d selected from build %d", TIER_26100, build)
+        return TIER_26100
+    if build < TIER_20231:
+        # Windows 10 shipped 19041 to 19045 on one shell generation.
+        logger.debug("Virtual desktop tier %d selected from build %d", TIER_WIN10, build)
+        return TIER_WIN10
+
+    provider = _service_provider()
+    for tier in PROBE_ORDER:
+        if not _manager_available(provider, MANAGER_GUID_BY_TIER[tier]):
+            continue
+        # 22449 added a method to the 21313 interface without changing its GUID.
+        if tier == TIER_21313 and build >= TIER_22449:
+            tier = TIER_22449
+        logger.debug("Virtual desktop tier %d resolved by probe on build %d", tier, build)
+        return tier
+
+    tried = ", ".join(str(MANAGER_GUID_BY_TIER[t]) for t in PROBE_ORDER)
+    raise VirtualDesktopUnsupportedError(
+        f"No supported IVirtualDesktopManagerInternal interface found on build {build}. "
+        f"Tried: {tried}. Please report this at https://github.com/amnweb/yasb/issues"
+    )
+
+
+_interfaces: DesktopInterfaces | None = None
+
+
+def get_interfaces() -> DesktopInterfaces:
+    """Return the interface set for this machine, resolving it on first call.
+
+    Only one tier is built per process. comtypes keeps a global registry keyed by
+    interface GUID, and several tiers reuse the same GUID with different vtables,
+    so building more than one would leave it pointing at the wrong layout.
+    """
+    global _interfaces
+    if _interfaces is None:
+        tier = resolve_tier()
+        desktop = _make_virtual_desktop(tier)
+        notification, notification2 = _make_notification_ifaces(tier)
+        _interfaces = DesktopInterfaces(
+            tier=tier,
+            IVirtualDesktop=desktop,
+            IVirtualDesktopManagerInternal=_make_manager_internal(tier, desktop),
+            IVirtualDesktopManagerInternal2=_make_manager_internal2(desktop),
+            IVirtualDesktopNotification=notification,
+            IVirtualDesktopNotification2=notification2,
+        )
+    return _interfaces

--- a/src/core/widgets/services/windows_desktops/notification.py
+++ b/src/core/widgets/services/windows_desktops/notification.py
@@ -1,0 +1,176 @@
+"""Virtual desktop change notifications from the shell.
+
+The shell pushes changes to any COM object that implements
+IVirtualDesktopNotification and registers with the notification service, which
+avoids polling entirely.
+
+The sink translates the raw callbacks into a DesktopEvent and hands them to one
+callable. Callback parameters are ignored: they are desktop pointers whose layout
+varies by build, and consumers re-read state through the API anyway.
+
+Callbacks arrive on whichever thread the shell calls in on, not necessarily the
+one that registered, so consumers must treat them as arriving from an arbitrary
+thread. The service marshals them onto the Qt main thread with a signal.
+"""
+
+import logging
+from collections.abc import Callable
+from ctypes import c_void_p, cast
+from enum import Enum, auto
+from typing import Any
+
+import comtypes
+
+from core.widgets.services.windows_desktops.com import VirtualDesktopApi, get_api
+from core.widgets.services.windows_desktops.interfaces import DesktopInterfaces
+
+logger = logging.getLogger("windows_desktop_service")
+
+
+class DesktopEvent(Enum):
+    """A desktop change reported by the shell."""
+
+    CURRENT_CHANGED = auto()
+    CREATED = auto()
+    DESTROYED = auto()
+    MOVED = auto()
+    RENAMED = auto()
+    WALLPAPER_CHANGED = auto()
+    SWITCHED = auto()
+
+
+_sink_class: type | None = None
+
+
+def _make_sink_class(interfaces: DesktopInterfaces) -> type:
+    """Build the notification sink class for the resolved interface tier.
+
+    The sink implements every callback name used by any build; names absent from
+    this build's vtable go uncalled, so one class covers all tiers.
+
+    IVirtualDesktopNotification2 is implemented alongside the primary interface
+    because on 19041 the shell reports renames through it instead.
+    """
+
+    class DesktopNotificationSink(comtypes.COMObject):
+        _com_interfaces_ = [
+            interfaces.IVirtualDesktopNotification,
+            interfaces.IVirtualDesktopNotification2,
+        ]
+
+        def __init__(self, dispatch: Callable[[DesktopEvent], None]):
+            super().__init__()
+            self._dispatch = dispatch
+
+        def _emit(self, event: DesktopEvent) -> int:
+            """Pass the event to the consumer, swallowing any error.
+
+            An exception escaping into COM crosses the boundary as a failed
+            HRESULT and can make the shell drop the registration.
+            """
+            try:
+                self._dispatch(event)
+            except Exception:
+                logger.exception("Virtual desktop notification handler failed for %s", event)
+            return 0  # S_OK regardless; never report failure to the shell
+
+        def VirtualDesktopCreated(self, *_args: Any) -> int:
+            return self._emit(DesktopEvent.CREATED)
+
+        def VirtualDesktopDestroyed(self, *_args: Any) -> int:
+            return self._emit(DesktopEvent.DESTROYED)
+
+        def VirtualDesktopMoved(self, *_args: Any) -> int:
+            return self._emit(DesktopEvent.MOVED)
+
+        def VirtualDesktopRenamed(self, *_args: Any) -> int:
+            return self._emit(DesktopEvent.RENAMED)
+
+        def CurrentVirtualDesktopChanged(self, *_args: Any) -> int:
+            return self._emit(DesktopEvent.CURRENT_CHANGED)
+
+        def VirtualDesktopWallpaperChanged(self, *_args: Any) -> int:
+            return self._emit(DesktopEvent.WALLPAPER_CHANGED)
+
+        def VirtualDesktopSwitched(self, *_args: Any) -> int:
+            return self._emit(DesktopEvent.SWITCHED)
+
+        # Callbacks we deliberately ignore. They still need implementations so
+        # the shell gets S_OK rather than E_NOTIMPL.
+        def VirtualDesktopDestroyBegin(self, *_args: Any) -> int:
+            return 0
+
+        def VirtualDesktopDestroyFailed(self, *_args: Any) -> int:
+            return 0
+
+        def ViewVirtualDesktopChanged(self, *_args: Any) -> int:
+            return 0
+
+        def RemoteVirtualDesktopConnected(self, *_args: Any) -> int:
+            return 0
+
+        def Proc7(self, *_args: Any) -> int:
+            return 0
+
+    return DesktopNotificationSink
+
+
+def _sink_type(interfaces: DesktopInterfaces) -> type:
+    """The sink class for this process, built once."""
+    global _sink_class
+    if _sink_class is None:
+        _sink_class = _make_sink_class(interfaces)
+    return _sink_class
+
+
+class DesktopNotificationListener:
+    """Keeps a notification sink registered with the shell.
+
+    start() returns False rather than raising so callers can fall back to polling.
+    """
+
+    def __init__(self, on_event: Callable[[DesktopEvent], None], api: VirtualDesktopApi | None = None):
+        self._on_event = on_event
+        self._api = api or get_api()
+        self._service: Any = None
+        self._sink: Any = None
+        self._cookie: int | None = None
+
+    @property
+    def active(self) -> bool:
+        return self._cookie is not None
+
+    def start(self) -> bool:
+        """Register with the shell. Returns whether notifications are live."""
+        if self.active:
+            return True
+        try:
+            interfaces = self._api.interfaces
+            self._service = self._api.notification_service()
+            self._sink = _sink_type(interfaces)(self._on_event)
+            # Register takes the raw interface pointer, not the Python object.
+            pointer = cast(
+                self._sink._com_pointers_[interfaces.IVirtualDesktopNotification._iid_],
+                c_void_p,
+            )
+            self._cookie = self._service.Register(pointer)
+        except Exception:
+            logger.warning("Could not register for virtual desktop notifications", exc_info=True)
+            self._service = None
+            self._sink = None
+            self._cookie = None
+            return False
+        logger.info("Registered for virtual desktop notifications (cookie=%s)", self._cookie)
+        return True
+
+    def stop(self) -> None:
+        """Unregister and drop the sink. Safe to call when not started."""
+        if self._cookie is not None and self._service is not None:
+            try:
+                self._service.Unregister(self._cookie)
+                logger.info("Unregistered virtual desktop notifications (cookie=%s)", self._cookie)
+            except Exception:
+                logger.debug("Failed to unregister virtual desktop notifications", exc_info=True)
+        self._cookie = None
+        self._service = None
+        self._sink = None

--- a/src/core/widgets/services/windows_desktops/selfcheck.py
+++ b/src/core/widgets/services/windows_desktops/selfcheck.py
@@ -1,0 +1,219 @@
+"""Virtual desktop self-check.
+
+Windows drives virtual desktops through undocumented COM interfaces whose GUIDs
+and vtable layouts changed several times between Windows 10 and Windows 11. The
+widget keeps one interface set per build tier and picks the right one at runtime.
+Picking the wrong one fails quietly: the widget stops updating, or a menu entry
+does nothing, with no error to go on.
+
+There is no practical way to test that from here. A tier cannot be exercised
+without a machine running that build, and mocking the shell proves nothing, since
+what the real shell does is the entire question. So rather than trying to test
+every build ourselves, this script reports what one machine actually does.
+
+Run it on any machine where the widget misbehaves and attach the output to the
+bug report. It prints the build number, which tier was selected and how many COM
+probes that took, which capabilities the build has, and a pass or fail line for
+every call the widget makes.
+
+    pip install comtypes
+    cd src
+    python -m core.widgets.services.windows_desktops.selfcheck
+    python -m core.widgets.services.windows_desktops.selfcheck --full
+
+Without --full nothing is modified. With --full it creates a scratch desktop,
+renames it, switches to it and back, moves the focused window there and back, and
+toggles both pin states. Every change is undone and the scratch desktop deleted
+before the summary prints, so the desktops you start with are the ones you end
+with.
+"""
+
+import ctypes
+import sys
+import time
+import traceback
+from ctypes.wintypes import MSG
+
+from core.utils.win32.bindings.user32 import user32
+
+# PeekMessage removes the message from the queue after retrieving it.
+PM_REMOVE = 0x0001
+
+results: list[tuple[str, bool, str]] = []
+
+
+def record(name: str, fn) -> object:
+    """Run one check, record pass or fail, and return its value."""
+    try:
+        value = fn()
+    except Exception as e:
+        results.append((name, False, f"{type(e).__name__}: {e}"))
+        return None
+    results.append((name, True, "" if value is None else str(value)))
+    return value
+
+
+def pump(seconds: float = 1.2) -> None:
+    """Dispatch Windows messages so COM can deliver notifications."""
+    message = MSG()
+    end = time.time() + seconds
+    while time.time() < end:
+        while user32.PeekMessageW(ctypes.byref(message), None, 0, 0, PM_REMOVE):
+            user32.TranslateMessage(ctypes.byref(message))
+            user32.DispatchMessageW(ctypes.byref(message))
+        time.sleep(0.01)
+
+
+def main(full: bool = False) -> int:
+    from core.widgets.services.windows_desktops import interfaces as vd
+    from core.widgets.services.windows_desktops.com import get_api
+    from core.widgets.services.windows_desktops.notification import DesktopEvent, DesktopNotificationListener
+
+    version = sys.getwindowsversion()
+    print(f"Windows {version.major}.{version.minor} build {version.build}")
+    print(f"platform version {'.'.join(str(p) for p in version.platform_version)}")
+    print(f"Python {sys.version.split()[0]}\n")
+
+    probes = {"count": 0}
+    original_probe = vd._manager_available
+
+    def counting_probe(provider, iid):
+        probes["count"] += 1
+        return original_probe(provider, iid)
+
+    vd._manager_available = counting_probe
+    tier = record("resolve tier", vd.resolve_tier)
+    vd._manager_available = original_probe
+    print(f"tier {tier}, resolved with {probes['count']} COM probe(s)")
+
+    api = get_api()
+    record("acquire COM interfaces", api.available)
+    record("supports desktop names", lambda: api.supports_names)
+    record("supports per-desktop wallpaper", lambda: api.supports_wallpaper)
+    record("IVirtualDesktopManagerInternal2", lambda: api._ensure().manager2 is not None)
+
+    desktops = record("list desktops", api.list_desktops)
+    current = record("read current desktop", api.current_guid)
+    record("desktop count", api.count)
+    if desktops:
+        print("\ndesktops:")
+        for d in desktops:
+            mark = "  <- current" if d.guid == current else ""
+            print(f"   {d.number}. name={d.name!r} {d.guid}{mark}")
+        record("current desktop is in the list", lambda: any(d.guid == current for d in desktops))
+        record("resolve a desktop by GUID", lambda: api._find(desktops[0].guid) is not None)
+
+    from core.utils.win32.bindings.user32 import GetForegroundWindow
+
+    hwnd = GetForegroundWindow()
+    view = record("view for foreground window", lambda: api.try_view_for_hwnd(hwnd))
+    if view is not None:
+        record("read window pin state", lambda: api.is_view_pinned(view))
+        record("read app pin state", lambda: api.is_app_pinned(view))
+
+    events: list[DesktopEvent] = []
+    listener = DesktopNotificationListener(events.append, api)
+    registered = record("register for notifications", listener.start)
+
+    if full and desktops and registered:
+        print("\n--- full mode: creating a scratch desktop ---")
+
+        scratch = None
+        try:
+            scratch = record("create desktop", api.create)
+            pump()
+            record("CREATED notification", lambda: DesktopEvent.CREATED in events)
+
+            if scratch:
+                events.clear()
+                if api.supports_names:
+                    record("rename desktop", lambda: api.rename(scratch, "__yasb_selfcheck__"))
+                    pump()
+                    record(
+                        "rename reflected",
+                        lambda: any(d.guid == scratch and d.name == "__yasb_selfcheck__" for d in api.list_desktops()),
+                    )
+                    record("RENAMED notification", lambda: DesktopEvent.RENAMED in events)
+
+                events.clear()
+                record("switch desktop", lambda: api.switch_to(scratch))
+                pump()
+                record("switch took effect", lambda: api.current_guid() == scratch)
+                record("CURRENT_CHANGED notification", lambda: DesktopEvent.CURRENT_CHANGED in events)
+
+                record("switch back", lambda: api.switch_to(current))
+                pump()
+
+                if view is not None:
+                    # Window operations, on the window that had focus at start.
+                    # Each is undone immediately afterwards.
+                    def desktop_of_window() -> str:
+                        return str(api.view_for_hwnd(hwnd).GetVirtualDesktopId())
+
+                    home = desktop_of_window()
+                    record("move window to another desktop", lambda: api.move_view(api.view_for_hwnd(hwnd), scratch))
+                    pump(0.8)
+                    record("window moved", lambda: desktop_of_window() == scratch)
+                    record("move window back", lambda: api.move_view(api.view_for_hwnd(hwnd), home))
+                    pump(0.8)
+                    record("window moved back", lambda: desktop_of_window() == home)
+
+                    was_pinned = api.is_view_pinned(api.view_for_hwnd(hwnd))
+                    record("pin window", lambda: api.pin_view(api.view_for_hwnd(hwnd)))
+                    pump(0.4)
+                    record("window reports pinned", lambda: api.is_view_pinned(api.view_for_hwnd(hwnd)) is True)
+                    record("unpin window", lambda: api.unpin_view(api.view_for_hwnd(hwnd)))
+                    pump(0.4)
+                    record(
+                        "window pin state restored",
+                        lambda: api.is_view_pinned(api.view_for_hwnd(hwnd)) == was_pinned,
+                    )
+
+                    was_app_pinned = api.is_app_pinned(api.view_for_hwnd(hwnd))
+                    record("pin app", lambda: api.pin_app(api.view_for_hwnd(hwnd)))
+                    pump(0.4)
+                    record("app reports pinned", lambda: api.is_app_pinned(api.view_for_hwnd(hwnd)) is True)
+                    record("unpin app", lambda: api.unpin_app(api.view_for_hwnd(hwnd)))
+                    pump(0.4)
+                    record(
+                        "app pin state restored",
+                        lambda: api.is_app_pinned(api.view_for_hwnd(hwnd)) == was_app_pinned,
+                    )
+        finally:
+            if scratch:
+                try:
+                    if api.current_guid() != current:
+                        api.switch_to(current)
+                        pump(0.6)
+                    events.clear()
+                    record("remove desktop", lambda: api.remove(scratch, current))
+                    pump()
+                    record("DESTROYED notification", lambda: DesktopEvent.DESTROYED in events)
+                except Exception:
+                    print("cleanup failed:")
+                    traceback.print_exc()
+
+        final = api.list_desktops()
+        record(
+            "original desktops restored",
+            lambda: [(d.guid, d.name) for d in final] == [(d.guid, d.name) for d in desktops],
+        )
+        record("original desktop still active", lambda: api.current_guid() == current)
+
+    listener.stop()
+
+    print()
+    failed = 0
+    for name, ok, detail in results:
+        if not ok:
+            failed += 1
+        print(f"  {'OK  ' if ok else 'FAIL'} {name}" + (f"  {detail}" if detail else ""))
+
+    print(f"\n{len(results) - failed}/{len(results)} checks passed on build {version.build}, tier {tier}")
+    if failed:
+        print("Please report this output at https://github.com/amnweb/yasb/issues")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(full="--full" in sys.argv))

--- a/src/core/widgets/services/windows_desktops/service.py
+++ b/src/core/widgets/services/windows_desktops/service.py
@@ -1,25 +1,29 @@
+import ctypes
 import logging
+import os
+from ctypes import wintypes
+from dataclasses import dataclass, field
+from typing import Any
 
+from comtypes import COMError
 from PyQt6.QtCore import QObject, QTimer, pyqtSignal
 
-from core.utils.win32.bindings.user32 import GetClassName, GetForegroundWindow
-
-try:
-    from pyvda import (
-        AppView,
-        VirtualDesktop,
-        VirtualDesktopNotificationService,
-        get_virtual_desktops,
-        set_wallpaper_for_all_desktops,
-    )
-except Exception:
-    AppView = None
-    VirtualDesktop = None
-    VirtualDesktopNotificationService = None
-    get_virtual_desktops = None
-    set_wallpaper_for_all_desktops = None
+from core.utils.win32.bindings.user32 import GetClassName, GetForegroundWindow, GetWindowThreadProcessId
+from core.widgets.services.windows_desktops.com import (
+    DesktopInfo,
+    VirtualDesktopApi,
+    VirtualDesktopError,
+    get_api,
+)
+from core.widgets.services.windows_desktops.interfaces import VirtualDesktopUnsupportedError
+from core.widgets.services.windows_desktops.notification import DesktopEvent, DesktopNotificationListener
 
 logger = logging.getLogger("windows_desktop_service")
+
+# The shell is not always reachable: briefly during sign-in, or while a previous
+# instance is still releasing its COM connection after being killed. Nothing is
+# cached on failure, so a later call picks the shell up again once it answers.
+SHELL_UNAVAILABLE = (VirtualDesktopError, VirtualDesktopUnsupportedError, COMError, OSError, AttributeError)
 
 SKIP_WINDOW_CLASSES = frozenset(
     {
@@ -30,31 +34,55 @@ SKIP_WINDOW_CLASSES = frozenset(
     }
 )
 
+# How often to re-read state when the shell will not push notifications. This is
+# only reached when registering a notification sink fails, which happens while
+# the shell is briefly unreachable, such as when the previous instance was killed
+# rather than closed. Polling covers that gap and stops as soon as a sink
+# registers.
+POLL_INTERVAL_MS = 500
 
-class _NotificationHandler:
-    """Receives pyvda desktop notification callbacks and forwards them to the service."""
+# Events that change which desktops exist or how they are ordered.
+SET_CHANGED_EVENTS = frozenset({DesktopEvent.CREATED, DesktopEvent.DESTROYED, DesktopEvent.MOVED})
 
-    def __init__(self, service: WindowsDesktopService):
-        self._service = service
 
-    def desktop_changed(self, *args):
-        self._service._sig_com_desktop_changed.emit()
+def _is_own_window(hwnd: int) -> bool:
+    """Does this window belong to us?
 
-    def desktop_created(self, *args):
-        self._service._sig_com_desktops_updated.emit()
+    Our own windows are never valid move or pin targets and have no application
+    view, so asking the shell about them would only fail.
+    """
+    pid = wintypes.DWORD()
+    GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+    return pid.value == os.getpid()
 
-    def desktop_destroyed(self, *args):
-        self._service._sig_com_desktops_updated.emit()
 
-    def desktop_moved(self, *args):
-        self._service._sig_com_desktops_updated.emit()
+@dataclass(frozen=True)
+class ForegroundView:
+    """A foreground window and the shell view behind it.
 
-    def desktop_renamed(self, *args):
-        self._service._sig_com_desktop_renamed.emit()
+    The context menu reads pin state from this object to label its entries.
+    """
+
+    hwnd: int
+    view: Any = field(repr=False)
+    api: VirtualDesktopApi = field(repr=False)
+
+    def is_pinned(self) -> bool:
+        """Is this window pinned to every desktop?"""
+        return self.api.is_view_pinned(self.view)
+
+    def is_app_pinned(self) -> bool:
+        """Is this window's whole app pinned to every desktop?"""
+        return self.api.is_app_pinned(self.view)
 
 
 class WindowsDesktopService(QObject):
-    """Service for managing Windows virtual desktops and broadcasting changes."""
+    """Manages Windows virtual desktops and broadcasts changes.
+
+    One instance is shared by every widget. Desktop state is cached and dropped
+    whenever the shell reports a change, so redrawing a bar of buttons costs one
+    enumeration rather than one per button.
+    """
 
     _instance = None
     _init_done = False
@@ -62,9 +90,9 @@ class WindowsDesktopService(QObject):
     desktop_changed = pyqtSignal(dict)
     desktops_updated = pyqtSignal(dict, dict)
 
-    _sig_com_desktop_changed = pyqtSignal()
-    _sig_com_desktops_updated = pyqtSignal()
-    _sig_com_desktop_renamed = pyqtSignal()
+    # Carries a notification from whichever thread COM called in on to the Qt
+    # main thread. Same-thread emits stay direct; cross-thread ones queue.
+    _com_event = pyqtSignal(object)
 
     def __new__(cls):
         if cls._instance is None:
@@ -76,115 +104,180 @@ class WindowsDesktopService(QObject):
             return
         super().__init__()
         WindowsDesktopService._init_done = True
-        # Connect internal COM marshaling signals
-        self._sig_com_desktop_changed.connect(self._handle_desktop_changed)
-        self._sig_com_desktops_updated.connect(self._handle_desktops_updated)
-        self._sig_com_desktop_renamed.connect(self._handle_desktop_renamed)
+
+        self._api = get_api()
         self._widgets: list = []
         self._timer: QTimer | None = None
-        self._notification_cookie: int | None = None
-        self._notification_service = None
-        self._com_events_active = False
-        # Cached state for change detection
-        self._desktop_count: int = 0
-        self._current_index: int = 0
-        try:
-            self._desktop_count = len(get_virtual_desktops())
-            self._current_index = VirtualDesktop.current().number
-        except Exception:
-            pass
+        self._listener: DesktopNotificationListener | None = None
 
-    def _register_com_notifications(self):
-        """Try to register for COM virtual desktop notifications via pyvda."""
-        if self._com_events_active:
-            return True
-        if VirtualDesktopNotificationService is None:
-            return False
-        try:
-            self._notification_service = VirtualDesktopNotificationService()
-            handler = _NotificationHandler(self)
-            self._notification_cookie = self._notification_service.register(handler)
-            self._com_events_active = True
-            logger.info("Registered COM virtual desktop event successfully")
-            return True
-        except Exception:
-            logger.warning("Failed to register COM desktop notifications, falling back to polling")
-            return False
+        self._com_event.connect(self._on_com_event)
 
-    def _unregister_com_notifications(self):
-        """Unregister the COM notification sink."""
-        if not self._com_events_active or self._notification_service is None:
+        # Cached snapshot, dropped whenever the shell reports a change.
+        self._desktops: list[DesktopInfo] | None = None
+        self._current_guid: str | None = None
+
+        # One user action can produce several notifications: switching desktops
+        # also reports a wallpaper change and a switch. These collect what needs
+        # doing so a single refresh covers all of it.
+        self._pending_current_changed = False
+        self._pending_set_changed = False
+        self._pending_buttons = False
+        self._refresh_queued = False
+
+        # Last state broadcast, used to suppress no-op signals.
+        self._last_count = 0
+        self._last_number = 0
+        try:
+            snapshot = self._snapshot()
+            self._last_count = len(snapshot)
+            self._last_number = self._current_number()
+        except SHELL_UNAVAILABLE:
+            logger.debug("Could not read initial virtual desktop state", exc_info=True)
+
+    def _snapshot(self) -> list[DesktopInfo]:
+        """The desktop list, read from the shell only when the cache is cold."""
+        if self._desktops is None:
+            self._desktops = self._api.list_desktops()
+        return self._desktops
+
+    def _current(self) -> str:
+        """The current desktop's GUID, cached alongside the list."""
+        if self._current_guid is None:
+            self._current_guid = self._api.current_guid()
+        return self._current_guid
+
+    def _current_number(self) -> int:
+        """The current desktop's 1-based position.
+
+        Raises if the current desktop is not in the snapshot, so callers skip
+        the update rather than broadcasting a position no button can match.
+        """
+        guid = self._current()
+        number = next((d.number for d in self._snapshot() if d.guid == guid), 0)
+        if not number:
+            raise VirtualDesktopError(f"Current desktop {guid} is not in the desktop list")
+        return number
+
+    def _invalidate(self) -> None:
+        self._desktops = None
+        self._current_guid = None
+
+    def _resolve(self, number: int) -> DesktopInfo:
+        """Find a desktop by its 1-based position."""
+        desktop = next((d for d in self._snapshot() if d.number == number), None)
+        if desktop is None:
+            # The cache may predate a change we have not been told about yet.
+            self._invalidate()
+            desktop = next((d for d in self._snapshot() if d.number == number), None)
+        if desktop is None:
+            raise VirtualDesktopError(f"No desktop at position {number}")
+        return desktop
+
+    def _on_com_event(self, event: DesktopEvent) -> None:
+        """Record what a notification implies, then schedule one refresh."""
+        if event is DesktopEvent.CURRENT_CHANGED:
+            self._pending_current_changed = True
+        elif event in SET_CHANGED_EVENTS:
+            self._pending_set_changed = True
+        elif event is DesktopEvent.RENAMED:
+            self._pending_set_changed = True
+            self._pending_buttons = True
+        else:
+            # Wallpaper and switch notifications tell us nothing the other
+            # events do not already cover.
             return
-        try:
-            self._notification_service.unregister(self._notification_cookie)
-        except Exception:
-            logger.debug("Failed to unregister COM notifications")
-        self._notification_cookie = None
-        self._notification_service = None
-        self._com_events_active = False
 
-    def _handle_desktop_changed(self):
-        """Qt main thread fetch current desktop and emit signal."""
+        if not self._refresh_queued:
+            self._refresh_queued = True
+            QTimer.singleShot(0, self._apply_pending)
+
+    def _apply_pending(self) -> None:
+        """Apply everything the notifications asked for, in one pass."""
+        self._refresh_queued = False
+        current_changed = self._pending_current_changed
+        set_changed = self._pending_set_changed
+        update_buttons = self._pending_buttons
+        self._pending_current_changed = False
+        self._pending_set_changed = False
+        self._pending_buttons = False
+
+        self._invalidate()
         try:
-            current = VirtualDesktop.current().number
-        except Exception:
+            number = self._current_number()
+        except SHELL_UNAVAILABLE:
+            logger.debug("Failed to read virtual desktop state after notification", exc_info=True)
             return
-        self._current_index = current
-        self.desktop_changed.emit({"index": current})
-        # Also refresh in case desktop count changed simultaneously
-        self._refresh_state(update_buttons=False)
 
-    def _handle_desktops_updated(self):
-        """Refresh desktop list."""
-        self._refresh_state(update_buttons=False)
+        if current_changed:
+            self._last_number = number
+            self.desktop_changed.emit({"index": number})
 
-    def _handle_desktop_renamed(self):
-        """Refresh with button update for name change."""
-        self._refresh_state(update_buttons=True)
+        if current_changed or set_changed:
+            self._refresh_state(update_buttons=update_buttons)
 
-    def _refresh_state(self, update_buttons: bool = False):
-        """Refresh cached state and emit desktops_updated if changed."""
+    def _refresh_state(self, update_buttons: bool = False) -> None:
+        """Emit `desktops_updated` when the desktop set or selection moved."""
         try:
-            desktop_count = len(get_virtual_desktops())
-            current_index = VirtualDesktop.current().number
-        except Exception:
+            count = len(self._snapshot())
+            number = self._current_number()
+        except SHELL_UNAVAILABLE:
+            logger.debug("Failed to refresh virtual desktop state", exc_info=True)
             return
-        if desktop_count != self._desktop_count or current_index != self._current_index or update_buttons:
-            self._desktop_count = desktop_count
-            self._current_index = current_index
-            self.desktops_updated.emit(
-                {"index": current_index},
-                {"update_buttons": update_buttons},
-            )
+        if count != self._last_count or number != self._last_number or update_buttons:
+            self._last_count = count
+            self._last_number = number
+            self.desktops_updated.emit({"index": number}, {"update_buttons": update_buttons})
 
     def register_widget(self, widget):
+        """Track a widget, starting notifications on the first one."""
         if widget not in self._widgets:
             self._widgets.append(widget)
 
-        if not self._com_events_active:
-            com_ok = self._register_com_notifications()
-        else:
-            com_ok = True
+        if self._listener is None:
+            self._listener = DesktopNotificationListener(self._com_event.emit, self._api)
 
-        # Only start a polling timer if COM notifications failed
-        if not com_ok and self._timer is None:
+        # Fall back to polling only if the shell will not push to us.
+        if not self._listener.active and not self._listener.start() and self._timer is None:
+            logger.warning("Falling back to polling for virtual desktop changes")
             self._timer = QTimer(self)
-            self._timer.setInterval(500)
+            self._timer.setInterval(POLL_INTERVAL_MS)
             self._timer.timeout.connect(self._poll)
             self._timer.start()
 
     def unregister_widget(self, widget):
+        """Stop tracking a widget, releasing the shell once the last one goes."""
         try:
             self._widgets.remove(widget)
         except ValueError:
             pass
         if not self._widgets:
-            self._unregister_com_notifications()
+            if self._listener is not None:
+                self._listener.stop()
+                self._listener = None
             if self._timer:
                 self._timer.stop()
                 self._timer = None
 
     def _poll(self):
+        self._invalidate()
+        try:
+            number = self._current_number()
+        except SHELL_UNAVAILABLE:
+            logger.debug("Virtual desktop poll failed", exc_info=True)
+            return
+
+        # The shell answered, so it may now accept a notification sink. Polling
+        # is only ever a fallback, so hand back to notifications as soon as one
+        # registers - otherwise a shell that was briefly unreachable at startup
+        # would leave us polling for the rest of the session.
+        if self._listener is not None and not self._listener.active and self._listener.start():
+            logger.info("Virtual desktop notifications registered, stopping the polling fallback")
+            if self._timer:
+                self._timer.stop()
+                self._timer = None
+
+        if number != self._last_number:
+            self.desktop_changed.emit({"index": number})
         self._refresh_state(update_buttons=False)
 
     def notify_desktop_changed(self, index: int):
@@ -192,95 +285,137 @@ class WindowsDesktopService(QObject):
 
     def notify_desktops_updated(self, update_buttons: bool = False):
         """Force a refresh (e.g. after rename/create/delete)."""
+        self._invalidate()
         try:
-            current = VirtualDesktop.current().number
-        except Exception:
-            current = self._current_index
-        self._desktop_count = len(get_virtual_desktops())
-        self._current_index = current
-        self.desktops_updated.emit(
-            {"index": current},
-            {"update_buttons": update_buttons},
-        )
+            number = self._current_number()
+            self._last_count = len(self._snapshot())
+        except SHELL_UNAVAILABLE:
+            logger.debug("Failed to read state for forced refresh", exc_info=True)
+            number = self._last_number
+        self._last_number = number
+        self.desktops_updated.emit({"index": number}, {"update_buttons": update_buttons})
 
     @staticmethod
-    def get_desktops():
-        return get_virtual_desktops()
+    def get_desktops() -> list[DesktopInfo]:
+        """Every desktop, or an empty list while the shell is unreachable."""
+        try:
+            return WindowsDesktopService()._snapshot()
+        except SHELL_UNAVAILABLE:
+            logger.debug("Could not read the desktop list", exc_info=True)
+            return []
 
     @staticmethod
-    def get_current_desktop():
-        return VirtualDesktop.current()
+    def get_current_desktop() -> DesktopInfo:
+        """The desktop in view.
+
+        Returns a placeholder numbered 0 while the shell is unreachable, so a
+        widget can still be built and pick up the real state once it answers.
+        """
+        service = WindowsDesktopService()
+        try:
+            return service._resolve(service._current_number())
+        except SHELL_UNAVAILABLE:
+            logger.debug("Could not read the current desktop", exc_info=True)
+            return DesktopInfo(number=0, guid="", name="")
 
     @staticmethod
-    def get_desktop(number: int):
-        return VirtualDesktop(number)
-
-    @staticmethod
-    def switch_desktop(number: int):
-        VirtualDesktop(number).go()
-
-    @staticmethod
-    def create_desktop():
-        return VirtualDesktop.create()
-
-    @staticmethod
-    def remove_desktop(number: int):
-        VirtualDesktop(number).remove()
-
-    @staticmethod
-    def rename_desktop(number: int, name: str):
-        VirtualDesktop(number).rename(name)
+    def get_desktop(number: int) -> DesktopInfo:
+        return WindowsDesktopService()._resolve(number)
 
     @staticmethod
     def get_desktop_name(number: int) -> str:
         try:
-            name = VirtualDesktop(number).name
-        except Exception:
-            name = ""
-        return name.strip() if name else ""
+            return WindowsDesktopService()._resolve(number).name
+        except SHELL_UNAVAILABLE:
+            return ""
+
+    @staticmethod
+    def switch_desktop(number: int):
+        service = WindowsDesktopService()
+        service._api.switch_to(service._resolve(number).guid)
+        # The notification that follows would drop the cache anyway, but not
+        # before a caller could read the previous desktop back out of it.
+        service._invalidate()
+
+    @staticmethod
+    def create_desktop():
+        service = WindowsDesktopService()
+        guid = service._api.create()
+        service._invalidate()
+        return guid
+
+    @staticmethod
+    def remove_desktop(number: int):
+        service = WindowsDesktopService()
+        service._api.remove(service._resolve(number).guid)
+        service._invalidate()
+
+    @staticmethod
+    def rename_desktop(number: int, name: str):
+        service = WindowsDesktopService()
+        service._api.rename(service._resolve(number).guid, name)
+        service._invalidate()
 
     @staticmethod
     def set_wallpaper(number: int, path: str):
-        VirtualDesktop(number).set_wallpaper(path)
+        service = WindowsDesktopService()
+        service._api.set_wallpaper(service._resolve(number).guid, path)
 
     @staticmethod
     def set_wallpaper_all(path: str):
-        set_wallpaper_for_all_desktops(path)
+        WindowsDesktopService()._api.set_wallpaper_all(path)
 
     @staticmethod
-    def get_foreground_app_view():
-        """Return an AppView for the current foreground window, or None
-        if the foreground is the desktop, taskbar, or a non-switcher window."""
+    def get_foreground_app_view() -> ForegroundView | None:
+        """Return the foreground window, or None if it is the desktop, taskbar,
+        or a window that does not appear in the switcher."""
+        service = WindowsDesktopService()
         try:
             hwnd = GetForegroundWindow()
             if not hwnd:
                 return None
-            if GetClassName(hwnd) in SKIP_WINDOW_CLASSES:
+            if GetClassName(hwnd) in SKIP_WINDOW_CLASSES or _is_own_window(hwnd):
                 return None
-            app_view = AppView(hwnd=hwnd)
-            if not app_view.is_shown_in_switchers():
+            # None means the foreground is not an application window: a menu,
+            # a popup or the desktop. That is an ordinary outcome.
+            view = service._api.try_view_for_hwnd(hwnd)
+            if view is None:
+                # Logged with identifying detail: which window ends up in the
+                # foreground here is the only reason the move and pin entries
+                # go missing from the menu, so it needs to be diagnosable.
+                logger.debug(
+                    "Foreground window %s (class %r) has no application view; move and pin entries will be omitted",
+                    hwnd,
+                    GetClassName(hwnd),
+                )
                 return None
-            return app_view
+            if not service._api.is_shown_in_switchers(view):
+                return None
+            return ForegroundView(hwnd=hwnd, view=view, api=service._api)
         except Exception:
+            logger.debug("Could not read the foreground window", exc_info=True)
             return None
 
     @staticmethod
     def move_window(hwnd: int, desktop_number: int):
-        window = AppView(hwnd=hwnd)
-        window.move(VirtualDesktop(desktop_number))
+        service = WindowsDesktopService()
+        view = service._api.view_for_hwnd(hwnd)
+        service._api.move_view(view, service._resolve(desktop_number).guid)
 
     @staticmethod
     def toggle_pin_window(hwnd: int):
-        window = AppView(hwnd=hwnd)
-        if window.is_pinned():
-            window.unpin()
+        service = WindowsDesktopService()
+        view = service._api.view_for_hwnd(hwnd)
+        if service._api.is_view_pinned(view):
+            service._api.unpin_view(view)
         else:
-            window.pin()
+            service._api.pin_view(view)
 
     @staticmethod
     def toggle_pin_app(hwnd: int):
-        window = AppView(hwnd=hwnd)
-        if window.is_app_pinned():
-            window.unpin_app()
+        service = WindowsDesktopService()
+        view = service._api.view_for_hwnd(hwnd)
+        if service._api.is_app_pinned(view):
+            service._api.unpin_app(view)
         else:
-            window.pin_app()
+            service._api.pin_app(view)


### PR DESCRIPTION
Drops the pyvda git dependency and moves the COM code in-tree, under the widget that uses it.

pyvda does its COM setup at import time. When that failed (shell busy right after a taskkill, for example) the import failed, every name became None, and the widget stayed dead until you reloaded the bar. That's #1072. Setup is lazy now and retries, so a temporary failure doesn't stick. Startup also drops about ~200ms.

Other things fixed while in there:

- desktops are looked up by GUID instead of by position, so we stop enumerating
  everything on every call.
- Win10 no longer probes for Win11 interfaces, and Win11 no longer asks for
  IVirtualDesktopManagerInternal2, which only exists on Win10
- the polling fallback hands back to notifications once they register instead of
  polling for the rest of the session

`comtypes` is now declared in pyproject. It never was, even though four files import it directly. It came in through pycaw.

Vtables were diffed against the fork, 428 signatures across all 7 tiers, no differences. 
`selfcheck.py --full` passes 39/39 on Win10 19045 and Win11 26200.

`selfcheck.py` is new. It prints the build, the tier that was picked and a pass/fail per call, so users on builds we don't have can paste something useful into an issue. Needs comtypes only.