### PR TITLE
feat(audio-visualizer): add native WASAPI-based audio visualizer widget

### DIFF
--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -12,6 +12,7 @@
 - Widgets:
     - [Active Windows Title](./(Widget)-Active-Windows-Title)
     - [Applications](./(Widget)-Applications)
+    - [Audio Visualizer](./(Widget)-Audio-Visualizer)
     - [Battery](./(Widget)-Battery)
     - [Bluetooth](./(Widget)-Bluetooth)
     - [Brightness](./(Widget)-Brightness)

--- a/docs/widgets/(Widget)-Audio-Visualizer.md
+++ b/docs/widgets/(Widget)-Audio-Visualizer.md
@@ -1,0 +1,131 @@
+# Audio Visualizer Widget Configuration
+
+Native audio visualizer for the default output device (WASAPI loopback). No external audio app or process needed.
+
+## How it captures audio
+
+Audio comes from a WASAPI loopback capture on whatever Windows currently has set as the default playback device - the same device shown selected in the Windows volume mixer. This is automatic and dynamic: there is no device picker, and switching outputs (plugging in headphones, disabling a device, changing the default in Windows sound settings) is picked up on its own, with capture rebuilding against the new endpoint.
+
+Because of that, only audio going through the normal Windows shared-mixer path is visible. Anything routed through **ASIO**, or another driver model that bypasses the shared mixer for direct hardware access, never reaches this capture, since that audio doesn't pass through the default device's loopback path at all - a limitation of WASAPI loopback itself, not something specific to this widget. If an app is set to output via ASIO, the visualizer will sit silent for that app's audio while continuing to show anything else still playing through the normal output.
+
+## Shared options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `class_name` | string | `""` | Additional CSS class names for the widget container |
+| `style` | string | `"bars"` | Visual style: `"bars"`, `"waves"`, or `"dots"` |
+| `height` | integer | `14` | Paint surface height in pixels |
+| `smoothness` | integer | `55` | Motion smoothing 0–100 (higher = smoother, slower). Expressed in real time, so the motion looks identical at any `framerate` |
+| `sensitivity` | integer | `50` | Amplitude trim 0–100. With `auto_gain` on it sets how hard the peaks push: `50` = loudest bars ride near the top, lower = calmer, higher = into the ceiling. With `auto_gain` off it is a plain multiplier (`50` = 1×, `100` = 2×) |
+| `auto_gain` | boolean | `true` | Auto-sensitivity: continuously tracks the level so quiet tracks and loud tracks look the same and bars never pin flat at the top. Turn off to set the level yourself with `sensitivity` |
+| `framerate` | integer | `60` | Upper limit on repaints per second. Frames are pushed by the audio stream, so the real rate is also capped by the device period |
+| `freq_min` | integer | `50` | Lowest frequency bucket in Hz (20–24000) |
+| `freq_max` | integer | `12000` | Highest frequency bucket in Hz (must be greater than `freq_min`) |
+| `hide_idle` | boolean | `false` | Collapse the widget once audio stops, freeing its space in the bar. It reappears the moment audio returns |
+| `hide_idle_after` | integer | `2000` | How long audio must be absent before collapsing (ms) |
+| `channels` | string | `"mono"` | Visual channels: `"stereo"` or `"mono"` |
+| `mono_option` | string | `"average"` | Mono input source: `"average"`, `"left"`, or `"right"` (ignored when `channels` is `"stereo"`) |
+| `reverse` | boolean | `false` | Flip frequency direction |
+| `gradient` | boolean | `true` | Bars/waves: gradient across `colors`. `false` = solid `colors[0]`. Dots always cycle `colors` per column |
+| `mirror` | boolean | `false` | Grow from the vertical center instead of the bottom edge, symmetric up and down. Applies to all three styles |
+| `colors` | list[string] | see example | Hex color palette |
+| `edge_fade` | integer or array | `0` | Edge fade in pixels. Single value, or `[left, right]` |
+| `callbacks` | dict | do_nothing | Mouse callbacks: `on_left`, `on_middle`, `on_right` |
+
+## Style blocks
+
+Only the block matching `style` is used; the others are ignored.
+
+### `bars`
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `count` | integer | `24` | Number of bar columns (4–128). With `channels: stereo` the count is split between the two channels. Past roughly 40 the extra bars mostly subdivide the low end rather than add detail (see [Levels](#levels)) |
+| `width` | integer | `2` | Bar thickness in pixels |
+| `gap` | integer | `4` | Gap between bars in pixels |
+
+### `waves`
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `width` | integer | `80` | Total widget width in pixels. Spectrum point count is derived automatically |
+
+### `dots`
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `count` | integer | `24` | Number of LED columns (4–128) |
+| `size` | integer | `2` | Block size in pixels |
+| `gap` | integer | `4` | Gap between stacked blocks (also used between columns) |
+
+## Example Configuration
+
+```yaml
+  audio_visualizer:
+    type: "yasb.audio_visualizer.AudioVisualizerWidget"
+    options:
+      style: bars
+      height: 16
+      smoothness: 80
+      sensitivity: 50
+      auto_gain: true
+      framerate: 60
+      freq_min: 500
+      freq_max: 12000
+      hide_idle: true
+      hide_idle_after: 2000
+      channels: mono
+      mono_option: average
+      reverse: false
+      gradient: true
+      mirror: false
+      colors:
+        - "#8A9AFF"
+        - "#8A8AFF"
+        - "#C38AFF"
+      bars:
+        count: 24
+        width: 2
+        gap: 4
+      waves:
+        width: 80
+      dots:
+        count: 24
+        size: 2
+        gap: 4
+```
+
+## Styles
+
+- **bars**: sharp rectangular frequency bars.
+- **waves**: same spectrum as bars, connected into a filled outline. With stereo, left and right halves are drawn separately.
+- **dots**: LED-style stacked square blocks per column.
+
+## Levels
+
+`auto_gain` (on by default) is an auto-sensitivity loop: it backs off quickly when a band saturates and creeps back up when there is headroom, with a hard ramp on startup so the level settles in under a second. The result is that a quiet track and a loud track look the same, and bars never sit pinned flat at the top.
+
+`sensitivity` rides on top. With `auto_gain` on it sets the target the auto-level aims for: `50` keeps the loudest bars near the top, lower leaves headroom for a calmer look, higher pushes them into the ceiling for a hotter, more clipped look. It does not fight the auto-level, so a quiet track and a loud track still match at the same `sensitivity`. With `auto_gain: false` it becomes the only level control, a plain fixed multiplier (`50` = ×1, `100` = ×2).
+
+The bar heights stay roughly consistent as you change the `count`. More bars means finer frequency resolution, so the tallest bars reach about the same height either way but there are more short bars filling the gaps between peaks.
+
+## Channels
+
+- **`channels: mono`**: one spectrum across the strip, lowest to highest left to right. Use `mono_option` to pick `"average"`, `"left"`, or `"right"` as the input.
+- **`channels: stereo`**: mirrors both channels with low frequencies in the center (left half = L, right half = R).
+- **`reverse: true`**: flips frequency direction.
+  - mono: highest to lowest left to right
+  - stereo: bass moves to the outer edges, highs meet in the center
+
+## Style
+
+```css
+.audio-visualizer-widget {
+    padding: 0;
+    margin: 0;
+}
+.audio-visualizer-widget .widget-container {
+    padding: 0;
+    margin: 0;
+}
+```

--- a/docs/widgets/(Widget)-Audio-Visualizer.md
+++ b/docs/widgets/(Widget)-Audio-Visualizer.md
@@ -26,9 +26,7 @@ Because of that, only audio going through the normal Windows shared-mixer path i
 | `channels` | string | `"mono"` | Visual channels: `"stereo"` or `"mono"` |
 | `mono_option` | string | `"average"` | Mono input source: `"average"`, `"left"`, or `"right"` (ignored when `channels` is `"stereo"`) |
 | `reverse` | boolean | `false` | Flip frequency direction |
-| `gradient` | boolean | `true` | Bars/waves: gradient across `colors`. `false` = solid `colors[0]`. Dots always cycle `colors` per column |
 | `mirror` | boolean | `false` | Grow from the vertical center instead of the bottom edge, symmetric up and down. Applies to all three styles |
-| `colors` | list[string] | see example | Hex color palette |
 | `edge_fade` | integer or array | `0` | Edge fade in pixels. Single value, or `[left, right]` |
 | `callbacks` | dict | do_nothing | Mouse callbacks: `on_left`, `on_middle`, `on_right` |
 
@@ -77,12 +75,7 @@ Only the block matching `style` is used; the others are ignored.
       channels: mono
       mono_option: average
       reverse: false
-      gradient: true
       mirror: false
-      colors:
-        - "#8A9AFF"
-        - "#8A8AFF"
-        - "#C38AFF"
       bars:
         count: 24
         width: 2
@@ -128,4 +121,32 @@ The bar heights stay roughly consistent as you change the `count`. More bars mea
     padding: 0;
     margin: 0;
 }
+.audio-visualizer-widget .audio-visualizer-canvas {
+    -qproperty-fillbrush: linear-gradient(to top, #8A9AFF, #8A8AFF, #C38AFF);
+}
 ```
+
+### Colors
+
+Colours come from `-qproperty-fillbrush` on `.audio-visualizer-canvas`. The value is
+a solid colour (`#89b4fa`) or a CSS gradient example (`linear-gradient(to top, #74c7ec, #89b4fa 50%, #cba6f7)`).
+
+The gradient is drawn once across the whole strip. The bars, wave or dots show the part of it they
+cover, so the direction works the same for every style:
+
+| Direction | Result |
+|-----------|--------|
+| `to top`, `to bottom` | colour by height |
+| `to left`, `to right` | sweep across the strip |
+| an angle like `135deg` | diagonal |
+| a solid colour | every shape the same |
+
+`mirror` only moves the shapes to the vertical centre. It does not change the colours for
+`to left` / `to right`. For `to top` / `to bottom` a short shape then sits over the middle of the
+ramp instead of the bottom.
+
+The `-qproperty-` dash follows the same convention as the [adaptive bar style](Styling#adaptive-bar-style):
+CSS editors read it as a vendor prefix, and YASB strips it before Qt sees it.
+
+Qt reads a `qproperty` once, at polish. Changing the value and saving works with `watch_stylesheet`,
+but removing the line keeps the old colour until restart, so set it back to a default instead of deleting it.

--- a/src/core/utils/win32/bindings/ole32.py
+++ b/src/core/utils/win32/bindings/ole32.py
@@ -1,11 +1,22 @@
 """Wrappers for ole32 win32 API functions to make them easier to use and have proper types"""
 
-from ctypes import c_long, c_void_p, windll
+from ctypes import c_long, c_ulong, c_void_p, windll
 
 ole32 = windll.ole32
+
+COINIT_MULTITHREADED = 0x0
+
+# COM was already initialised on this thread with a different apartment model.
+RPC_E_CHANGED_MODE = -2147417850
 
 ole32.CoInitialize.argtypes = [c_void_p]
 ole32.CoInitialize.restype = c_long
 
+ole32.CoInitializeEx.argtypes = [c_void_p, c_ulong]
+ole32.CoInitializeEx.restype = c_long
+
 ole32.CoUninitialize.argtypes = []
 ole32.CoUninitialize.restype = None
+
+ole32.CoTaskMemFree.argtypes = [c_void_p]
+ole32.CoTaskMemFree.restype = None

--- a/src/core/validation/widgets/yasb/audio_visualizer.py
+++ b/src/core/validation/widgets/yasb/audio_visualizer.py
@@ -1,0 +1,70 @@
+from typing import Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from core.validation.widgets.base_model import CallbacksConfig, CustomBaseModel, KeybindingConfig
+
+DEFAULT_COLORS = ["#74c7ec", "#89b4fa", "#cba6f7"]
+
+
+class BarsStyleConfig(CustomBaseModel):
+    count: int = Field(default=24, ge=4, le=128)
+    width: int = Field(default=2, ge=1, le=32)
+    gap: int = Field(default=4, ge=0, le=32)
+
+
+class WavesStyleConfig(CustomBaseModel):
+    width: int = Field(default=80, ge=16, le=512)
+
+
+class DotsStyleConfig(CustomBaseModel):
+    count: int = Field(default=24, ge=4, le=128)
+    size: int = Field(default=2, ge=1, le=32)
+    gap: int = Field(default=4, ge=0, le=32)
+
+
+class AudioVisualizerConfig(CustomBaseModel):
+    class_name: str = ""
+    style: Literal["bars", "waves", "dots"] = "bars"
+    height: int = Field(default=14, ge=4, le=64)
+    smoothness: int = Field(default=55, ge=0, le=100)
+    sensitivity: int = Field(default=50, ge=0, le=100)
+    auto_gain: bool = True
+    framerate: int = Field(default=60, ge=1, le=120)
+    freq_min: int = Field(default=50, ge=20, le=24000)
+    freq_max: int = Field(default=12000, ge=20, le=24000)
+    hide_idle: bool = False
+    hide_idle_after: int = Field(default=2000, ge=100, le=60000)
+    channels: Literal["stereo", "mono"] = "mono"
+    mono_option: Literal["average", "left", "right"] = "average"
+    reverse: bool = False
+    gradient: bool = True
+    mirror: bool = False
+    colors: list = Field(default=DEFAULT_COLORS)
+    edge_fade: int | list[int] = 0
+    bars: BarsStyleConfig = Field(default_factory=BarsStyleConfig)
+    waves: WavesStyleConfig = Field(default_factory=WavesStyleConfig)
+    dots: DotsStyleConfig = Field(default_factory=DotsStyleConfig)
+    keybindings: list[KeybindingConfig] = []
+    callbacks: CallbacksConfig = CallbacksConfig()
+
+    @field_validator("colors")
+    @classmethod
+    def _validate_colors(cls, value: list[str]) -> list[str]:
+        cleaned = [c.strip() for c in value if isinstance(c, str) and c.strip()]
+        return cleaned or list(DEFAULT_COLORS)
+
+    @field_validator("edge_fade")
+    @classmethod
+    def _validate_edge_fade(cls, value: int | list[int]) -> int | list[int]:
+        if isinstance(value, list):
+            if len(value) != 2:
+                raise ValueError("edge_fade must be a single number, or a [left, right] list of exactly two")
+            return [max(0, int(value[0])), max(0, int(value[1]))]
+        return max(0, int(value))
+
+    @model_validator(mode="after")
+    def _validate_freq_range(self) -> AudioVisualizerConfig:
+        if self.freq_min >= self.freq_max:
+            raise ValueError("freq_min must be less than freq_max")
+        return self

--- a/src/core/validation/widgets/yasb/audio_visualizer.py
+++ b/src/core/validation/widgets/yasb/audio_visualizer.py
@@ -4,8 +4,6 @@ from pydantic import Field, field_validator, model_validator
 
 from core.validation.widgets.base_model import CallbacksConfig, CustomBaseModel, KeybindingConfig
 
-DEFAULT_COLORS = ["#74c7ec", "#89b4fa", "#cba6f7"]
-
 
 class BarsStyleConfig(CustomBaseModel):
     count: int = Field(default=24, ge=4, le=128)
@@ -38,21 +36,13 @@ class AudioVisualizerConfig(CustomBaseModel):
     channels: Literal["stereo", "mono"] = "mono"
     mono_option: Literal["average", "left", "right"] = "average"
     reverse: bool = False
-    gradient: bool = True
     mirror: bool = False
-    colors: list = Field(default=DEFAULT_COLORS)
     edge_fade: int | list[int] = 0
     bars: BarsStyleConfig = Field(default_factory=BarsStyleConfig)
     waves: WavesStyleConfig = Field(default_factory=WavesStyleConfig)
     dots: DotsStyleConfig = Field(default_factory=DotsStyleConfig)
     keybindings: list[KeybindingConfig] = []
     callbacks: CallbacksConfig = CallbacksConfig()
-
-    @field_validator("colors")
-    @classmethod
-    def _validate_colors(cls, value: list[str]) -> list[str]:
-        cleaned = [c.strip() for c in value if isinstance(c, str) and c.strip()]
-        return cleaned or list(DEFAULT_COLORS)
 
     @field_validator("edge_fade")
     @classmethod

--- a/src/core/widgets/services/audio_visualizer/loopback.py
+++ b/src/core/widgets/services/audio_visualizer/loopback.py
@@ -1,0 +1,852 @@
+"""WASAPI loopback capture of the default render device."""
+
+import logging
+import threading
+import time
+from array import array
+from ctypes import POINTER, Structure, c_ubyte, c_uint16, c_uint32, c_uint64, c_void_p, cast
+
+import win32event
+from comtypes import CLSCTX_ALL, COMMETHOD, GUID, HRESULT, COMError, IUnknown
+from pycaw.callbacks import MMNotificationClient
+from pycaw.constants import DEVICE_STATE
+from pycaw.pycaw import AudioUtilities, EDataFlow, ERole, IAudioClient
+from PyQt6.QtCore import QObject, pyqtSignal
+from PyQt6.QtWidgets import QApplication
+
+from core.utils.win32.bindings.ole32 import COINIT_MULTITHREADED, RPC_E_CHANGED_MODE, ole32
+from core.widgets.services.audio_visualizer.spectrum import FFT_SIZE, SpectrumSource
+
+# Channel selectors a widget can ask for.
+_CHANNELS = ("left", "right", "average")
+
+# Returned by magnitudes() before the first frame and while the stream is idle.
+_SILENT_SPECTRUM: list[float] = [0.0] * (FFT_SIZE // 2)
+
+IID_IAudioCaptureClient = GUID("{C8ADBD64-E71E-48A0-A4DE-185C395CD317}")
+KSDATAFORMAT_SUBTYPE_IEEE_FLOAT = GUID("{00000003-0000-0010-8000-00AA00389B71}")
+KSDATAFORMAT_SUBTYPE_PCM = GUID("{00000001-0000-0010-8000-00AA00389B71}")
+
+AUDCLNT_STREAMFLAGS_LOOPBACK = 0x00020000
+AUDCLNT_STREAMFLAGS_EVENTCALLBACK = 0x00040000
+AUDCLNT_SHAREMODE_SHARED = 0
+AUDCLNT_BUFFERFLAGS_SILENT = 0x2
+REFTIMES_PER_SEC = 10_000_000
+WAVE_FORMAT_PCM = 0x0001
+WAVE_FORMAT_IEEE_FLOAT = 0x0003
+WAVE_FORMAT_EXTENSIBLE = 0xFFFE
+
+# cbSize of a WAVEFORMATEXTENSIBLE payload (2 + 4 + sizeof(GUID)).
+_WFX_EXTENSIBLE_CBSIZE = 22
+
+# Newest PCM frames kept per channel. Only the newest FFT window is ever
+# transformed; the rest is headroom for several packets between publishes.
+_RING_SIZE = 4096
+
+# A healthy stream signals every device period (~10 ms). Waiting several
+# periods with nothing to show means the render stream went away, which is how
+# "the browser was closed" is detected without polling anything.
+_STALE_TIMEOUT_MIN_MS = 160
+_STALE_TIMEOUT_PERIODS = 4
+
+_REOPEN_BACKOFF_MIN_MS = 500
+_REOPEN_BACKOFF_MAX_MS = 8000
+
+# Peak amplitude at or below which a packet counts as silence. About -100 dBFS,
+# far below anything that could move a bar by a whole pixel.
+_SILENCE_FLOOR = 1e-5
+
+# Indices into the WaitForMultipleObjects handle list.
+_STOP = 0
+_WAKE = 1
+_AUDIO = 2
+
+
+class _WAVEFORMATEX(Structure):
+    """Windows ABI layout: 18 bytes, no trailing padding.
+
+    ``_pack_`` matters. The default ctypes alignment pads this to 20 bytes,
+    which would put every WAVEFORMATEXTENSIBLE field at the wrong offset.
+    """
+
+    _pack_ = 1
+    _fields_ = [
+        ("wFormatTag", c_uint16),
+        ("nChannels", c_uint16),
+        ("nSamplesPerSec", c_uint32),
+        ("nAvgBytesPerSec", c_uint32),
+        ("nBlockAlign", c_uint16),
+        ("wBitsPerSample", c_uint16),
+        ("cbSize", c_uint16),
+    ]
+
+
+class _WAVEFORMATEXTENSIBLE(Structure):
+    """Windows ABI layout: 40 bytes, SubFormat at offset 24."""
+
+    _pack_ = 1
+    _fields_ = [
+        ("Format", _WAVEFORMATEX),
+        ("wValidBitsPerSample", c_uint16),
+        ("dwChannelMask", c_uint32),
+        ("SubFormat", GUID),
+    ]
+
+
+class IAudioCaptureClient(IUnknown):
+    _iid_ = IID_IAudioCaptureClient
+    _methods_ = [
+        COMMETHOD(
+            [],
+            HRESULT,
+            "GetBuffer",
+            (["out"], POINTER(POINTER(c_ubyte)), "ppData"),
+            (["out"], POINTER(c_uint32), "pNumFramesToRead"),
+            (["out"], POINTER(c_uint32), "pdwFlags"),
+            (["out"], POINTER(c_uint64), "pu64DevicePosition"),
+            (["out"], POINTER(c_uint64), "pu64QPCPosition"),
+        ),
+        COMMETHOD([], HRESULT, "ReleaseBuffer", (["in"], c_uint32, "NumFramesRead")),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "GetNextPacketSize",
+            (["out"], POINTER(c_uint32), "pNumFramesInNextPacket"),
+        ),
+    ]
+
+
+class UnsupportedFormatError(RuntimeError):
+    """The endpoint mix format cannot be decoded, and retrying will not help."""
+
+
+def _is_silent(samples: list[float]) -> bool:
+    """Is this channel inaudible? Cheap because max()/min() run in C."""
+    return not samples or (max(samples) <= _SILENCE_FLOOR and min(samples) >= -_SILENCE_FLOOR)
+
+
+def _decode_stereo(buf: bytes, channels: int, sample_code: str, scale: float) -> tuple[list[float], list[float]]:
+    """Split an interleaved packet into its first two channels.
+
+    Strided slicing over an ``array`` keeps the per-sample work in C, which is
+    roughly 20x faster than walking every frame from Python. Float mix formats
+    need no scaling at all, which is the overwhelmingly common case.
+    """
+    samples = array(sample_code)
+    samples.frombytes(buf)
+    if channels >= 2:
+        left = samples[0::channels]
+        right = samples[1::channels]
+    else:
+        left = right = samples
+    if scale == 1.0:
+        return left.tolist(), right.tolist()
+    return [v * scale for v in left], [v * scale for v in right]
+
+
+class _WasapiLoopbackClient:
+    """A live event-driven loopback client.
+
+    Created, used and released entirely on the capture thread. Format details
+    are read from the endpoint every time a client is opened, so a device
+    switch can never leave a stale frame stride behind.
+    """
+
+    def __init__(self, audio_event: int) -> None:
+        self.sample_rate = 48000
+        self.channels = 2
+        self.frame_bytes = 8
+        self.bits = 32
+        self.sample_code = "f"
+        self.sample_scale = 1.0
+        self.stale_timeout_ms = _STALE_TIMEOUT_MIN_MS
+        self.running = False
+        self.capture: IAudioCaptureClient | None = None
+        self._client: IAudioClient | None = None
+        self._open(audio_event)
+
+    @property
+    def format_summary(self) -> str:
+        kind = {"f": "float", "h": "int16", "i": "int32"}.get(self.sample_code, self.sample_code)
+        return f"{self.sample_rate} Hz, {self.channels} ch, {self.bits}-bit {kind}"
+
+    def _open(self, audio_event: int) -> None:
+        enumerator = AudioUtilities.GetDeviceEnumerator()
+        device = enumerator.GetDefaultAudioEndpoint(EDataFlow.eRender.value, ERole.eMultimedia.value)
+        client = device.Activate(IAudioClient._iid_, CLSCTX_ALL, None).QueryInterface(IAudioClient)
+
+        wfx = client.GetMixFormat()
+        try:
+            self._read_format(wfx)
+            client.Initialize(
+                AUDCLNT_SHAREMODE_SHARED,
+                AUDCLNT_STREAMFLAGS_LOOPBACK | AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+                REFTIMES_PER_SEC // 10,
+                0,  # periodicity must be 0 alongside EVENTCALLBACK
+                wfx,
+                None,
+            )
+        finally:
+            # GetMixFormat hands over a CoTaskMemAlloc'd block that comtypes
+            # will not release. Initialize has copied what it needs by now.
+            ole32.CoTaskMemFree(cast(wfx, c_void_p))
+
+        default_period, _minimum = client.GetDevicePeriod()
+        period_ms = max(1.0, default_period / 10_000.0)
+        self.stale_timeout_ms = max(_STALE_TIMEOUT_MIN_MS, int(period_ms * _STALE_TIMEOUT_PERIODS) + 1)
+
+        client.SetEventHandle(audio_event)
+        capture = client.GetService(IAudioCaptureClient._iid_).QueryInterface(IAudioCaptureClient)
+        client.Start()
+        self._client = client
+        self.capture = capture
+        self.running = True
+
+    def pause(self) -> None:
+        """Freeze the stream while every visualizer is hidden. The client stays
+        initialised, so :meth:`resume` costs nothing like a fresh open would."""
+        if self._client is None or not self.running:
+            return
+        self._client.Stop()
+        self.running = False
+
+    def resume(self) -> None:
+        if self._client is None or self.running:
+            return
+        self._client.Start()
+        self.running = True
+
+    def _read_format(self, wfx) -> None:
+        fmt = cast(wfx, POINTER(_WAVEFORMATEX)).contents
+        self.sample_rate = max(1, int(fmt.nSamplesPerSec))
+        self.channels = max(1, int(fmt.nChannels))
+        self.bits = int(fmt.wBitsPerSample)
+        # nBlockAlign is the authoritative frame stride; only fall back to a
+        # computed value if the driver reports nonsense.
+        self.frame_bytes = int(fmt.nBlockAlign) or self.channels * max(1, self.bits // 8)
+
+        tag = int(fmt.wFormatTag)
+        if tag == WAVE_FORMAT_EXTENSIBLE:
+            if int(fmt.cbSize) < _WFX_EXTENSIBLE_CBSIZE:
+                raise UnsupportedFormatError(f"WAVE_FORMAT_EXTENSIBLE with truncated cbSize {int(fmt.cbSize)}")
+            subtype = cast(wfx, POINTER(_WAVEFORMATEXTENSIBLE)).contents.SubFormat
+            is_float = subtype == KSDATAFORMAT_SUBTYPE_IEEE_FLOAT
+            if not is_float and subtype != KSDATAFORMAT_SUBTYPE_PCM:
+                raise UnsupportedFormatError(f"unsupported loopback subformat {subtype}")
+        else:
+            is_float = tag == WAVE_FORMAT_IEEE_FLOAT
+            if not is_float and tag != WAVE_FORMAT_PCM:
+                raise UnsupportedFormatError(f"unsupported loopback format tag 0x{tag:04X}")
+
+        bytes_per_sample = self.frame_bytes // self.channels
+        if is_float and bytes_per_sample == 4:
+            self.sample_code, self.sample_scale = "f", 1.0
+        elif not is_float and bytes_per_sample == 2:
+            self.sample_code, self.sample_scale = "h", 1.0 / 32768.0
+        elif not is_float and bytes_per_sample == 4:
+            self.sample_code, self.sample_scale = "i", 1.0 / 2147483648.0
+        else:
+            raise UnsupportedFormatError(
+                f"cannot decode {self.bits}-bit {'float' if is_float else 'PCM'} ({bytes_per_sample} bytes per sample)"
+            )
+
+    def close(self) -> None:
+        client, self._client = self._client, None
+        self.capture = None
+        self.running = False
+        if client is None:
+            return
+        try:
+            client.Stop()
+            client.Reset()
+        except Exception:
+            logging.debug("Audio visualizer: WASAPI client teardown failed", exc_info=True)
+
+
+class _RenderDeviceWatcher(MMNotificationClient):
+    """Asks the capture thread to rebuild its client when the endpoint changes.
+
+    Registered on the UI thread, matching how ``services/volume`` does it. The
+    callbacks only flip a flag and signal an event, so they never block the
+    audio service that invokes them.
+    """
+
+    def __init__(self, service: AudioVisualizerCaptureService) -> None:
+        super().__init__()
+        self._service = service
+        self._last_device_id = self._current_render_device_id()
+        self._last_states: dict[str, int] = {}
+
+    @staticmethod
+    def _current_render_device_id() -> str | None:
+        try:
+            enumerator = AudioUtilities.GetDeviceEnumerator()
+            endpoint = enumerator.GetDefaultAudioEndpoint(EDataFlow.eRender.value, ERole.eMultimedia.value)
+            return endpoint.GetId()
+        except Exception:
+            return None
+
+    def on_default_device_changed(self, flow, flow_id, role, role_id, default_device_id) -> None:
+        logging.debug(
+            "Audio visualizer: default device changed flow=%s role=%s device=%s",
+            flow_id,
+            role_id,
+            default_device_id,
+        )
+        if flow_id != EDataFlow.eRender.value or role_id != ERole.eMultimedia.value:
+            return
+        if default_device_id == self._last_device_id:
+            return
+        self._last_device_id = default_device_id
+        logging.debug("Audio visualizer: default device change accepted, reopening")
+        self._service.request_reopen()
+
+    def on_device_state_changed(self, device_id, new_state, new_state_id) -> None:
+        logging.debug(
+            "Audio visualizer: device state changed device=%s state=%#x",
+            device_id,
+            new_state_id,
+        )
+        # A device connecting or disconnecting can touch several unrelated
+        # endpoints (a headset's own microphone, other devices Windows
+        # happens to re-enumerate along the way), only the one we are
+        # actually reading from matters to a render-only loopback capture.
+        if device_id != self._last_device_id:
+            return
+        if new_state_id not in (
+            DEVICE_STATE.ACTIVE.value,
+            DEVICE_STATE.DISABLED.value,
+            DEVICE_STATE.UNPLUGGED.value,
+        ):
+            return
+        if self._last_states.get(device_id) == new_state_id:
+            return
+        self._last_states[device_id] = new_state_id
+        logging.debug("Audio visualizer: device state change accepted, reopening")
+        self._service.request_reopen()
+
+
+class AudioVisualizerCaptureService(QObject):
+    """Shared, event-driven loopback capture for every visualizer widget.
+
+    A single WASAPI stream and a single capture thread serve all widgets, on
+    every monitor. The stream is open while at least one widget is attached,
+    frozen while every widget's bar is hidden, and torn down once the last
+    widget goes away.
+    """
+
+    #: A new spectrum has been published. Rate limited to the fastest framerate
+    #: among attached widgets.
+    frame_ready = pyqtSignal()
+    #: The render stream went away. The published spectra have been dropped, so
+    #: magnitudes() now returns silence and widgets should fade out.
+    audio_stopped = pyqtSignal()
+    #: The endpoint sample rate changed; analyzers must be rebuilt.
+    format_changed = pyqtSignal(int)
+
+    _instance: AudioVisualizerCaptureService | None = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._lock = threading.Lock()
+        self._ring_l: list[float] = []
+        self._ring_r: list[float] = []
+        # (framerate, wanted-channels) per attached widget, plus a count of the
+        # ones that are currently visible (not paused by a hidden bar).
+        self._readers: list[tuple[int, frozenset[str]]] = []
+        self._active_readers = 0
+        self._wanted_channels: frozenset[str] = frozenset()
+        self._frame_interval_ns = 1_000_000_000 // 60
+        self._last_emit_ns = 0
+        self._frame_pending = False
+        # One transform per channel selector, shared by every widget and every
+        # monitor. Touched only from the capture thread (_publish_frame).
+        self._sources = {ch: SpectrumSource(FFT_SIZE) for ch in _CHANNELS}
+        # Last spectrum per channel. The capture thread swaps this dict in one
+        # atomic rebind; the UI thread reads it lock-free in magnitudes().
+        self._channel_mags: dict[str, list[float]] = {}
+        self._sample_rate = 48000
+        self._active = False
+        self._running = False
+        # Capture thread only: when real (non-silent) audio last arrived.
+        self._last_audio_ns = 0
+        self._device_dirty = False
+        self._format_rejected = False
+        self._thread: threading.Thread | None = None
+        self._enumerator = None
+        self._watcher: _RenderDeviceWatcher | None = None
+
+        self._audio_event = win32event.CreateEvent(None, False, False, None)  # auto-reset
+        self._wake_event = win32event.CreateEvent(None, False, False, None)  # auto-reset
+        self._stop_event = win32event.CreateEvent(None, True, False, None)  # manual-reset
+
+        # Connected first so it runs before the widget slots and re-arms
+        # emission as early as possible.
+        self.frame_ready.connect(self._on_frame_dispatched)
+        app = QApplication.instance()
+        if app is not None:
+            app.aboutToQuit.connect(self.shutdown)
+
+    @classmethod
+    def instance(cls) -> AudioVisualizerCaptureService:
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = cls()
+            return cls._instance
+
+    @property
+    def sample_rate(self) -> int:
+        return self._sample_rate
+
+    @property
+    def is_active(self) -> bool:
+        """True while real audio is flowing."""
+        return self._active
+
+    def attach(self, framerate: int, channels: frozenset[str]) -> None:
+        """Register a reader wanting ``channels`` at up to ``framerate`` fps.
+
+        A reader starts visible; the widget calls :meth:`set_reader_visible`
+        when its bar is hidden or shown.
+        """
+        with self._lock:
+            self._readers.append((self._clamp_framerate(framerate), channels))
+            self._active_readers += 1
+            self._refresh_readers()
+        self._ensure_thread()
+        win32event.SetEvent(self._wake_event)
+
+    def detach(self, framerate: int, channels: frozenset[str], visible: bool) -> None:
+        """Drop a reader. The stream closes once the last one leaves."""
+        with self._lock:
+            if not self._running:
+                return
+            try:
+                self._readers.remove((self._clamp_framerate(framerate), channels))
+                if visible:
+                    self._active_readers = max(0, self._active_readers - 1)
+            except ValueError:
+                logging.debug("Audio visualizer: detach without a matching attach")
+            self._refresh_readers()
+        win32event.SetEvent(self._wake_event)
+
+    def set_reader_visible(self, visible: bool) -> None:
+        """A widget's bar became visible (``True``) or hidden (``False``).
+
+        When the last visible reader goes away the capture thread freezes the
+        WASAPI stream without closing it, so a re-show resumes instantly.
+        """
+        with self._lock:
+            self._active_readers = max(0, self._active_readers + (1 if visible else -1))
+        win32event.SetEvent(self._wake_event)
+
+    @staticmethod
+    def _clamp_framerate(framerate: int) -> int:
+        return max(1, min(240, int(framerate)))
+
+    def _refresh_readers(self) -> None:
+        """Recompute the emit interval and the union of wanted channels.
+
+        Caller holds the lock.
+        """
+        if self._readers:
+            fps = max(fr for fr, _ in self._readers)
+            wanted: set[str] = set()
+            for _, chans in self._readers:
+                wanted |= chans
+            self._wanted_channels = frozenset(wanted)
+        else:
+            fps = 60
+            self._wanted_channels = frozenset()
+        self._frame_interval_ns = max(1, 1_000_000_000 // fps)
+
+    def _reader_state(self) -> tuple[bool, bool]:
+        """(any readers, any visible readers). Capture thread poll."""
+        with self._lock:
+            return bool(self._readers), self._active_readers > 0
+
+    def _raw_window_locked(self, n: int) -> tuple[list[float], list[float]]:
+        """Newest ``n`` samples per channel, zero-padded at the front.
+
+        Caller holds the lock. Returns silence while the stream is idle,
+        because ``_mark_stopped`` and ``_open`` clear the rings.
+        """
+        left = self._ring_l[-n:]
+        right = self._ring_r[-n:]
+        pad = n - len(left)
+        if pad > 0:
+            head = [0.0] * pad
+            left = head + left
+            right = head + right
+        return left, right
+
+    def magnitudes(self, channel: str) -> list[float]:
+        """Latest magnitude spectrum for ``channel`` (``"left"``, ``"right"`` or
+        ``"average"``).
+
+        The transform itself runs on the capture thread, once per frame per
+        channel no matter how many widgets or monitors ask for it. This is a
+        lock-free read of the last published result, cheap enough to call from
+        paint; it returns silence until the first frame after audio starts.
+        """
+        return self._channel_mags.get(channel, _SILENT_SPECTRUM)
+
+    def _safe_emit(self, signal_name: str, *args) -> None:
+        try:
+            getattr(self, signal_name).emit(*args)
+        except RuntimeError:
+            pass
+
+    def request_reopen(self) -> None:
+        """Rebuild the client, e.g. after the default endpoint changed."""
+        with self._lock:
+            self._device_dirty = True
+            self._format_rejected = False
+        win32event.SetEvent(self._wake_event)
+
+    def _ensure_thread(self) -> None:
+        # Only ever called from the UI thread (via attach), so the read of
+        # _thread and the start below cannot race each other.
+        with self._lock:
+            thread = self._thread
+            if self._running and thread is not None and thread.is_alive():
+                return
+            self._running = True
+        self._register_device_watcher()
+        win32event.ResetEvent(self._stop_event)
+        self._thread = threading.Thread(target=self._capture_thread, name="yasb-audio-visualizer", daemon=True)
+        self._thread.start()
+
+    def shutdown(self) -> None:
+        """Stop capturing and join the thread. Safe to call more than once."""
+        with self._lock:
+            self._readers.clear()
+            self._active_readers = 0
+            self._refresh_readers()
+            was_running = self._running
+            self._running = False
+        if not was_running:
+            return
+
+        win32event.SetEvent(self._stop_event)
+        thread, self._thread = self._thread, None
+        if thread is not None and thread.is_alive() and threading.current_thread() is not thread:
+            thread.join(timeout=2.0)
+            if thread.is_alive():
+                logging.warning("Audio visualizer: capture thread did not exit in time")
+
+        self._unregister_device_watcher()
+        with self._lock:
+            self._ring_l.clear()
+            self._ring_r.clear()
+            self._active = False
+
+    def _register_device_watcher(self) -> None:
+        if self._watcher is not None:
+            return
+        try:
+            self._enumerator = AudioUtilities.GetDeviceEnumerator()
+            self._watcher = _RenderDeviceWatcher(self)
+            self._enumerator.RegisterEndpointNotificationCallback(self._watcher)
+        except Exception:
+            self._watcher = None
+            self._enumerator = None
+            logging.warning("Audio visualizer: device change notifications unavailable", exc_info=True)
+
+    def _unregister_device_watcher(self) -> None:
+        watcher, self._watcher = self._watcher, None
+        enumerator, self._enumerator = self._enumerator, None
+        if watcher is None or enumerator is None:
+            return
+        try:
+            enumerator.UnregisterEndpointNotificationCallback(watcher)
+        except Exception:
+            logging.debug("Audio visualizer: could not unregister device watcher", exc_info=True)
+
+    def _capture_thread(self) -> None:
+        hr = ole32.CoInitializeEx(None, COINIT_MULTITHREADED)
+        if hr < 0 and hr != RPC_E_CHANGED_MODE:
+            logging.error("Audio visualizer: CoInitializeEx failed (0x%08X)", hr & 0xFFFFFFFF)
+            return
+        try:
+            self._capture_loop()
+        except Exception:
+            logging.exception("Audio visualizer: capture thread crashed")
+        finally:
+            self._mark_stopped()
+            if hr >= 0:
+                ole32.CoUninitialize()
+
+    def _capture_loop(self) -> None:
+        handles = [self._stop_event, self._wake_event, self._audio_event]
+        idle_handles = [self._stop_event, self._wake_event]
+        client: _WasapiLoopbackClient | None = None
+        backoff_ms = _REOPEN_BACKOFF_MIN_MS
+        try:
+            while self._running:
+                if self._take_device_dirty():
+                    client = self._close(client)
+                    backoff_ms = _REOPEN_BACKOFF_MIN_MS
+
+                has_readers, has_visible = self._reader_state()
+
+                # No widgets at all: close the stream and park.
+                if not has_readers:
+                    client = self._close(client)
+                    self._mark_stopped()
+                    if self._park(idle_handles, win32event.INFINITE):
+                        break
+                    continue
+
+                # Widgets exist but every one is hidden (an auto-hiding bar, a
+                # fullscreen window, a monitor asleep). Freeze the stream but
+                # keep the client, so the next re-show resumes with no reopen.
+                if not has_visible:
+                    if client is not None:
+                        try:
+                            client.pause()
+                        except Exception:
+                            logging.debug("Audio visualizer: pause failed, closing", exc_info=True)
+                            client = self._close(client)
+                    self._mark_stopped()
+                    if self._park(idle_handles, win32event.INFINITE):
+                        break
+                    continue
+
+                if client is None:
+                    if self._format_rejected:
+                        # Only a device change can make this work; wait for one
+                        # rather than retrying a format we cannot decode.
+                        if self._park(idle_handles, win32event.INFINITE):
+                            break
+                        continue
+                    client = self._open()
+                    if client is None:
+                        self._mark_stopped()
+                        if self._park(idle_handles, backoff_ms):
+                            break
+                        backoff_ms = min(backoff_ms * 2, _REOPEN_BACKOFF_MAX_MS)
+                        continue
+                    backoff_ms = _REOPEN_BACKOFF_MIN_MS
+                    # Give the new stream the full timeout to produce audio, so
+                    # swapping devices mid-track does not blip the bars to zero.
+                    self._last_audio_ns = time.monotonic_ns()
+                elif not client.running:
+                    try:
+                        client.resume()
+                    except Exception:
+                        logging.warning("Audio visualizer: resume failed, reopening", exc_info=True)
+                        client = self._close(client)
+                        continue
+                    self._last_audio_ns = time.monotonic_ns()
+
+                rc = win32event.WaitForMultipleObjects(handles, False, client.stale_timeout_ms)
+                if rc == win32event.WAIT_OBJECT_0 + _STOP:
+                    break
+                if rc == win32event.WAIT_OBJECT_0 + _WAKE:
+                    continue
+
+                if rc == win32event.WAIT_OBJECT_0 + _AUDIO:
+                    try:
+                        if self._drain(client):
+                            self._last_audio_ns = time.monotonic_ns()
+                            self._publish_frame()
+                    except COMError as exc:
+                        # The endpoint was invalidated mid-stream: another app
+                        # claimed the device exclusively (ASIO and similar
+                        # drivers bypass the shared mixer entirely), it was
+                        # unplugged, or it was reconfigured. Reopening below
+                        # succeeds on its own once the device is available
+                        # again, same as _open()'s COMError handling.
+                        logging.debug("Audio visualizer: loopback stream invalidated (%s), reopening", exc)
+                        client = self._close(client)
+                        self._mark_stopped()
+                        if self._park(idle_handles, backoff_ms):
+                            break
+                        backoff_ms = min(backoff_ms * 2, _REOPEN_BACKOFF_MAX_MS)
+                        continue
+                    except Exception:
+                        logging.warning("Audio visualizer: loopback stream failed, reopening", exc_info=True)
+                        client = self._close(client)
+                        self._mark_stopped()
+                        # Back off like a failed open, so a packet that keeps
+                        # failing to drain cannot spin this loop at the device
+                        # period rate.
+                        if self._park(idle_handles, backoff_ms):
+                            break
+                        backoff_ms = min(backoff_ms * 2, _REOPEN_BACKOFF_MAX_MS)
+                        continue
+                elif rc != win32event.WAIT_TIMEOUT:
+                    continue
+
+                # Idle means "no real audio for several device periods", which
+                # covers both the render stream ending and it staying open while
+                # feeding pure silence. Muting an app is the latter: packets keep
+                # arriving forever, so waiting for them to stop would leave the
+                # bars frozen on the last frame before the mute.
+                if self._silent_for(client.stale_timeout_ms):
+                    self._mark_stopped()
+        finally:
+            self._close(client)
+
+    def _silent_for(self, timeout_ms: int) -> bool:
+        """Has no real audio arrived for ``timeout_ms``? Capture thread only."""
+        return time.monotonic_ns() - self._last_audio_ns >= timeout_ms * 1_000_000
+
+    def _park(self, handles: list, timeout_ms: int) -> bool:
+        """Block on wake/stop. Returns True when shutdown was requested."""
+        rc = win32event.WaitForMultipleObjects(handles, False, timeout_ms)
+        return rc == win32event.WAIT_OBJECT_0 + _STOP
+
+    def _take_device_dirty(self) -> bool:
+        with self._lock:
+            dirty, self._device_dirty = self._device_dirty, False
+        return dirty
+
+    def _open(self) -> _WasapiLoopbackClient | None:
+        try:
+            client = _WasapiLoopbackClient(int(self._audio_event))
+        except UnsupportedFormatError as exc:
+            logging.error("Audio visualizer: %s", exc)
+            with self._lock:
+                self._format_rejected = True
+            return None
+        except COMError:
+            return None
+        except Exception:
+            logging.debug("Audio visualizer: could not open WASAPI loopback", exc_info=True)
+            return None
+
+        with self._lock:
+            self._ring_l.clear()
+            self._ring_r.clear()
+            rate_changed = client.sample_rate != self._sample_rate
+            self._sample_rate = client.sample_rate
+        if rate_changed:
+            self._safe_emit("format_changed", client.sample_rate)
+        logging.info("Audio visualizer: loopback capture open (%s)", client.format_summary)
+        return client
+
+    @staticmethod
+    def _close(client: _WasapiLoopbackClient | None) -> None:
+        if client is not None:
+            client.close()
+        return None
+
+    def _drain(self, client: _WasapiLoopbackClient) -> bool:
+        """Consume every ready packet. Returns True if real audio arrived."""
+        capture = client.capture
+        if capture is None:
+            return False
+        frame_bytes = client.frame_bytes
+        got_audio = False
+
+        while self._running:
+            if not capture.GetNextPacketSize():
+                break
+
+            data_ptr, nframes, flags, *_ = capture.GetBuffer()
+            nframes = int(nframes)
+            try:
+                if nframes and not (flags & AUDCLNT_BUFFERFLAGS_SILENT):
+                    nbytes = nframes * frame_bytes
+                    buf = bytes(cast(data_ptr, POINTER(c_ubyte * nbytes)).contents)
+                else:
+                    buf = b""
+            finally:
+                # The packet must be released even if the copy raised, or the
+                # capture buffer stays locked and the stream stalls for good.
+                capture.ReleaseBuffer(nframes)
+
+            # While "nothing is playing but the endpoint is open" every packet
+            # is digital silence. count() is a C-level scan and roughly 35x
+            # cheaper than decoding, so discard those before doing any work.
+            if not buf or buf.count(0) == len(buf):
+                self._publish_silence()
+                continue
+
+            left, right = _decode_stereo(buf, client.channels, client.sample_code, client.sample_scale)
+
+            # Muting an app scales its samples by zero, which turns every
+            # negative one into negative zero. Those are not zero bytes, so the
+            # scan above lets them through and the stream would look alive
+            # forever. Test amplitude as well; max() short-circuits this to a
+            # single C pass for anything actually audible.
+            if _is_silent(left) and _is_silent(right):
+                self._publish_silence()
+                continue
+
+            with self._lock:
+                self._ring_l.extend(left)
+                self._ring_r.extend(right)
+                overflow = len(self._ring_l) - _RING_SIZE
+                if overflow > 0:
+                    del self._ring_l[:overflow]
+                    del self._ring_r[:overflow]
+            got_audio = True
+
+        return got_audio
+
+    def _publish_frame(self) -> None:
+        now = time.monotonic_ns()
+        with self._lock:
+            self._active = True
+            if self._frame_pending or now - self._last_emit_ns < self._frame_interval_ns:
+                return
+            wanted = self._wanted_channels
+            if not wanted:
+                return
+            self._frame_pending = True
+            self._last_emit_ns = now
+            left, right = self._raw_window_locked(FFT_SIZE)
+
+        # The transform is the expensive part (~0.3 ms per channel). Run it here
+        # on the capture thread, outside the lock, so it never competes with the
+        # bar's own painting and animations on the UI thread.
+        mags: dict[str, list[float]] = {}
+        for channel in wanted:
+            if channel == "left":
+                window = left
+            elif channel == "right":
+                window = right
+            else:
+                window = [0.5 * (left[i] + right[i]) for i in range(FFT_SIZE)]
+            mags[channel] = self._sources[channel].magnitudes(window)
+        # One atomic rebind; magnitudes() reads it lock-free.
+        self._channel_mags = mags
+        self._safe_emit("frame_ready")
+
+    def _publish_silence(self) -> None:
+        """Publish a zero spectrum for a silent packet, the same as a real
+        frame but without the transform. Gated on ``_active`` so it only
+        applies while a stream was recently live, never during genuine idle.
+        """
+        now = time.monotonic_ns()
+        with self._lock:
+            if not self._active or self._frame_pending or now - self._last_emit_ns < self._frame_interval_ns:
+                return
+            wanted = self._wanted_channels
+            if not wanted:
+                return
+            self._frame_pending = True
+            self._last_emit_ns = now
+
+        self._channel_mags = dict.fromkeys(wanted, _SILENT_SPECTRUM)
+        self._safe_emit("frame_ready")
+
+    def _on_frame_dispatched(self) -> None:
+        """Runs on the UI thread ahead of the widget slots; re-arms emission."""
+        self._frame_pending = False
+
+    def _mark_stopped(self) -> None:
+        """Drop captured history and tell the widgets the stream went away."""
+        with self._lock:
+            if not self._active:
+                return
+            self._active = False
+            self._frame_pending = False
+            self._ring_l.clear()
+            self._ring_r.clear()
+        self._channel_mags = {}
+        self._safe_emit("audio_stopped")

--- a/src/core/widgets/services/audio_visualizer/paint.py
+++ b/src/core/widgets/services/audio_visualizer/paint.py
@@ -1,0 +1,353 @@
+"""Paint surface for the audio visualizer.
+
+Everything that depends only on geometry (column positions, edge-fade
+opacities, the colour brush and the fade mask) is built once and reused, so a
+frame costs no more than the fills it actually needs.
+"""
+
+import logging
+
+from PyQt6.QtCore import QRect, Qt
+from PyQt6.QtGui import QColor, QLinearGradient, QPainter, QPainterPath, QPixmap
+from PyQt6.QtWidgets import QFrame
+
+
+class AudioVizCanvas(QFrame):
+    """Fixed-size widget that paints spectrum samples."""
+
+    def __init__(
+        self,
+        *,
+        style: str,
+        height: int,
+        columns: int,
+        canvas_width: int,
+        item_width: int,
+        item_gap: int,
+        gradient: bool,
+        mirror: bool,
+        stereo: bool,
+        colors: list[QColor],
+        edge_fade_left: int,
+        edge_fade_right: int,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.style_name = style
+        self.item_width = max(1, item_width)
+        self.item_gap = max(0, item_gap)
+        self.gradient = gradient
+        self.mirror = mirror
+        self.stereo = stereo
+        self.colors = colors
+        self.edge_fade_left = max(0, edge_fade_left)
+        self.edge_fade_right = max(0, edge_fade_right)
+        self.faded = bool(self.edge_fade_left or self.edge_fade_right)
+        self.samples: list[float] = [0.0] * columns
+
+        self._paint_failed = False
+        self._brush_cache: QColor | QLinearGradient | None = None
+        self._column_cache: dict[int, tuple[list[int], list[float], list[QColor]]] = {}
+        self._fade_mask: QLinearGradient | None = None
+        self._layer: QPixmap | None = None
+        self._layer_key: tuple[int, int, float] | None = None
+
+        self.setFrameShape(QFrame.Shape.NoFrame)
+        self.setLineWidth(0)
+        self.setContentsMargins(0, 0, 0, 0)
+        self.setFixedSize(max(8, canvas_width), max(4, height))
+
+    def set_samples(self, samples: list[float]) -> None:
+        if samples == self.samples:
+            return  # nothing moved, so there is nothing to repaint
+        self.samples = samples
+        self.update()
+
+    def reset(self) -> None:
+        """Blank the surface immediately, without waiting for a fade-out."""
+        self.set_samples([0.0] * len(self.samples))
+
+    def paintEvent(self, _event) -> None:
+        if not self.samples:
+            return
+        try:
+            with QPainter(self) as painter:
+                if self.style_name == "waves":
+                    painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+                    self._paint_waves(painter)
+                elif self.style_name == "dots":
+                    self._paint_dots(painter)
+                else:
+                    self._paint_bars(painter)
+        except Exception:
+            if not self._paint_failed:
+                self._paint_failed = True
+                logging.warning("Audio visualizer paint failed; suppressing further paint errors", exc_info=True)
+
+    def _columns(self, count: int) -> tuple[list[int], list[float], list[QColor]]:
+        """Left edge, edge-fade opacity and colour for each column."""
+        cached = self._column_cache.get(count)
+        if cached is not None:
+            return cached
+
+        width = self.width()
+        if self.style_name == "dots":
+            size = self.item_width
+            pitch = max(self.item_width + self.item_gap, width // max(1, count))
+            offset = (pitch - size) // 2
+            xs = [i * pitch + offset for i in range(count)]
+        else:
+            step = self.item_width + self.item_gap
+            start = self.item_gap // 2
+            xs = [start + i * step for i in range(count)]
+
+        centre = self.item_width / 2.0
+        opacities = [self._fade_at(x + centre, width) for x in xs]
+        palette = [self.colors[i % len(self.colors)] for i in range(count)]
+        result = (xs, opacities, palette)
+        self._column_cache[count] = result
+        return result
+
+    def _brush(self) -> QColor | QLinearGradient:
+        if self._brush_cache is None:
+            if self.gradient and len(self.colors) > 1:
+                gradient = QLinearGradient(0, 1, 0, 0)
+                gradient.setCoordinateMode(QLinearGradient.CoordinateMode.ObjectBoundingMode)
+                step = 1.0 / (len(self.colors) - 1)
+                for i, color in enumerate(self.colors):
+                    gradient.setColorAt(i * step, color)
+                self._brush_cache = gradient
+            else:
+                self._brush_cache = self.colors[0]
+        return self._brush_cache
+
+    _FADE_STEPS = 16
+
+    @staticmethod
+    def _ease(t: float) -> float:
+        return t * t * (3 - 2 * t)
+
+    def _fade_at(self, x: float, width: float) -> float:
+        left = self.edge_fade_left
+        right = self.edge_fade_right
+        if left <= 0 and right <= 0:
+            return 1.0
+        if left > 0 and right > 0:
+            left = min(left, width / 2)
+            right = min(right, width / 2)
+        else:
+            left = min(left, width) if left > 0 else 0
+            right = min(right, width) if right > 0 else 0
+        if left > 0 and x <= left:
+            return self._ease(max(0.0, x / left))
+        if right > 0 and x >= width - right:
+            return self._ease(max(0.0, (width - x) / right))
+        return 1.0
+
+    def _fade_gradient(self) -> QLinearGradient:
+        """Horizontal alpha ramp used to mask the wave fill in one pass."""
+        if self._fade_mask is not None:
+            return self._fade_mask
+
+        width = float(self.width())
+        left = self.edge_fade_left
+        right = self.edge_fade_right
+        if left > 0 and right > 0:
+            left = min(left, width / 2)
+            right = min(right, width / 2)
+        else:
+            left = min(left, width) if left > 0 else 0
+            right = min(right, width) if right > 0 else 0
+
+        opaque = QColor(255, 255, 255, 255)
+        gradient = QLinearGradient(0.0, 0.0, width, 0.0)
+        steps = self._FADE_STEPS
+        if left > 0:
+            for i in range(steps + 1):
+                t = i / steps
+                alpha = round(self._ease(t) * 255)
+                gradient.setColorAt(t * left / width, QColor(255, 255, 255, alpha))
+        else:
+            gradient.setColorAt(0.0, opaque)
+        if right > 0:
+            for i in range(steps + 1):
+                t = i / steps
+                alpha = round(self._ease(t) * 255)
+                gradient.setColorAt(1.0 - t * right / width, QColor(255, 255, 255, alpha))
+        else:
+            gradient.setColorAt(1.0, opaque)
+        self._fade_mask = gradient
+        return gradient
+
+    def _masking_layer(self, ratio: float) -> QPixmap:
+        """Scratch surface for compositing the wave fill with the fade mask."""
+        key = (self.width(), self.height(), ratio)
+        if self._layer_key != key or self._layer is None:
+            layer = QPixmap(int(self.width() * ratio), int(self.height() * ratio))
+            layer.setDevicePixelRatio(ratio)
+            self._layer = layer
+            self._layer_key = key
+        return self._layer
+
+    @staticmethod
+    def _clamp_sample(value: float) -> float:
+        return max(0.0, min(1.0, value))
+
+    def _paint_bars(self, painter: QPainter) -> None:
+        h = self.height()
+        brush = self._brush()
+        bar_w = self.item_width
+        xs, opacities, _ = self._columns(len(self.samples))
+        faded = self.faded
+        mirror = self.mirror
+        ratio = self.devicePixelRatioF()
+
+        # Painting straight onto `painter` would let Qt's own logical->physical
+        # transform round each bar's edges independently: at a fractional scale
+        # (125%, 150%) a 1-2px bar can then land on a different physical width
+        # per bar, even though every bar asks for the same width. Deriving every
+        # bar's position from one fixed physical step (rather than rounding each
+        # bar's logical position separately) keeps the gaps between bars just as
+        # constant as the bars themselves.
+        layer = self._masking_layer(ratio)
+        layer.setDevicePixelRatio(1.0)
+        layer.fill(Qt.GlobalColor.transparent)
+        n = len(self.samples)
+        bar_w_phys = max(1, round(bar_w * ratio))
+        step_phys = round((xs[1] - xs[0]) * ratio) if n > 1 else 0
+        start_phys = round(xs[0] * ratio) if n else 0
+        h_phys = layer.height()
+        with QPainter(layer) as lp:
+            for i, sample in enumerate(self.samples):
+                sample = self._clamp_sample(sample)
+                bar_h = max(1, min(h, round(sample * h)))
+                bar_h_phys = max(1, round(bar_h * ratio))
+                y_phys = (h_phys - bar_h_phys) // 2 if mirror else h_phys - bar_h_phys
+                if faded:
+                    lp.setOpacity(opacities[i])
+                x_phys = start_phys + i * step_phys
+                lp.fillRect(QRect(x_phys, y_phys, bar_w_phys, bar_h_phys), brush)
+
+        layer.setDevicePixelRatio(ratio)
+        painter.drawPixmap(0, 0, layer)
+
+    def _paint_dots(self, painter: QPainter) -> None:
+        size = self.item_width
+        pitch = size + self.item_gap
+        h = self.height()
+        slots = max(1, (h - size) // pitch + 1) if pitch > 0 else 1
+        xs, opacities, palette = self._columns(len(self.samples))
+        faded = self.faded
+        mirror = self.mirror
+        ratio = self.devicePixelRatioF()
+
+        layer = self._masking_layer(ratio)
+        layer.setDevicePixelRatio(1.0)
+        layer.fill(Qt.GlobalColor.transparent)
+        n = len(self.samples)
+        size_phys = max(1, round(size * ratio))
+        step_phys = round((xs[1] - xs[0]) * ratio) if n > 1 else 0
+        start_phys = round(xs[0] * ratio) if n else 0
+        v_pitch_phys = max(1, round(pitch * ratio))
+        h_phys = layer.height()
+        with QPainter(layer) as lp:
+            lp.setPen(Qt.PenStyle.NoPen)
+            for i, sample in enumerate(self.samples):
+                sample = self._clamp_sample(sample)
+                lit = max(1, min(slots, round(sample * slots)))
+                if faded:
+                    lp.setOpacity(opacities[i])
+                x_phys = start_phys + i * step_phys
+                color = palette[i]
+                start = (slots - lit) // 2 if mirror else 0
+                for s in range(start, start + lit):
+                    y_phys = h_phys - size_phys - s * v_pitch_phys
+                    if y_phys < 0:
+                        break
+                    lp.fillRect(QRect(x_phys, y_phys, size_phys, size_phys), color)
+
+        layer.setDevicePixelRatio(ratio)
+        painter.drawPixmap(0, 0, layer)
+
+    def _paint_waves(self, painter: QPainter) -> None:
+        samples = self.samples
+        if len(samples) < 2:
+            return
+
+        w = float(self.width())
+        h = self.height()
+        brush = self._brush()
+
+        if self.stereo and len(samples) >= 4:
+            # The widget gives the left channel the larger half when the band
+            # count is odd (right_bands = n // 2), so split there, not at n // 2.
+            mid = len(samples) - len(samples) // 2
+            half = w / 2.0
+            path = self._wave_path(samples[:mid], 0.0, half, h)
+            path.addPath(self._wave_path(samples[mid:], half, w - half, h))
+        else:
+            path = self._wave_path(samples, 0.0, w, h)
+
+        if not self.faded:
+            painter.fillPath(path, brush)
+            return
+
+        # Fill once into a scratch layer and knock the edges out with a cached
+        # alpha ramp. Masking per column would cost one full path fill per pixel
+        # of width.
+        layer = self._masking_layer(self.devicePixelRatioF())
+        layer.fill(Qt.GlobalColor.transparent)
+        with QPainter(layer) as mask_painter:
+            mask_painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+            mask_painter.fillPath(path, brush)
+            mask_painter.setCompositionMode(QPainter.CompositionMode.CompositionMode_DestinationIn)
+            mask_painter.fillRect(0, 0, self.width(), h, self._fade_gradient())
+        painter.drawPixmap(0, 0, layer)
+
+    def _wave_path(self, samples: list[float], x0: float, width: float, height: int) -> QPainterPath:
+        path = QPainterPath()
+        if not samples:
+            return path
+
+        mirror = self.mirror
+        centre = height / 2.0
+
+        def edges(sample: float) -> tuple[float, float]:
+            """(top, bottom) y for one sample: floor-anchored, or split around centre."""
+            bar_h = max(1, min(height, round(self._clamp_sample(sample) * height)))
+            if mirror:
+                half = bar_h / 2.0
+                return centre - half, centre + half
+            return float(height - bar_h), float(height)
+
+        n = len(samples)
+        step = width / max(1, n)
+        xs = [x0 + i * step + step / 2.0 for i in range(n)]
+        tops = [edges(s)[0] for s in samples]
+
+        top0, bottom0 = edges(samples[0])
+        path.moveTo(x0, bottom0)
+        path.lineTo(x0, top0)
+        self._curve_through(path, xs, tops)
+
+        top_last, bottom_last = edges(samples[-1])
+        path.lineTo(x0 + width, top_last)
+        path.lineTo(x0 + width, bottom_last)
+        if mirror:
+            # Floor-anchored waves close along the flat bottom edge for free
+            # (closeSubpath draws straight back to (x0, height)); a mirrored
+            # wave needs that bottom edge traced back the same way the top was.
+            bottoms = [edges(s)[1] for s in samples]
+            self._curve_through(path, list(reversed(xs)), list(reversed(bottoms)))
+        path.closeSubpath()
+        return path
+
+    @staticmethod
+    def _curve_through(path: QPainterPath, xs: list[float], ys: list[float]) -> None:
+        n = len(xs)
+        path.lineTo(xs[0], ys[0])
+        for i in range(1, n):
+            mid_x = (xs[i - 1] + xs[i]) / 2.0
+            mid_y = (ys[i - 1] + ys[i]) / 2.0
+            path.quadTo(xs[i - 1], ys[i - 1], mid_x, mid_y)
+        path.lineTo(xs[-1], ys[-1])

--- a/src/core/widgets/services/audio_visualizer/paint.py
+++ b/src/core/widgets/services/audio_visualizer/paint.py
@@ -7,8 +7,8 @@ frame costs no more than the fills it actually needs.
 
 import logging
 
-from PyQt6.QtCore import QRect, Qt
-from PyQt6.QtGui import QColor, QLinearGradient, QPainter, QPainterPath, QPixmap
+from PyQt6.QtCore import QRect, Qt, pyqtProperty
+from PyQt6.QtGui import QBrush, QColor, QLinearGradient, QPainter, QPainterPath, QPixmap
 from PyQt6.QtWidgets import QFrame
 
 
@@ -24,30 +24,27 @@ class AudioVizCanvas(QFrame):
         canvas_width: int,
         item_width: int,
         item_gap: int,
-        gradient: bool,
         mirror: bool,
         stereo: bool,
-        colors: list[QColor],
         edge_fade_left: int,
         edge_fade_right: int,
         parent=None,
     ) -> None:
         super().__init__(parent)
+        self.setProperty("class", "audio-visualizer-canvas")
         self.style_name = style
         self.item_width = max(1, item_width)
         self.item_gap = max(0, item_gap)
-        self.gradient = gradient
         self.mirror = mirror
         self.stereo = stereo
-        self.colors = colors
         self.edge_fade_left = max(0, edge_fade_left)
         self.edge_fade_right = max(0, edge_fade_right)
         self.faded = bool(self.edge_fade_left or self.edge_fade_right)
         self.samples: list[float] = [0.0] * columns
-
+        self._fill: QBrush = QBrush(QColor("white"))
         self._paint_failed = False
-        self._brush_cache: QColor | QLinearGradient | None = None
-        self._column_cache: dict[int, tuple[list[int], list[float], list[QColor]]] = {}
+        self._column_cache: dict[int, tuple[list[int], list[float]]] = {}
+        self._surface_brush_cache: tuple[tuple[int, int], QBrush] | None = None
         self._fade_mask: QLinearGradient | None = None
         self._layer: QPixmap | None = None
         self._layer_key: tuple[int, int, float] | None = None
@@ -56,6 +53,16 @@ class AudioVizCanvas(QFrame):
         self.setLineWidth(0)
         self.setContentsMargins(0, 0, 0, 0)
         self.setFixedSize(max(8, canvas_width), max(4, height))
+
+    @pyqtProperty(QBrush)
+    def fillbrush(self) -> QBrush:
+        return self._fill
+
+    @fillbrush.setter
+    def fillbrush(self, brush: QBrush) -> None:
+        self._fill = QBrush(brush)
+        self._surface_brush_cache = None
+        self.update()
 
     def set_samples(self, samples: list[float]) -> None:
         if samples == self.samples:
@@ -84,8 +91,8 @@ class AudioVizCanvas(QFrame):
                 self._paint_failed = True
                 logging.warning("Audio visualizer paint failed; suppressing further paint errors", exc_info=True)
 
-    def _columns(self, count: int) -> tuple[list[int], list[float], list[QColor]]:
-        """Left edge, edge-fade opacity and colour for each column."""
+    def _columns(self, count: int) -> tuple[list[int], list[float]]:
+        """Left edge and edge-fade opacity for each column."""
         cached = self._column_cache.get(count)
         if cached is not None:
             return cached
@@ -103,23 +110,31 @@ class AudioVizCanvas(QFrame):
 
         centre = self.item_width / 2.0
         opacities = [self._fade_at(x + centre, width) for x in xs]
-        palette = [self.colors[i % len(self.colors)] for i in range(count)]
-        result = (xs, opacities, palette)
+        result = (xs, opacities)
         self._column_cache[count] = result
         return result
 
-    def _brush(self) -> QColor | QLinearGradient:
-        if self._brush_cache is None:
-            if self.gradient and len(self.colors) > 1:
-                gradient = QLinearGradient(0, 1, 0, 0)
-                gradient.setCoordinateMode(QLinearGradient.CoordinateMode.ObjectBoundingMode)
-                step = 1.0 / (len(self.colors) - 1)
-                for i, color in enumerate(self.colors):
-                    gradient.setColorAt(i * step, color)
-                self._brush_cache = gradient
-            else:
-                self._brush_cache = self.colors[0]
-        return self._brush_cache
+    def _surface_brush(self, width: float, height: float) -> QBrush:
+        """fillbrush with its gradient anchored to the whole surface, not each shape."""
+        gradient = self._fill.gradient()
+        if gradient is None or not isinstance(gradient, QLinearGradient):
+            return self._fill
+        if gradient.coordinateMode() != QLinearGradient.CoordinateMode.ObjectBoundingMode:
+            return self._fill
+
+        key = (round(width), round(height))
+        cached = self._surface_brush_cache
+        if cached is not None and cached[0] == key:
+            return cached[1]
+
+        start = gradient.start()
+        end = gradient.finalStop()
+        anchored = QLinearGradient(start.x() * width, start.y() * height, end.x() * width, end.y() * height)
+        for pos, colour in gradient.stops():
+            anchored.setColorAt(pos, colour)
+        brush = QBrush(anchored)
+        self._surface_brush_cache = (key, brush)
+        return brush
 
     _FADE_STEPS = 16
 
@@ -195,9 +210,8 @@ class AudioVizCanvas(QFrame):
 
     def _paint_bars(self, painter: QPainter) -> None:
         h = self.height()
-        brush = self._brush()
         bar_w = self.item_width
-        xs, opacities, _ = self._columns(len(self.samples))
+        xs, opacities = self._columns(len(self.samples))
         faded = self.faded
         mirror = self.mirror
         ratio = self.devicePixelRatioF()
@@ -212,6 +226,7 @@ class AudioVizCanvas(QFrame):
         layer = self._masking_layer(ratio)
         layer.setDevicePixelRatio(1.0)
         layer.fill(Qt.GlobalColor.transparent)
+        brush = self._surface_brush(layer.width(), layer.height())
         n = len(self.samples)
         bar_w_phys = max(1, round(bar_w * ratio))
         step_phys = round((xs[1] - xs[0]) * ratio) if n > 1 else 0
@@ -236,7 +251,7 @@ class AudioVizCanvas(QFrame):
         pitch = size + self.item_gap
         h = self.height()
         slots = max(1, (h - size) // pitch + 1) if pitch > 0 else 1
-        xs, opacities, palette = self._columns(len(self.samples))
+        xs, opacities = self._columns(len(self.samples))
         faded = self.faded
         mirror = self.mirror
         ratio = self.devicePixelRatioF()
@@ -244,6 +259,7 @@ class AudioVizCanvas(QFrame):
         layer = self._masking_layer(ratio)
         layer.setDevicePixelRatio(1.0)
         layer.fill(Qt.GlobalColor.transparent)
+        brush = self._surface_brush(layer.width(), layer.height())
         n = len(self.samples)
         size_phys = max(1, round(size * ratio))
         step_phys = round((xs[1] - xs[0]) * ratio) if n > 1 else 0
@@ -258,13 +274,12 @@ class AudioVizCanvas(QFrame):
                 if faded:
                     lp.setOpacity(opacities[i])
                 x_phys = start_phys + i * step_phys
-                color = palette[i]
                 start = (slots - lit) // 2 if mirror else 0
                 for s in range(start, start + lit):
                     y_phys = h_phys - size_phys - s * v_pitch_phys
                     if y_phys < 0:
                         break
-                    lp.fillRect(QRect(x_phys, y_phys, size_phys, size_phys), color)
+                    lp.fillRect(QRect(x_phys, y_phys, size_phys, size_phys), brush)
 
         layer.setDevicePixelRatio(ratio)
         painter.drawPixmap(0, 0, layer)
@@ -276,7 +291,7 @@ class AudioVizCanvas(QFrame):
 
         w = float(self.width())
         h = self.height()
-        brush = self._brush()
+        brush = self._surface_brush(w, h)
 
         if self.stereo and len(samples) >= 4:
             # The widget gives the left channel the larger half when the band

--- a/src/core/widgets/services/audio_visualizer/spectrum.py
+++ b/src/core/widgets/services/audio_visualizer/spectrum.py
@@ -1,0 +1,373 @@
+"""Spectrum analysis and band layout for the audio visualizer.
+
+SpectrumSource turns a PCM window into a magnitude spectrum and is shared by
+every widget on the same channel. SpectrumAnalyzer maps that spectrum onto
+log-spaced bands and smooths them, one instance per widget since band count,
+frequency range and smoothing are all configurable.
+"""
+
+import cmath
+import math
+
+FFT_SIZE = 512
+
+# Below this a band is treated as fully silent and snapped to zero, so a
+# fade-out terminates in finite time instead of approaching zero forever.
+_SILENCE_EPSILON = 1e-3
+
+# Smoothing is defined as a per-frame rate at this reference framerate and then
+# converted to a time constant, so the motion looks the same at any framerate
+# while still matching the rates the visualizer was originally tuned around.
+_REFERENCE_FPS = 60.0
+
+# Guard rails for the frame delta, so a long pause cannot produce a wild jump.
+_MIN_DT = 1.0 / 240.0
+_MAX_DT = 0.25
+
+# Per-band equalizer shape: a cutoff^0.85 tilt that lifts the highs, divided
+# by the band's bin count to average it.
+#
+# _EQ_SCALE sets the starting overall level. With auto_gain off it's the only
+# level control, chosen so sensitivity 50 gives a usable level at the default
+# band count. With auto_gain on, autosens only trims gain down on clipping and
+# creeps it up slowly otherwise, so it can absorb a moderate mismatch but not
+# an arbitrary one: too large a value still pins bands at the ceiling instead
+# of releveling.
+_EQ_SCALE = 0.18
+
+# Autosens per-second rates, scaled from a 66fps reference so they behave the
+# same at any real framerate. Drop fast when a band clips, creep up otherwise,
+# ramp hard until the first clip.
+_SENS_FALL = 0.02 * 66.0
+_SENS_RISE = 0.001 * 66.0
+_SENS_RISE_INIT = 0.1 * 66.0
+# Not clamped in normal use; this only guards a runaway on a pathologically
+# quiet feed.
+_SENS_MIN = 1e-4
+_SENS_MAX = 1e7
+
+_HALF_NEG_J = complex(0.0, -0.5)
+
+
+def layout_mono(samples: list[float], reverse: bool = False) -> list[float]:
+    """Mono display order.
+
+    reverse=False: left → right, low → high
+    reverse=True:  left → right, high → low
+    """
+    return list(reversed(samples)) if reverse else samples
+
+
+def layout_stereo(left: list[float], right: list[float], reverse: bool = False) -> list[float]:
+    """Join left and right bands into one row.
+
+    Left half = left channel, right half = right channel.
+    reverse=False: bass in the center  (highs…bass | bass…highs)
+    reverse=True:  bass on the edges   (bass…highs | highs…bass)
+    """
+    if reverse:
+        return left + list(reversed(right))
+    return list(reversed(left)) + right
+
+
+def _rate_to_tau(rate_per_frame: float) -> float:
+    """Convert a per-frame smoothing rate at the reference framerate to seconds."""
+    rate = max(1e-4, min(0.999, rate_per_frame))
+    return -(1.0 / _REFERENCE_FPS) / math.log(1.0 - rate)
+
+
+def _hann_window(n: int) -> list[float]:
+    if n <= 1:
+        return [1.0] * n
+    return [0.5 - 0.5 * math.cos(2.0 * math.pi * i / (n - 1)) for i in range(n)]
+
+
+def _bit_reversal(m: int) -> list[int]:
+    bits = m.bit_length() - 1
+    rev = [0] * m
+    for i in range(m):
+        r = 0
+        v = i
+        for _ in range(bits):
+            r = (r << 1) | (v & 1)
+            v >>= 1
+        rev[i] = r
+    return rev
+
+
+def _twiddle_stages(m: int) -> list[list[complex]]:
+    stages: list[list[complex]] = []
+    length = 2
+    while length <= m:
+        half = length >> 1
+        stages.append([cmath.exp(complex(0.0, -2.0 * math.pi * j / length)) for j in range(half)])
+        length <<= 1
+    return stages
+
+
+class SpectrumSource:
+    """Windowed magnitude spectrum of a real signal.
+
+    A real N-point transform is computed as a complex N/2-point transform plus
+    an untangling pass, with every twiddle factor precomputed. That is about
+    2.2x faster than transforming the real signal as if it were complex, and it
+    avoids the numerical drift of accumulating twiddles by repeated multiply.
+    """
+
+    def __init__(self, fft_size: int = FFT_SIZE) -> None:
+        if fft_size < 4 or fft_size & (fft_size - 1):
+            raise ValueError("FFT size must be a power of two >= 4")
+        self.fft_size = fft_size
+        self.bins = fft_size // 2
+        self._window = _hann_window(fft_size)
+        self._reversal = _bit_reversal(self.bins)
+        self._stages = _twiddle_stages(self.bins)
+        self._untangle = [cmath.exp(complex(0.0, -2.0 * math.pi * k / fft_size)) for k in range(self.bins)]
+        self._inv_size = 1.0 / fft_size
+
+    def magnitudes(self, samples: list[float]) -> list[float]:
+        """One-sided magnitude spectrum of the newest ``fft_size`` samples."""
+        n = self.fft_size
+        # Always analyse the newest window; a longer input must be trimmed from
+        # the front, never truncated to its oldest n samples.
+        if len(samples) > n:
+            samples = samples[-n:]
+        elif len(samples) < n:
+            samples = [0.0] * (n - len(samples)) + samples
+
+        window = self._window
+        m = self.bins
+        # Window and pack pairs of real samples into one complex sequence in a
+        # single pass.
+        packed = [complex(samples[2 * i] * window[2 * i], samples[2 * i + 1] * window[2 * i + 1]) for i in range(m)]
+        spectrum = self._transform(packed)
+
+        untangle = self._untangle
+        inv = self._inv_size
+        mags = [0.0] * m
+        for k in range(m):
+            head = spectrum[k]
+            tail = spectrum[m - k if k else 0].conjugate()
+            even = (head + tail) * 0.5
+            odd = (head - tail) * _HALF_NEG_J
+            mags[k] = abs(even + untangle[k] * odd) * inv
+        return mags
+
+    def _transform(self, values: list[complex]) -> list[complex]:
+        """Iterative radix-2 FFT over a precomputed twiddle table."""
+        m = self.bins
+        reversal = self._reversal
+        out = [values[reversal[i]] for i in range(m)]
+        length = 2
+        stage = 0
+        while length <= m:
+            table = self._stages[stage]
+            half = length >> 1
+            for start in range(0, m, length):
+                for k in range(half):
+                    i = start + k
+                    j = i + half
+                    u = out[i]
+                    v = out[j] * table[k]
+                    out[i] = u + v
+                    out[j] = u - v
+            length <<= 1
+            stage += 1
+        return out
+
+
+class SpectrumAnalyzer:
+    """Log-spaced bands with attack/decay smoothing, from a magnitude spectrum."""
+
+    def __init__(
+        self,
+        bands: int = 24,
+        fft_size: int = FFT_SIZE,
+        sample_rate: int = 48000,
+        f_min: float = 50.0,
+        f_max: float = 12000.0,
+        sensitivity: float = 1.0,
+        smoothness: float = 0.55,
+        auto_gain: bool = False,
+    ) -> None:
+        self.fft_size = fft_size
+        self.sample_rate = sample_rate
+        self.f_min = f_min
+        self.f_max = f_max
+        self.auto_gain = auto_gain
+        self.attack_tau = _rate_to_tau(0.45)
+        self.decay_tau = _rate_to_tau(0.18)
+        self.bands = 0
+        self._smooth: list[float] = []
+        self._band_bins: list[tuple[int, int]] = []
+        self._band_eq: list[float] = []
+        # Autosens state: a global gain the loop tunes so the loudest band
+        # sits near the top. _sens_init drives the fast startup ramp until the
+        # first clip, then stays off.
+        self._sens = 1.0
+        self._sens_init = True
+        self._alpha_key = -1
+        self._attack_alpha = 0.5
+        self._decay_alpha = 0.2
+        self.set_bands(bands)
+        self.set_sensitivity(sensitivity)
+        self.set_smoothness(smoothness)
+
+    def set_sample_rate(self, sample_rate: int) -> None:
+        if sample_rate <= 0 or sample_rate == self.sample_rate:
+            return
+        self.sample_rate = sample_rate
+        self._rebuild_bands()
+
+    def set_bands(self, bands: int) -> None:
+        bands = max(2, min(128, bands))
+        if bands == self.bands:
+            return
+        self.bands = bands
+        self._smooth = [0.0] * bands
+        self._rebuild_bands()
+
+    def set_sensitivity(self, value: float) -> None:
+        self.sensitivity = max(0.1, min(2.0, value))
+
+    def set_smoothness(self, value: float) -> None:
+        """0 = snappy, 1 = very smooth."""
+        t = max(0.0, min(1.0, value))
+        self.attack_tau = _rate_to_tau(0.70 - t * 0.45)
+        self.decay_tau = _rate_to_tau(0.32 - t * 0.26)
+        self._alpha_key = -1
+
+    def reset(self) -> None:
+        """Snap every band to silence."""
+        self._smooth = [0.0] * self.bands
+
+    def _resolve_alphas(self, dt: float) -> tuple[float, float]:
+        """Per-frame smoothing factors for a real elapsed time.
+
+        Deriving these from ``dt`` rather than assuming a fixed frame rate is
+        what makes ``smoothness`` mean the same thing at any framerate.
+        """
+        dt = min(_MAX_DT, max(_MIN_DT, dt))
+        key = int(dt * 1000.0)
+        if key != self._alpha_key:
+            self._alpha_key = key
+            self._attack_alpha = 1.0 - math.exp(-dt / self.attack_tau)
+            self._decay_alpha = 1.0 - math.exp(-dt / self.decay_tau)
+        return self._attack_alpha, self._decay_alpha
+
+    def decay(self, dt: float) -> tuple[list[float], bool]:
+        """Advance the envelope one frame toward silence, without a transform.
+
+        Equivalent to feeding a frame of zeros through :meth:`map_bands` but far
+        cheaper, which matters because this drives the whole fade-out after the
+        stream ends. Returns the bands and whether any is still moving.
+        """
+        keep = 1.0 - self._resolve_alphas(dt)[1]
+        smooth = self._smooth
+        moving = False
+        for i, previous in enumerate(smooth):
+            value = previous * keep
+            if value <= _SILENCE_EPSILON:
+                smooth[i] = 0.0
+            else:
+                smooth[i] = value
+                moving = True
+        return [v if v < 1.0 else 1.0 for v in smooth], moving
+
+    def map_bands(self, magnitudes: list[float], dt: float) -> list[float]:
+        """Fold a magnitude spectrum into smoothed bands."""
+        attack, decay = self._resolve_alphas(dt)
+        gain = self.sensitivity * self._sens
+        smooth = self._smooth
+        peak = 0.0
+        for band, (start, end) in enumerate(self._band_bins):
+            # Empty bands are stored as (0, 0): the slice is [] and eq is 0, so
+            # value is 0 and the band simply decays to rest.
+            value = sum(magnitudes[start:end]) * self._band_eq[band] * gain
+            previous = smooth[band]
+            alpha = attack if value > previous else decay
+            # Keep the envelope unclamped so the autosens loop reacts to a
+            # sustained overshoot, not a one-frame transient. A generous
+            # ceiling still bounds a runaway.
+            s = previous + (value - previous) * alpha
+            smooth[band] = s if s < 4.0 else 4.0
+            if smooth[band] > peak:
+                peak = smooth[band]
+
+        if self.auto_gain:
+            # Feed autosens the envelope with `sensitivity` divided back out, so
+            # the loop always levels to the same target and `sensitivity` stays a
+            # real trim on top: > 1 rides the bars into the ceiling, < 1 leaves
+            # headroom. Otherwise autosens just cancels every sensitivity change.
+            self._adapt_sens(peak / self.sensitivity, dt)
+        return [v if v < 1.0 else 1.0 for v in smooth]
+
+    def _adapt_sens(self, peak: float, dt: float) -> None:
+        """Auto-sensitivity loop.
+
+        ``peak`` is the loudest band before the 0..1 clamp. A value over 1
+        means some band clipped, so drop the global gain quickly; otherwise
+        creep it up, with a hard ramp until the first clip so the level finds
+        itself in a fraction of a second.
+        """
+        dt = min(_MAX_DT, max(_MIN_DT, dt))
+        if peak > 1.0:
+            self._sens *= math.exp(-_SENS_FALL * dt)
+            self._sens_init = False
+        else:
+            self._sens *= math.exp(_SENS_RISE * dt)
+            if self._sens_init:
+                self._sens *= math.exp(_SENS_RISE_INIT * dt)
+        self._sens = min(_SENS_MAX, max(_SENS_MIN, self._sens))
+
+    def _rebuild_bands(self) -> None:
+        """Log-spaced band cutoffs, pushed apart when bins clump; extras stay empty."""
+        half = self.fft_size // 2
+        rate = float(self.sample_rate)
+        nyquist = rate / 2.0
+        lower = max(1.0, self.f_min)
+        # Clamp so upper stays above lower even at a nonsensical sample rate;
+        # otherwise the log10(lower / upper) below can hit a math domain error.
+        upper = max(lower + 1.0, min(nyquist - 1.0, self.f_max))
+        n_bars = self.bands
+
+        # Logarithmic cutoff frequencies, low to high.
+        freq_const = math.log10(lower / upper) / (1.0 / (n_bars + 1) - 1.0)
+        cutoffs = [0.0] * (n_bars + 1)
+        for n in range(n_bars + 1):
+            coeff = freq_const * (-1.0) + (n + 1) / (n_bars + 1) * freq_const
+            cutoffs[n] = upper * (10.0**coeff)
+            if n > 0 and cutoffs[n - 1] >= cutoffs[n]:
+                cutoffs[n] = cutoffs[n - 1] + rate / self.fft_size
+
+        lowers = [0] * (n_bars + 1)
+        uppers = [0] * n_bars
+        for n in range(n_bars + 1):
+            bin_i = int(cutoffs[n] / nyquist * half)
+            # Bin 0 is DC: including it would light the first bar from any
+            # constant offset in the stream.
+            lowers[n] = max(1, min(half, bin_i))
+
+        for n in range(1, n_bars + 1):
+            if lowers[n] <= lowers[n - 1] and lowers[n - 1] + 1 <= half:
+                lowers[n] = lowers[n - 1] + 1
+            if n > 0:
+                uppers[n - 1] = max(lowers[n - 1], lowers[n] - 1)
+
+        bins: list[tuple[int, int]] = []
+        eq: list[float] = []
+        for n in range(n_bars):
+            start = lowers[n]
+            end = uppers[n] + 1
+            if end <= start or start >= half:
+                bins.append((0, 0))
+                eq.append(0.0)
+                continue
+            bins.append((start, end))
+            # A cutoff^0.85 tilt, averaged over the band's bins. The overall
+            # level is set by _EQ_SCALE and then tracked dynamically by
+            # auto_gain / _adapt_sens.
+            eq.append((cutoffs[n + 1] ** 0.85) * _EQ_SCALE / (end - start))
+
+        self._band_bins = bins
+        self._band_eq = eq

--- a/src/core/widgets/yasb/audio_visualizer.py
+++ b/src/core/widgets/yasb/audio_visualizer.py
@@ -1,0 +1,333 @@
+"""Native YASB audio visualizer, event-driven WASAPI loopback capture."""
+
+import logging
+import time
+
+from PyQt6.QtCore import QEasingCurve, QPropertyAnimation, Qt, QTimer
+from PyQt6.QtGui import QColor, QHideEvent, QShowEvent
+
+from core.validation.widgets.yasb.audio_visualizer import DEFAULT_COLORS, AudioVisualizerConfig
+from core.widgets.base import BaseWidget
+from core.widgets.services.audio_visualizer.loopback import AudioVisualizerCaptureService
+from core.widgets.services.audio_visualizer.paint import AudioVizCanvas
+from core.widgets.services.audio_visualizer.spectrum import (
+    FFT_SIZE,
+    SpectrumAnalyzer,
+    layout_mono,
+    layout_stereo,
+)
+
+
+def _sensitivity_mult(value: int) -> float:
+    """Map config 0–100 (default 50 = 1.0*) to analyzer gain."""
+    return max(0.1, min(2.0, value / 50.0))
+
+
+def _wave_points(width: int) -> int:
+    return max(4, min(128, width // 5))
+
+
+def _resolve_edge_fade(edge_fade: int | list[int]) -> tuple[int, int]:
+    # The config validator guarantees a list here is exactly [left, right].
+    if isinstance(edge_fade, list):
+        return int(edge_fade[0]), int(edge_fade[1])
+    fade = int(edge_fade)
+    return fade, fade
+
+
+class _ReaderToken:
+    """A widget's claim on the shared capture stream.
+
+    Deliberately holds no reference to the widget, so it can be handed to the
+    ``destroyed`` signal without keeping the widget alive.
+
+    ``attach`` opens the claim (visible); ``set_visible`` follows the bar as it
+    hides and shows, and only ``detach`` (on widget destruction) drops it.
+    """
+
+    __slots__ = ("_service", "_framerate", "_channels", "_attached", "_visible")
+
+    def __init__(
+        self,
+        service: AudioVisualizerCaptureService,
+        framerate: int,
+        channels: frozenset[str],
+    ) -> None:
+        self._service = service
+        self._framerate = framerate
+        self._channels = channels
+        self._attached = False
+        self._visible = True
+
+    def attach(self) -> None:
+        if self._attached:
+            return
+        self._attached = True
+        self._visible = True
+        self._service.attach(self._framerate, self._channels)
+
+    def detach(self) -> None:
+        if not self._attached:
+            return
+        self._service.detach(self._framerate, self._channels, self._visible)
+        self._attached = False
+        self._visible = True
+
+    def set_visible(self, visible: bool) -> None:
+        if not self._attached or visible == self._visible:
+            return
+        self._visible = visible
+        self._service.set_reader_visible(visible)
+
+
+class AudioVisualizerWidget(BaseWidget):
+    validation_schema = AudioVisualizerConfig
+
+    def __init__(self, config: AudioVisualizerConfig) -> None:
+        super().__init__(class_name=f"audio-visualizer-widget {config.class_name}".strip())
+        self.config = config
+        self._stereo = config.channels == "stereo"
+        self._audio_active = False
+        self._idle_hidden = False
+        self._last_render_ns = 0
+        self._frame_interval_ns = 1_000_000_000 // max(1, config.framerate)
+
+        edge_left, edge_right = _resolve_edge_fade(config.edge_fade)
+
+        self._init_container()
+        colors = self._parse_colors(config.colors)
+        smoothness = config.smoothness / 100.0
+        sensitivity = _sensitivity_mult(config.sensitivity)
+
+        columns, canvas_width, item_width, item_gap = self._resolve_style_metrics(config)
+        if self._stereo:
+            right_bands = max(2, columns // 2)
+            left_bands = max(2, columns - right_bands)
+        else:
+            left_bands = right_bands = columns
+
+        def make_analyzer(bands: int) -> SpectrumAnalyzer:
+            return SpectrumAnalyzer(
+                bands=bands,
+                fft_size=FFT_SIZE,
+                f_min=float(config.freq_min),
+                f_max=float(config.freq_max),
+                sensitivity=sensitivity,
+                smoothness=smoothness,
+                auto_gain=config.auto_gain,
+            )
+
+        self._analyzer_l = make_analyzer(left_bands)
+        self._analyzer_r = make_analyzer(right_bands) if self._stereo else None
+
+        self._canvas = AudioVizCanvas(
+            style=config.style,
+            height=config.height,
+            columns=columns,
+            canvas_width=canvas_width,
+            item_width=item_width,
+            item_gap=item_gap,
+            gradient=config.gradient,
+            mirror=config.mirror,
+            stereo=self._stereo,
+            colors=colors,
+            edge_fade_left=edge_left,
+            edge_fade_right=edge_right,
+        )
+        self._widget_container_layout.setContentsMargins(0, 0, 0, 0)
+        self._widget_container_layout.setAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignHCenter)
+        self._widget_container_layout.addWidget(self._canvas)
+
+        self._expanded_width = self.sizeHint().width()
+        self._collapse_animation = QPropertyAnimation(self, b"maximumWidth", self)
+        self._collapse_animation.setDuration(150)
+        self._collapse_animation.setEasingCurve(QEasingCurve.Type.InOutQuad)
+
+        self.callback_left = config.callbacks.on_left
+        self.callback_middle = config.callbacks.on_middle
+        self.callback_right = config.callbacks.on_right
+
+        frame_ms = max(8, 1000 // max(1, config.framerate))
+        self._fade_timer = QTimer(self)
+        self._fade_timer.setTimerType(Qt.TimerType.CoarseTimer)
+        self._fade_timer.setInterval(frame_ms)
+        self._fade_timer.timeout.connect(self._on_fade_tick)
+
+        self._hide_timer = QTimer(self)
+        self._hide_timer.setSingleShot(True)
+        self._hide_timer.setTimerType(Qt.TimerType.CoarseTimer)
+        self._hide_timer.setInterval(config.hide_idle_after)
+        self._hide_timer.timeout.connect(self._hide_for_idle)
+
+        # Tell the shared service which spectra to compute for us: both for
+        # stereo, otherwise just the one the mono mix draws from.
+        channels = frozenset({"left", "right"}) if self._stereo else frozenset({config.mono_option})
+
+        self._service = AudioVisualizerCaptureService.instance()
+        self._token = _ReaderToken(self._service, config.framerate, channels)
+        token = self._token
+        self.destroyed.connect(lambda *_: token.detach())
+
+        self._service.frame_ready.connect(self._on_frame)
+        self._service.audio_stopped.connect(self._on_audio_stopped)
+        self._service.format_changed.connect(self._apply_sample_rate)
+        self._apply_sample_rate(self._service.sample_rate)
+
+        if config.hide_idle:
+            # Start collapsed so the bar never reserves space for a silent
+            # visualizer, but stay attached so the stream can wake us.
+            self._idle_hidden = True
+            self._apply_collapsed(True, animate=False)
+            self._token.attach()
+
+    def _apply_collapsed(self, collapsed: bool, *, animate: bool = True) -> None:
+        """Collapse to zero width rather than ``hide()``, eased so the bar
+        reflows smoothly instead of the widget popping in or out.
+
+        A hidden widget stops receiving show/hide events, so it cannot tell
+        when the bar itself is hidden and would keep the capture stream open
+        forever. A zero-width widget stays visually gone but still gets the
+        bar's show/hide events, so ``hideEvent`` can always release the stream.
+        """
+        target = 0 if collapsed else self._expanded_width
+        if not animate:
+            self._collapse_animation.stop()
+            self.setMinimumWidth(0)
+            self.setMaximumWidth(target)
+            self.updateGeometry()
+            return
+        current = self.width()
+        self._collapse_animation.stop()
+        self.setMinimumWidth(0)
+        self._collapse_animation.setStartValue(current)
+        self._collapse_animation.setEndValue(target)
+        self._collapse_animation.start()
+
+    @staticmethod
+    def _resolve_style_metrics(config: AudioVisualizerConfig) -> tuple[int, int, int, int]:
+        if config.style == "waves":
+            width = config.waves.width
+            return _wave_points(width), width, 1, 0
+        if config.style == "dots":
+            d = config.dots
+            return d.count, d.count * max(2, d.size + d.gap), d.size, d.gap
+        b = config.bars
+        return b.count, b.count * (b.width + b.gap), b.width, b.gap
+
+    @staticmethod
+    def _parse_colors(raw: list[str]) -> list[QColor]:
+        colors: list[QColor] = []
+        for hex_color in raw or DEFAULT_COLORS:
+            c = QColor(hex_color)
+            if c.isValid():
+                colors.append(c)
+            else:
+                logging.error("Invalid audio visualizer color: %s", hex_color)
+        return colors or [QColor(c) for c in DEFAULT_COLORS]
+
+    def _apply_sample_rate(self, sample_rate: int) -> None:
+        self._analyzer_l.set_sample_rate(sample_rate)
+        if self._analyzer_r is not None:
+            self._analyzer_r.set_sample_rate(sample_rate)
+
+    def showEvent(self, event: QShowEvent) -> None:
+        super().showEvent(event)
+        self._token.attach()
+        # Resume the shared stream. If the bar just blinked (auto-hide, a
+        # maximised window) it was only frozen, so this costs nothing.
+        self._token.set_visible(True)
+        if self._idle_hidden:
+            # The bar came back while we were idle-collapsed: stay collapsed
+            # and wait for audio to expand us again.
+            return
+        if not self._service.is_active:
+            self._reset_visual()
+            if self.config.hide_idle:
+                self._hide_timer.start()
+
+    def hideEvent(self, event: QHideEvent) -> None:
+        super().hideEvent(event)
+        # The idle collapse never calls hide(), so any hide event here means
+        # the bar, a monitor change or a minimise hid us. Freeze the shared
+        # stream (it stays open, so a re-show resumes instantly). _idle_hidden
+        # and the collapsed width are left as they are.
+        self._fade_timer.stop()
+        self._hide_timer.stop()
+        self._audio_active = False
+        self._reset_visual()
+        self._token.set_visible(False)
+
+    def _reset_visual(self) -> None:
+        self._analyzer_l.reset()
+        if self._analyzer_r is not None:
+            self._analyzer_r.reset()
+        self._canvas.reset()
+
+    def _on_frame(self) -> None:
+        if self._audio_active:
+            if time.monotonic_ns() - self._last_render_ns < self._frame_interval_ns:
+                return
+        else:
+            self._audio_active = True
+            self._fade_timer.stop()
+            self._hide_timer.stop()
+            if self._idle_hidden:
+                self._idle_hidden = False
+                self._apply_collapsed(False)
+        self._render()
+
+    def _frame_delta(self) -> float:
+        """Seconds since the last frame, so smoothing is framerate-independent."""
+        now = time.monotonic_ns()
+        previous = self._last_render_ns
+        self._last_render_ns = now
+        if not previous:
+            return 1.0 / max(1, self.config.framerate)
+        return (now - previous) / 1_000_000_000.0
+
+    def _render(self) -> None:
+        dt = self._frame_delta()
+        magnitudes = self._service.magnitudes
+        if self._stereo and self._analyzer_r is not None:
+            samples = layout_stereo(
+                self._analyzer_l.map_bands(magnitudes("left"), dt),
+                self._analyzer_r.map_bands(magnitudes("right"), dt),
+                self.config.reverse,
+            )
+        else:
+            bands = self._analyzer_l.map_bands(magnitudes(self.config.mono_option), dt)
+            samples = layout_mono(bands, self.config.reverse)
+        self._canvas.set_samples(samples)
+
+    def _on_audio_stopped(self) -> None:
+        if not self._audio_active:
+            return
+        self._audio_active = False
+        if self._idle_hidden:
+            return
+        # Walk the bars down to zero rather than leaving them frozen on the
+        # last captured frame. The timer stops itself once they settle.
+        self._fade_timer.start()
+        if self.config.hide_idle:
+            self._hide_timer.start()
+
+    def _on_fade_tick(self) -> None:
+        dt = self._frame_delta()
+        left, moving = self._analyzer_l.decay(dt)
+        if self._stereo and self._analyzer_r is not None:
+            right, moving_r = self._analyzer_r.decay(dt)
+            samples = layout_stereo(left, right, self.config.reverse)
+            moving = moving or moving_r
+        else:
+            samples = layout_mono(left, self.config.reverse)
+        self._canvas.set_samples(samples)
+        if not moving:
+            self._fade_timer.stop()
+
+    def _hide_for_idle(self) -> None:
+        if self._audio_active or self._idle_hidden:
+            return
+        self._fade_timer.stop()
+        self._reset_visual()
+        self._idle_hidden = True
+        self._apply_collapsed(True)

--- a/src/core/widgets/yasb/audio_visualizer.py
+++ b/src/core/widgets/yasb/audio_visualizer.py
@@ -1,12 +1,11 @@
 """Native YASB audio visualizer, event-driven WASAPI loopback capture."""
 
-import logging
 import time
 
 from PyQt6.QtCore import QEasingCurve, QPropertyAnimation, Qt, QTimer
-from PyQt6.QtGui import QColor, QHideEvent, QShowEvent
+from PyQt6.QtGui import QHideEvent, QShowEvent
 
-from core.validation.widgets.yasb.audio_visualizer import DEFAULT_COLORS, AudioVisualizerConfig
+from core.validation.widgets.yasb.audio_visualizer import AudioVisualizerConfig
 from core.widgets.base import BaseWidget
 from core.widgets.services.audio_visualizer.loopback import AudioVisualizerCaptureService
 from core.widgets.services.audio_visualizer.paint import AudioVizCanvas
@@ -95,7 +94,6 @@ class AudioVisualizerWidget(BaseWidget):
         edge_left, edge_right = _resolve_edge_fade(config.edge_fade)
 
         self._init_container()
-        colors = self._parse_colors(config.colors)
         smoothness = config.smoothness / 100.0
         sensitivity = _sensitivity_mult(config.sensitivity)
 
@@ -127,10 +125,8 @@ class AudioVisualizerWidget(BaseWidget):
             canvas_width=canvas_width,
             item_width=item_width,
             item_gap=item_gap,
-            gradient=config.gradient,
             mirror=config.mirror,
             stereo=self._stereo,
-            colors=colors,
             edge_fade_left=edge_left,
             edge_fade_right=edge_right,
         )
@@ -138,7 +134,6 @@ class AudioVisualizerWidget(BaseWidget):
         self._widget_container_layout.setAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignHCenter)
         self._widget_container_layout.addWidget(self._canvas)
 
-        self._expanded_width = self.sizeHint().width()
         self._collapse_animation = QPropertyAnimation(self, b"maximumWidth", self)
         self._collapse_animation.setDuration(150)
         self._collapse_animation.setEasingCurve(QEasingCurve.Type.InOutQuad)
@@ -189,7 +184,7 @@ class AudioVisualizerWidget(BaseWidget):
         forever. A zero-width widget stays visually gone but still gets the
         bar's show/hide events, so ``hideEvent`` can always release the stream.
         """
-        target = 0 if collapsed else self._expanded_width
+        target = 0 if collapsed else self.sizeHint().width()
         if not animate:
             self._collapse_animation.stop()
             self.setMinimumWidth(0)
@@ -213,17 +208,6 @@ class AudioVisualizerWidget(BaseWidget):
             return d.count, d.count * max(2, d.size + d.gap), d.size, d.gap
         b = config.bars
         return b.count, b.count * (b.width + b.gap), b.width, b.gap
-
-    @staticmethod
-    def _parse_colors(raw: list[str]) -> list[QColor]:
-        colors: list[QColor] = []
-        for hex_color in raw or DEFAULT_COLORS:
-            c = QColor(hex_color)
-            if c.isValid():
-                colors.append(c)
-            else:
-                logging.error("Invalid audio visualizer color: %s", hex_color)
-        return colors or [QColor(c) for c in DEFAULT_COLORS]
 
     def _apply_sample_rate(self, sample_rate: int) -> None:
         self._analyzer_l.set_sample_rate(sample_rate)


### PR DESCRIPTION
Bars/waves/dots spectrum styles with mirror, gradient, and edge-fade options, driven by an event-driven WASAPI loopback capture shared across every widget instance and monitor. Cava-inspired log-band frequency mapping with auto-gain leveling.