### PR TITLE
fix(bar): prevent autohide reveal zone from taking focus

### DIFF
--- a/src/core/bar_helper.py
+++ b/src/core/bar_helper.py
@@ -232,6 +232,7 @@ class AutoHideZone(QFrame):
             Qt.WindowType.Tool
             | Qt.WindowType.FramelessWindowHint
             | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.WindowDoesNotAcceptFocus
             | Qt.WindowType.NoDropShadowWindowHint
         )
         self.setWindowOpacity(0.01)


### PR DESCRIPTION
Prevent the auto-hide reveal zone from taking focus when clicked, so the bar hides normally after the cursor leaves it

## Problem

When `auto_hide` is enabled, clicking the top screen-edge reveal zone causes the bar to take focus from the active application.

After the reveal zone takes focus, the bar remains visible after the cursor leaves it. It hides again only when focus moves away, e.g. by clicking another window or using alt+tab.

This occurs even when the visible bar is offset from the top edge, because auto-hide creates a separate 1px detection zone at the physical screen edge.

## Fix

Add `Qt.WindowType.WindowDoesNotAcceptFocus` to `AutoHideZone`.

This keeps the reveal zone non-activating, preserving the active application’s focus and allowing normal auto-hide behaviour after the cursor leaves the bar.

## Steps to reproduce

1. Enable auto-hide:

   ```yaml
   window_flags:
     always_on_top: true
     auto_hide: true
     windows_app_bar: false
   ```

2. Focus another application
3. Move the cursor to the top screen edge to reveal the bar
4. Left- or right-click the reveal zone
5. Move the cursor away from the bar

## Without fix

The bar takes focus and remains visible after the cursor leaves it. It hides only after focus moves elsewhere, such as when clicking another window or using alt+tab.

## With fix

The previously active application retains focus, and the bar hides normally after the cursor leaves it.