### PR TITLE
feat(bar): add adaptive bar style 

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -113,6 +113,8 @@ tooltip:
 | `enabled`         | boolean | `true`        | Whether the status bar is enabled. |
 | `screens`         | list    | `['*']`       | The screens on which the status bar should be displayed. Use `['*']` for all unassigned screens, `['**']` for all screens (including assigned), or specify screen names like `['DELL P2419H (1)']`. |
 | `class_name`      | string  | `"yasb-bar"`  | The CSS class name for the status bar. |
+| `style`           | string  | `"bar"`       | The visual style of the status bar. Can be `"bar"` or `"adaptive"`. [See below](#bar-style) |
+| `style_adaptive_exclude` | list | `[]`          | Widgets the `"adaptive"` style leaves outside its painted surface. [See below](#bar-style) |
 | `context_menu`    | boolean | `true`        | Whether to enable the right-click context menu on the status bar. |
 | `alignment`       | object  | [See below](#bar-alignment) | The alignment settings for the status bar. |
 | `blur_effect`     | object  | [See below](#blur-effect-configuration) | The blur effect settings for the status bar. |
@@ -129,6 +131,44 @@ tooltip:
 > **Note:**
 > `screens` can be specified as a list of monitor names. If you want the bar to appear on all screens, use `['*']`. To specify a single screen, use `['DELL P2419H (1)']` or a similar name based on your monitor setup. To show the bar only and always on the primary screen, use `['primary']`.
 
+
+### Bar Style
+
+| Option    | Description |
+|-----------|-------------|
+| `"bar"`      | The default. The bar is a solid rectangle filled by the `background-color` of `.yasb-bar`. |
+| `"adaptive"` | The bar surface follows its content. A thin rail is painted along the outer edge across the full width, and each widget group (left, center and right) drops to the full bar height as its own island hugging its widgets. The space between islands is transparent, so the wallpaper shows through. The outermost islands sit flush against the edges of the bar. Islands can be turned off from the stylesheet for a plain full-width bar, optionally with just its outer corners curved. |
+
+```yaml
+bars:
+  primary-bar:
+    style: "adaptive"
+```
+
+The rail height, corner radius, the padding around each group, and whether islands are drawn at
+all are set from the stylesheet so they reload with your theme. See
+[Adaptive bar style](./Styling#adaptive-bar-style) for the available properties.
+
+> **Note:**
+> Islands need gaps to cut out, so with islands on this needs a bar wide enough to leave space
+> between the widget groups. A bar with `dimensions.width: "auto"`, or one whose widgets fill the
+> full width, is painted as a normal rectangle either way.
+
+`style_adaptive_exclude` lists widgets the island shape does not paint under. The island stops
+before the widget and starts again after it, so a widget in the middle of a group splits it into
+two islands. It has nothing to do if islands are turned off from the stylesheet, there is only
+one surface left to exclude a widget from.
+
+```yaml
+bars:
+  primary-bar:
+    style: "adaptive"
+    style_adaptive_exclude: ["systray", "weather"]
+```
+
+Names come from your `widgets` section. The widget draws as usual, only the surface under it is
+gone. Widgets inside a Grouper cannot be named on their own, excluding the grouper leaves the whole
+group out.
 
 ### Bar Alignment
 | Option            | Type    | Default       | Description |

--- a/docs/Styling.md
+++ b/docs/Styling.md
@@ -38,6 +38,83 @@ Each widget group can be styled individually with the following:
 - `.container-center`
 - `.container-right`
 
+## Adaptive bar style
+
+A bar with `style: "adaptive"` gets an extra `.adaptive` class and paints its own shape instead of
+a plain rectangle. By default a thin rail runs along the outer edge of the bar, and each widget
+group hangs below it as its own island, with transparent gaps between them. Islands are optional
+though, turn them off and it's a plain full-width bar that can still curve its outer corners.
+
+The `background-color` of `.yasb-bar` fills that shape, so your existing colors keep working.
+The shape itself comes from the stylesheet and reloads with the rest of your theme.
+
+```css
+.yasb-bar.adaptive {
+    background-color: rgba(20, 20, 22, 0.94);
+    -qproperty-railheight: 4;
+    -qproperty-islandradius: 16;
+    -qproperty-grouppadding: 8;
+}
+```
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `-qproperty-railheight` | `4` | Height of the rail along the outer edge of the bar. |
+| `-qproperty-islandradius` | `16` | Radius of the curve between the rail and an island. Capped at `(height - railheight) / 2`, so on a 40px bar with a 4px rail you cannot go above `18`. |
+| `-qproperty-grouppadding` | `8` | Space around each group's content. This grows the island, it does not move the widgets. Use `padding` on `.container-left` and friends to move the widgets themselves. |
+| `-qproperty-islands` | `true` | Set to `false` for a solid, full-width bar instead of separate islands. `railheight`, `islandradius`, `grouppadding` and `style_adaptive_exclude` have nothing left to do in this mode, there are no islands left to split. `edgeradius` still works, so you can have a plain bar with just the two outer corners curved. |
+| `-qproperty-edgeradius` | `0` | Curves the outer islands down into the screen edges. `0` is off, [see below](#curving-into-the-screen-edges). |
+
+> **Note:**
+> These use a `-qproperty-` prefix, not Qt's own `qproperty-`. The leading dash is there so
+> editors and linters read it as a vendor-prefixed property and stay quiet instead of flagging
+> it as unknown. YASB strips the dash before the stylesheet reaches Qt, so the effect is
+> identical either way. Write `-qproperty-`, not `qproperty-`.
+
+> **Note:**
+> The property names are lowercase and only do something on `style: "adaptive"`. Scope them to
+> `.yasb-bar.adaptive` so your other bars ignore them.
+
+> **Note:**
+> Qt reads a `qproperty` once, when the widget is polished, and never clears one you delete
+> ([Qt docs](https://doc.qt.io/qt-6/stylesheet-syntax.html#setting-qobject-properties)). Changing
+> a value works on save, but deleting a line keeps the old value until YASB restarts. Set it back
+> to the default instead of deleting it.
+
+Borders are not drawn around the shape. The background is rendered as a rectangle and then
+clipped to the adaptive shape, so a `border` in your theme stays rectangular and will not follow
+the curves. Turn it off, and make the widget backgrounds transparent so the islands read as one
+surface.
+
+```css
+.yasb-bar.adaptive {
+    border: none;
+}
+.yasb-bar.adaptive .widget {
+    background-color: transparent;
+}
+```
+
+### Curving into the screen edges
+
+`-qproperty-edgeradius` rounds the two corners where the bar meets the edges of the screen, so the
+desktop below looks like it has rounded top corners.
+
+```css
+.yasb-bar.adaptive {
+    -qproperty-edgeradius: 14;
+}
+```
+
+The bar window grows by that many pixels to have room for the curve. Your widgets do not move,
+and the space Windows reserves for the bar does not change, it is still `dimensions.height` plus
+`padding`.
+
+> **Note:**
+> This needs a bar that actually reaches the screen edges, so it is ignored unless
+> `dimensions.width` spans the screen. It also paints outside the bar, which means the small
+> corner areas will swallow clicks meant for the desktop.
+
 ## Generic Widget Style
 
 A style with the `.widget` selector would affect all the widgets. In practice, you may prefer to use more specific `.*-widget` selectors.

--- a/docs/Styling.md
+++ b/docs/Styling.md
@@ -64,6 +64,8 @@ The shape itself comes from the stylesheet and reloads with the rest of your the
 | `-qproperty-grouppadding` | `8` | Space around each group's content. This grows the island, it does not move the widgets. Use `padding` on `.container-left` and friends to move the widgets themselves. |
 | `-qproperty-islands` | `true` | Set to `false` for a solid, full-width bar instead of separate islands. `railheight`, `islandradius`, `grouppadding` and `style_adaptive_exclude` have nothing left to do in this mode, there are no islands left to split. `edgeradius` still works, so you can have a plain bar with just the two outer corners curved. |
 | `-qproperty-edgeradius` | `0` | Curves the outer islands down into the screen edges. `0` is off, [see below](#curving-into-the-screen-edges). |
+| `-qproperty-borderwidth` | `0` | Width of a border drawn inside the shape, the one a CSS `border` cannot follow. `0` is off, [see below](#bordering-the-shape). |
+| `-qproperty-bordercolor` | transparent | Colour of that border. Any CSS colour, including `rgba()`. |
 
 > **Note:**
 > These use a `-qproperty-` prefix, not Qt's own `qproperty-`. The leading dash is there so
@@ -81,10 +83,10 @@ The shape itself comes from the stylesheet and reloads with the rest of your the
 > a value works on save, but deleting a line keeps the old value until YASB restarts. Set it back
 > to the default instead of deleting it.
 
-Borders are not drawn around the shape. The background is rendered as a rectangle and then
-clipped to the adaptive shape, so a `border` in your theme stays rectangular and will not follow
-the curves. Turn it off, and make the widget backgrounds transparent so the islands read as one
-surface.
+A CSS `border` will not follow the shape. Qt draws it on the bar's rectangle before the shape is
+cut out of it, so a `border-bottom` survives only where an island happens to reach the bottom of
+that rectangle, and disappears altogether once `edgeradius` moves it below the bar. Turn it off,
+and make the widget backgrounds transparent so the islands read as one surface.
 
 ```css
 .yasb-bar.adaptive {
@@ -94,6 +96,23 @@ surface.
     background-color: transparent;
 }
 ```
+
+### Bordering the shape
+
+`-qproperty-borderwidth` and `-qproperty-bordercolor` draw the border a CSS `border` cannot, along
+the island corners, the fillets either side of a gap and the edge curves. It is drawn inside the
+shape, so it does not change the bar's silhouette.
+
+```css
+.yasb-bar.adaptive {
+    border: none;
+    -qproperty-borderwidth: 1;
+    -qproperty-bordercolor: #ffffff;
+}
+```
+
+It follows the side of the bar the gaps are on and stops there, so it does not draw along the
+screen edges. Both properties are needed, either one alone leaves it off.
 
 ### Curving into the screen edges
 

--- a/docs/widgets/(Widget)-Wallpapers.md
+++ b/docs/widgets/(Widget)-Wallpapers.md
@@ -96,6 +96,7 @@ If you turn off **Settings > Accessibility > Visual effects > Animation effects*
 
 It shows up around 4K and above, and not on every change. Smaller images are applied fast enough that the engine window is usually still covering the screen. There is no fix for it right now, it is how Windows applies the wallpaper. Turning off `engine.enabled`, or turning off Windows animation effects, both avoid it.
 
+**Animation not working** Animation is not working if you have **Settings > Accessibility > Visual effects > Animation effects** turned off.
 
 ## Gallery types
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dev = [
     "types-pywin32",
 ]
 packaging = [
-    "cx-freeze==8.7.0"
+    "cx-freeze==8.6.4"
 ]
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/src/core/bar.py
+++ b/src/core/bar.py
@@ -14,6 +14,7 @@ from core.bar_helper import (
     MaximizedWindowWatcher,
     OsThemeManager,
 )
+from core.bar_style import AdaptiveBarFrame, BarFrame
 from core.events.service import EventService
 from core.utils.utilities import is_valid_percentage_str, percent_to_float
 from core.utils.win32.backdrop import enable_blur
@@ -61,6 +62,7 @@ class Bar(QWidget):
         self._widgets = widgets  # Store widgets reference for context menu
         self._widget_config_map = self.config.widgets.model_dump() or {}
         self._is_auto_width = str(self.config.dimensions.width).lower() == "auto"
+        self._style = self.config.style
         self._os_theme_manager = None
         self._autohide_manager = None
         self._maximized_watcher = None
@@ -81,8 +83,15 @@ class Bar(QWidget):
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
 
-        self._bar_frame = QFrame(self)
-        self._bar_frame.setProperty("class", f"bar {self.config.class_name}")
+        if self._style == "adaptive":
+            self._bar_frame = AdaptiveBarFrame(self, self._alignment["position"], self.config.style_adaptive_exclude)
+            self._bar_frame.setProperty("class", f"bar {self.config.class_name} adaptive")
+        else:
+            self._bar_frame = BarFrame(self)
+            self._bar_frame.setProperty("class", f"bar {self.config.class_name}")
+
+        # Set cursor for the bar frame, so that it doesn't inherit from the parent widget.
+        self._bar_frame.setCursor(Qt.CursorShape.ArrowCursor)
 
         if IMPORT_APP_BAR_MANAGER_SUCCESSFUL:
             self.app_bar_manager = app_bar.Win32AppBar()
@@ -238,8 +247,16 @@ class Bar(QWidget):
 
         bar_x, bar_y = self.bar_pos(bar_width, bar_height, screen_width, screen_height)
 
-        self.setGeometry(bar_x, bar_y, bar_width, bar_height)
-        self._bar_frame.setGeometry(0, 0, bar_width, bar_height)
+        # Only the window grows for the edge curves, AppBar is still told dimensions.height
+        extra = 0
+        if self._style == "adaptive":
+            spans_screen = bar_width >= screen_width and not self._is_auto_width
+            extra = self._bar_frame.use_edge_curves(spans_screen)
+        if extra and self._alignment["position"] == "bottom":
+            bar_y -= extra
+
+        self.setGeometry(bar_x, bar_y, bar_width, bar_height + extra)
+        self._bar_frame.setGeometry(0, 0, bar_width, bar_height + extra)
 
     def _add_widgets(self, widgets: dict[str, list] = None):
         bar_layout = QGridLayout()

--- a/src/core/bar_style.py
+++ b/src/core/bar_style.py
@@ -1,0 +1,334 @@
+from PyQt6.QtCore import QEvent, QRect, QRectF, Qt, pyqtProperty
+from PyQt6.QtGui import QColor, QPainter, QPainterPath, QPalette, QTransform
+from PyQt6.QtWidgets import QFrame, QWidget
+
+RESTYLE_EVENTS = frozenset({QEvent.Type.Polish, QEvent.Type.StyleChange})
+
+
+class BarFrame(QFrame):
+    """Bar surface for style "bar"."""
+
+    def __init__(self, parent: QFrame | None = None):
+        super().__init__(parent)
+        # Windows passes clicks through fully transparent pixels, so we need to prevent this
+        # This layer is alpha 1 invisible, but takes clicks.
+        # So now background-color can be fully transparent in css.
+        self._click_floor = QFrame(self)
+        self._click_floor.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+        self._click_floor.setAutoFillBackground(True)
+        palette = self._click_floor.palette()
+        palette.setColor(QPalette.ColorRole.Window, QColor(0, 0, 0, 1))
+        self._click_floor.setPalette(palette)
+
+    def click_rect(self) -> QRect:
+        """The area of the frame that takes mouse clicks."""
+        return self.rect()
+
+    def _resize_click_floor(self) -> None:
+        self._click_floor.setGeometry(self.click_rect())
+
+    def resizeEvent(self, event) -> None:
+        super().resizeEvent(event)
+        self._resize_click_floor()
+
+
+class AdaptiveBarFrame(BarFrame):
+    """Bar surface for style "adaptive": a rail along the outer edge, each widget group its own
+    island by default. Islands and the edge curves are both optional, so this can also render
+    as a plain full-width bar with just its outer corners rounded."""
+
+    def __init__(self, parent: QWidget, position: str = "top", exclude: list[str] | None = None):
+        super().__init__(parent)
+        self._position = position
+        self._exclude = frozenset(exclude or ())
+        self._rail_height = 4
+        self._island_radius = 16
+        self._group_padding = 8
+        self._islands_enabled = True
+        self._edge_radius = 0
+        self._edge_curves = False
+        self._islands: tuple[tuple[int, int], ...] = ()
+        self._shape = QPainterPath()
+        self._gaps = QPainterPath()
+
+    @pyqtProperty(int)
+    def railheight(self) -> int:
+        return self._rail_height
+
+    @railheight.setter
+    def railheight(self, value: int) -> None:
+        self._rail_height = max(0, int(value))
+        self._update_shape(force=True)
+
+    @pyqtProperty(int)
+    def islandradius(self) -> int:
+        return self._island_radius
+
+    @islandradius.setter
+    def islandradius(self, value: int) -> None:
+        self._island_radius = max(0, int(value))
+        self._update_shape(force=True)
+
+    @pyqtProperty(int)
+    def grouppadding(self) -> int:
+        return self._group_padding
+
+    @grouppadding.setter
+    def grouppadding(self, value: int) -> None:
+        self._group_padding = max(0, int(value))
+        self._update_shape(force=True)
+
+    @pyqtProperty(bool)
+    def islands(self) -> bool:
+        return self._islands_enabled
+
+    @islands.setter
+    def islands(self, value: bool) -> None:
+        if value == self._islands_enabled:
+            return
+        self._islands_enabled = value
+        self._update_shape(force=True)
+
+    @pyqtProperty(int)
+    def edgeradius(self) -> int:
+        return self._edge_radius
+
+    @edgeradius.setter
+    def edgeradius(self, value: int) -> None:
+        value = max(0, int(value))
+        if value == self._edge_radius:
+            return
+        self._edge_radius = value
+        self._reserve_edge_space()
+        window = self.window()
+        if hasattr(window, "position_bar"):
+            window.position_bar()
+        self._update_shape(force=True)
+
+    @property
+    def edge_overhang(self) -> int:
+        """How far the frame reaches past the bar, zero unless the bar allowed the edge curves."""
+        return self._edge_radius if self._edge_curves else 0
+
+    def use_edge_curves(self, allowed: bool) -> int:
+        """Told by the bar whether the edge curves apply; returns the height they need.
+
+        Only the bar knows the width it is about to take, so it decides. Deciding here
+        would let the frame reserve space the window was never given.
+        """
+        allowed = allowed and self._edge_radius > 0
+        if allowed != self._edge_curves:
+            self._edge_curves = allowed
+            self._reserve_edge_space()
+            self._update_shape(force=True)
+        return self.edge_overhang
+
+    def click_rect(self) -> QRect:
+        """The area of the frame that takes mouse clicks, minus the edge curve overhang."""
+        overhang = self.edge_overhang
+        top = overhang if self._position == "bottom" else 0
+        return QRect(0, top, self.width(), self.height() - overhang)
+
+    def setLayout(self, layout) -> None:
+        super().setLayout(layout)
+        self._reserve_edge_space()
+
+    def _reserve_edge_space(self) -> None:
+        """Keep the widgets out of the strip the edge curves are drawn in."""
+        layout = self.layout()
+        if layout is None:
+            return
+        overhang = self.edge_overhang
+        above = overhang if self._position == "bottom" else 0
+        below = 0 if self._position == "bottom" else overhang
+        if layout.contentsMargins().top() != above or layout.contentsMargins().bottom() != below:
+            layout.setContentsMargins(0, above, 0, below)
+
+    def event(self, event: QEvent) -> bool:
+        # super() first, so the layout has run before we measure it
+        handled = super().event(event)
+        kind = event.type()
+
+        if kind == QEvent.Type.LayoutRequest:
+            self._update_shape()
+        elif kind in RESTYLE_EVENTS:
+            self._update_shape(force=True)
+
+        return handled
+
+    def resizeEvent(self, event) -> None:
+        super().resizeEvent(event)
+        self._update_shape(force=True)
+
+    def paintEvent(self, event) -> None:
+        """Cut the gaps out of the background Qt has already painted across the frame."""
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setClipPath(self._gaps)
+        painter.setCompositionMode(QPainter.CompositionMode.CompositionMode_Source)
+        painter.fillRect(self.rect(), Qt.GlobalColor.transparent)
+
+    def _update_shape(self, force: bool = False) -> None:
+        islands = self._island_spans()
+        if not force and islands == self._islands:
+            return
+
+        changed = self.rect() if force else self._changed_area(self._islands, islands)
+        self._islands = islands
+        self._shape = self._build_shape(islands)
+
+        frame = QPainterPath()
+        frame.addRect(QRectF(self.rect()))
+        self._gaps = frame.subtracted(self._shape)
+        self.update(changed)
+
+    def _changed_area(self, before: tuple, after: tuple) -> QRect:
+        """The part of the bar the shape moved in, so a one pixel step does not repaint
+        a whole bar and every child in it."""
+        if len(before) != len(after):
+            return self.rect()
+
+        edges = [x for old, new in zip(before, after) if old != new for x in (*old, *new)]
+        if not edges:
+            return self.rect()
+
+        margin = self._island_radius + 2
+        return QRect(min(edges) - margin, 0, max(edges) - min(edges) + 2 * margin, self.height())
+
+    def _island_spans(self) -> tuple[tuple[int, int], ...]:
+        """Horizontal spans covered by each widget group, padded, clamped and merged.
+
+        The containers are stretching grid cells a third of the bar wide, so their geometry
+        says nothing about where the widgets are, only their content defines an island.
+        An excluded widget ends the run it sits in, so one group can give two islands.
+        """
+        layout = self.layout()
+        if layout is None:
+            return ()
+
+        width = self.width()
+        if not self._islands_enabled:
+            return ((0, width),) if width > 0 else ()
+
+        padding = self._group_padding
+        spans: list[tuple[int, int]] = []
+        skipped: list[int] = []
+
+        for index in range(layout.count()):
+            container = layout.itemAt(index).widget()
+            if container is None:
+                continue
+
+            # The container's own layout may not have positioned its widgets yet on the
+            # first paint, so force it now instead of reading stale, pre-layout geometry
+            if container.layout() is not None:
+                container.layout().activate()
+
+            children = container.findChildren(QWidget, options=Qt.FindChildOption.FindDirectChildrenOnly)
+            run = None
+            for child in sorted(children, key=lambda child: child.x()):
+                if child.isHidden() or child.width() <= 0:
+                    continue
+                start = container.x() + child.x()
+                end = start + child.width()
+                if getattr(child, "widget_name", None) in self._exclude:
+                    skipped.extend((start, end))
+                    if run:
+                        spans.append((run[0] - padding, run[1] + padding))
+                        run = None
+                elif run:
+                    run[1] = end
+                else:
+                    run = [start, end]
+
+            if run:
+                spans.append((run[0] - padding, run[1] + padding))
+
+        merged: list[list[int]] = []
+        for start, end in sorted(spans):
+            start = max(0, start)
+            end = min(width, end)
+            if end <= start:
+                continue
+            if merged and start <= merged[-1][1]:
+                merged[-1][1] = max(merged[-1][1], end)
+            else:
+                merged.append([start, end])
+
+        if merged:
+            # An excluded widget against an edge must not be snapped over
+            if merged[0][0] <= self._island_radius and (not skipped or min(skipped) >= merged[0][0]):
+                merged[0][0] = 0
+            if merged[-1][1] >= width - self._island_radius and (not skipped or max(skipped) <= merged[-1][1]):
+                merged[-1][1] = width
+
+        return tuple((start, end) for start, end in merged)
+
+    def _build_shape(self, islands: tuple[tuple[int, int], ...]) -> QPainterPath:
+        width = float(self.width())
+        # The frame is taller than the bar by edgeradius, that strip holds the edge curves
+        overhang = float(self.edge_overhang)
+        height = float(self.height()) - overhang
+        rail = min(float(self._rail_height), height)
+
+        full_rect = QPainterPath()
+        full_rect.addRect(0.0, 0.0, width, height)
+
+        if width <= 0 or height <= rail or not islands:
+            return full_rect
+
+        # Both curves share the island's side, so together they cannot exceed its height
+        radius = min(float(self._island_radius), max(0.0, (height - rail) / 2))
+
+        path = QPainterPath()
+        path.moveTo(0.0, 0.0)
+        path.lineTo(width, 0.0)
+
+        last = len(islands) - 1
+        for index in range(last, -1, -1):
+            x0 = float(islands[index][0])
+            x1 = float(islands[index][1])
+            corner = min(radius, (x1 - x0) / 2)
+
+            if x1 >= width:
+                if overhang > 0.0:
+                    path.lineTo(width, height + overhang)
+                    path.arcTo(QRectF(width - 2 * overhang, height, 2 * overhang, 2 * overhang), 0.0, 90.0)
+                else:
+                    path.lineTo(width, height)
+            else:
+                if index == last:
+                    path.lineTo(width, rail)
+                next_start = float(islands[index + 1][0]) if index < last else width
+                fillet = min(radius, (next_start - x1) / 2)
+                path.lineTo(x1 + fillet, rail)
+                if fillet > 0.0:
+                    path.arcTo(QRectF(x1, rail, 2 * fillet, 2 * fillet), 90.0, 90.0)
+                path.lineTo(x1, height - corner)
+                if corner > 0.0:
+                    path.arcTo(QRectF(x1 - 2 * corner, height - 2 * corner, 2 * corner, 2 * corner), 0.0, -90.0)
+
+            if x0 <= 0.0:  # closeSubpath draws this side
+                if overhang > 0.0:
+                    path.lineTo(overhang, height)
+                    path.arcTo(QRectF(0.0, height, 2 * overhang, 2 * overhang), 90.0, 90.0)
+                else:
+                    path.lineTo(0.0, height)
+            else:
+                path.lineTo(x0 + corner, height)
+                if corner > 0.0:
+                    path.arcTo(QRectF(x0, height - 2 * corner, 2 * corner, 2 * corner), 270.0, -90.0)
+                previous_end = float(islands[index - 1][1]) if index > 0 else 0.0
+                fillet = min(radius, (x0 - previous_end) / 2)
+                path.lineTo(x0, rail + fillet)
+                if fillet > 0.0:
+                    path.arcTo(QRectF(x0 - 2 * fillet, rail, 2 * fillet, 2 * fillet), 0.0, 90.0)
+                if index == 0:
+                    path.lineTo(0.0, rail)
+
+        path.closeSubpath()
+
+        if self._position == "bottom":
+            path = QTransform().translate(0.0, height + overhang).scale(1.0, -1.0).map(path)
+
+        return path

--- a/src/core/bar_style.py
+++ b/src/core/bar_style.py
@@ -1,5 +1,7 @@
+import math
+
 from PyQt6.QtCore import QEvent, QRect, QRectF, Qt, pyqtProperty
-from PyQt6.QtGui import QColor, QPainter, QPainterPath, QPalette, QTransform
+from PyQt6.QtGui import QColor, QPainter, QPainterPath, QPalette, QPen, QTransform
 from PyQt6.QtWidgets import QFrame, QWidget
 
 RESTYLE_EVENTS = frozenset({QEvent.Type.Polish, QEvent.Type.StyleChange})
@@ -47,6 +49,8 @@ class AdaptiveBarFrame(BarFrame):
         self._islands_enabled = True
         self._edge_radius = 0
         self._edge_curves = False
+        self._border_width = 0
+        self._border_color = QColor(0, 0, 0, 0)
         self._islands: tuple[tuple[int, int], ...] = ()
         self._shape = QPainterPath()
         self._gaps = QPainterPath()
@@ -104,6 +108,24 @@ class AdaptiveBarFrame(BarFrame):
         if hasattr(window, "position_bar"):
             window.position_bar()
         self._update_shape(force=True)
+
+    @pyqtProperty(int)
+    def borderwidth(self) -> int:
+        return self._border_width
+
+    @borderwidth.setter
+    def borderwidth(self, value: int) -> None:
+        self._border_width = max(0, int(value))
+        self.update()
+
+    @pyqtProperty(QColor)
+    def bordercolor(self) -> QColor:
+        return self._border_color
+
+    @bordercolor.setter
+    def bordercolor(self, value: QColor) -> None:
+        self._border_color = QColor(value)
+        self.update()
 
     @property
     def edge_overhang(self) -> int:
@@ -166,7 +188,23 @@ class AdaptiveBarFrame(BarFrame):
         painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
         painter.setClipPath(self._gaps)
         painter.setCompositionMode(QPainter.CompositionMode.CompositionMode_Source)
-        painter.fillRect(self.rect(), Qt.GlobalColor.transparent)
+        painter.fillRect(QRectF(0.0, 0.0, float(self.width()), self._frame_bottom()), Qt.GlobalColor.transparent)
+
+        if self._border_width > 0 and self._border_color.alpha() > 0:
+            # Stroking the gaps leaves the frame's own edges bare clipped to the shape at
+            # twice the width so only the half inside the bar lands
+            painter.setCompositionMode(QPainter.CompositionMode.CompositionMode_SourceOver)
+            painter.setClipPath(self._shape)
+            painter.setPen(QPen(self._border_color, self._border_width * 2))
+            painter.drawPath(self._gaps)
+
+    def _frame_bottom(self) -> float:
+        """The frame's bottom, out to a whole device pixel. On fractional scaling the last
+        row is a fraction of one, and cutting only part of it leaves a line under the bar."""
+        if not self.edge_overhang:  # nothing is cut below the bar, so nothing to round out to
+            return float(self.height())
+        ratio = self.devicePixelRatioF()
+        return math.ceil(self.height() * ratio) / ratio if ratio > 0 else float(self.height())
 
     def _update_shape(self, force: bool = False) -> None:
         islands = self._island_spans()
@@ -178,7 +216,7 @@ class AdaptiveBarFrame(BarFrame):
         self._shape = self._build_shape(islands)
 
         frame = QPainterPath()
-        frame.addRect(QRectF(self.rect()))
+        frame.addRect(QRectF(0.0, 0.0, float(self.width()), self._frame_bottom()))
         self._gaps = frame.subtracted(self._shape)
         self.update(changed)
 
@@ -267,8 +305,9 @@ class AdaptiveBarFrame(BarFrame):
     def _build_shape(self, islands: tuple[tuple[int, int], ...]) -> QPainterPath:
         width = float(self.width())
         # The frame is taller than the bar by edgeradius, that strip holds the edge curves
-        overhang = float(self.edge_overhang)
-        height = float(self.height()) - overhang
+        bottom = self._frame_bottom()
+        height = float(self.height() - self.edge_overhang)
+        overhang = bottom - height
         rail = min(float(self._rail_height), height)
 
         full_rect = QPainterPath()

--- a/src/core/utils/css_processor.py
+++ b/src/core/utils/css_processor.py
@@ -5,7 +5,8 @@ import re
 
 class CSSProcessor:
     """
-    Processes CSS files: handles @import, CSS variables, and removes comments.
+    Processes CSS files: handles @import, CSS variables, -qproperty- normalization,
+    and removes comments.
     """
 
     _localdata_initialized = False
@@ -31,6 +32,9 @@ class CSSProcessor:
         css = self._remove_comments(css)
         # Extract and replace CSS variables
         css = self._extract_and_replace_variables(css)
+        # Strip the leading dash from -qproperty-*, so editors treat it as a vendor
+        # prefix and stay quiet, while Qt still gets the exact name it expects
+        css = self._normalize_qproperty(css)
         # Resolve relative url() paths to absolute paths
         css = self._resolve_urls(css)
         return css
@@ -115,6 +119,16 @@ class CSSProcessor:
         css = self._css_to_qt_hex_alpha(css)
 
         return css
+
+    def _normalize_qproperty(self, css: str) -> str:
+        """
+        Rewrites -qproperty-<name> to qproperty-<name>. Qt only recognizes the
+        undashed form, the leading dash is purely so editors read it as a vendor
+        prefix instead of flagging it as an unknown property. Only matches where a
+        real property name and colon follow, so it can't touch plain text that
+        happens to contain "-qproperty-", like a CSS variable's value.
+        """
+        return re.sub(r"(?<=[{;\s])-qproperty-(?=[\w-]+\s*:)", "qproperty-", css)
 
     def _css_to_qt_hex_alpha(self, css: str) -> str:
         """

--- a/src/core/validation/bar.py
+++ b/src/core/validation/bar.py
@@ -78,6 +78,8 @@ class BarConfig(CustomBaseModel):
     enabled: bool = True
     screens: list[str] = ["*"]
     class_name: str = "yasb-bar"
+    style: Literal["bar", "adaptive"] = "bar"
+    style_adaptive_exclude: list[str] = []
     context_menu: bool = True
     alignment: BarAlignment = BarAlignment()
     blur_effect: BarBlurEffect = BarBlurEffect()

--- a/src/core/widgets/services/wallpapers/engine.py
+++ b/src/core/widgets/services/wallpapers/engine.py
@@ -359,7 +359,7 @@ def _locate_workerw() -> int:
         user32.EnumWindows(_enum_proc, 0)
 
     if not worker:
-        logger.warning("Could not locate WorkerW. Wallpaper animation skipped.")
+        logger.warning("Could not locate WorkerW. Wallpaper animation skipped. (Windows OS animation must be enabled.)")
         return 0
     user32.ShowWindow(worker, 5)
     return worker

--- a/src/core/widgets/yasb/taskbar.py
+++ b/src/core/widgets/yasb/taskbar.py
@@ -527,6 +527,7 @@ class TaskbarWidget(BaseWidget):
         if connect_taskbar:
             self._task_manager = None
             self._task_manager_connected = False
+            self._initial_population = False
         else:
             logging.error("Shared task manager not available - taskbar functionality will be limited")
 
@@ -1011,10 +1012,14 @@ class TaskbarWidget(BaseWidget):
         try:
             if connect_taskbar and not getattr(self, "_task_manager_connected", False):
                 try:
+                    # connect_taskbar delivers the already open windows synchronously
+                    self._initial_population = True
                     self._task_manager = connect_taskbar(self)
                     self._task_manager_connected = True
                 except Exception as e:
                     logging.error("Failed to connect taskbar manager from showEvent: %s", e)
+                finally:
+                    self._initial_population = False
         except Exception:
             pass
 
@@ -1452,7 +1457,9 @@ class TaskbarWidget(BaseWidget):
         # Insert widget: pinned apps replace their button, unpinned apps go at the end
         position = insert_position if insert_position >= 0 else self._widget_container_layout.count()
 
-        if self._animation_enabled:
+        # Animating the whole startup burst at once is what stutters, so skip it for
+        # the initial population and only animate windows added after that.
+        if self._animation_enabled and not self._initial_population:
             container.setFixedWidth(0)
             self._widget_container_layout.insertWidget(position, container)
             self._animate_container(


### PR DESCRIPTION
Adds a new `style: "adaptive"` bar style. Instead of a fixed rectangle, the bar surface
follows its content: a thin rail along the top edge, with each widget group hanging
below it as its own rounded island. Gaps between islands are transparent, so the
wallpaper shows through.

Islands are optional. Turn them off (`-qproperty-islands: false`) and you get a plain
full-width bar that can still curve its outer corners against the screen edges.

config example:
```yaml
    style: "adaptive"
    #style_adaptive_exclude: ["wallpapers", "systray"]
```
css example:
```css
.yasb-bar.adaptive {
     -qproperty-railheight: 4;
     -qproperty-islandradius: 16;
     -qproperty-grouppadding: 24;
     -qproperty-islands: true;
     -qproperty-edgeradius: 24;
     -qproperty-borderwidth: 1;
     -qproperty-bordercolor: #ffffff
}
```
**UPDATE:** A CSS `border` will not follow the shape. Qt draws it on the bar's rectangle before the shape is
cut out of it, so a `border-*` survives only where an island happens to reach the bottom of
that rectangle, and disappears altogether once `edgeradius` moves it below the bar. Turn it off,
and make the widget backgrounds transparent so the islands read as one surface.

<img width="1920" height="321" alt="20260903_231220_104112" src="https://github.com/user-attachments/assets/6c082a89-e89d-437f-85ba-6d9fe1ffcd0e" />

Also in here:
- click-through protection, so a transparent bar background doesn't leak clicks to the desktop
- `qproperty-*` can be written with a leading dash (`-qproperty-`) so editors don't flag it as an unknown CSS property
- fixed a startup flash where the bar briefly rendered as one solid shape before settling into the real island layout