### PR TITLE
(feat): Allow Access to Inbuilt QPalette Color Roles

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -46,6 +46,7 @@ Valid options are:
 | `update_check`      | boolean  | `true`   | Enable automatic update check. This works only if the application is installed. |
 | `show_systray`      | boolean  | `true`   | Show or hide the YASB system tray icon. |
 | `system_colors`     | boolean  | `false`  | Enable automatic generation of CSS variables from Windows theme colors. |
+| `has_explicit_dark_mode` | boolean | `true` | Enable YASB to swtich to custom-defined `.dark` CSS classes when Windows is in Dark Mode | 
 | `tooltip`           | object   | [See below](#tooltip-configuration) | Global tooltip configuration. |
 | `komorebi`      | object  | [See below](#komorebi-settings-for-tray-menu)   | Komorebi configuration for tray menu. |
 | `glazewm`      | object  | [See below](#glazewm-settings-for-tray-menu)   | Glazewm configuration for tray menu. |

--- a/docs/Styling.md
+++ b/docs/Styling.md
@@ -284,8 +284,9 @@ Animations can't be added to sub-controls, for example `::item` or `::chunk` or 
 - `radial-gradient()`
 - `conic-gradient()`
 
-## Follow OS Theme
-YASB can follow the OS theme, if you have OS dark style YASB will add class `.dark` on the root element, if you want to have different light and dark themes you can use the following CSS to achieve this.
+## Explicit Light and Dark Theme
+YASB can have explicitly set styles for both light and dark mode. This is enabled by default, only disabled if you explicity set the ```has_explicit_dark_theme``` BarConfig property to ```false```.
+You can use the following CSS as a guide to achieve this:
 
 ```css
 .yasb-bar {
@@ -309,6 +310,33 @@ YASB can follow the OS theme, if you have OS dark style YASB will add class `.da
 }
 
 ```
+
+## Follow OS Color Mode and Accent Color
+YASB can also completely follow Windows in terms of Accent Color and Color Mode (Light/Dark).
+To achieve this, it is first recommended that you set `has_explicit_dark_theme` to `false`, since you're going to be letting Windows do all the driving when it comes to styling. As an extra bonus, if you set `Accent color` in Windows Personalization Settings to `Automatic`, you can also have YASB use the main accent color from your wallpaper without any custom scripting.
+From there, you can reference the QPalette ColorRole enum [here](https://doc.qt.io/qt-6/qpalette.html#ColorRole-enum), and use them in your CSS along with the inbuilt QSS function `palette()` to add colors to the bar.  Note that, when using the Color Roles with the `palette()` function, you must convert the `PascalCase` enum names with their `kebab-case` equivalent. For example, `Base` would be used like `palette(base)` and `WindowText` would be used like `palette(window-text)`. Please also note that some Color Roles are not set up properly (like AlternateBase, for example). A general rule of thumb is, if you try to use a Color Role, and the element you are styling becomes transparent, use a different Color Role.
+
+You can use the following CSS as a guide:
+
+```css
+.yasb-bar {
+	border: 1px solid palette(highlight);
+	background-color: palette(base);
+    color: palette(text);
+}
+
+.tooltip {
+	background-color: palette(tool-tip-base);
+	color: palette(tool-tip-text);
+	border-radius: 4px;
+	padding: 5px 12px;
+	font-size: 12px;
+	font-family: 'Segoe UI';
+	font-weight: 600;
+	margin-top: 4px;
+}
+```
+In this example, YASB would be light gray in Light Mode and dark gray in Dark Mode, and would have a border that is the color of the Accent Color in your Windows Personalization.
 
 ## Context Menu Styling
 Context menus can be styled using the `.context-menu` class. This allows you to customize the appearance of menus within YASB. 

--- a/docs/widgets/(Widget)-Wallpapers.md
+++ b/docs/widgets/(Widget)-Wallpapers.md
@@ -160,6 +160,16 @@ The gallery is not styled with CSS. Use `image_width`, `image_corner_radius` and
 
 If your stylesheet has `.wallpapers-gallery-window`, `.wallpapers-gallery-image` or `.wallpapers-gallery-buttons`, they no longer do anything and can be removed.
 
+# Using Windows Accent Color with Wallpapers
+You can have Windows automatically extract an Accent Color from your wallpaper, and then use it to automatically update the color of `YASB`. To achieve this, first go to Windows Settings > Personalization > Colors and set `Accent coloor` to `Automatic`. Then, use the `QSS` `palette()` function with the `highlight` Color Role like the following example:
+
+```css
+.yasb-bar {
+	border: 1px solid palette(highlight);
+	background-color: palette(base);
+}
+```
+
 # Using Pywal with Wallpapers
 You can use [pywal](https://github.com/eylles/pywal16) to change the colors of `YASB` by generating them from your wallpaper. You can also switch wallpapers directly with pywal.
 

--- a/schema.json
+++ b/schema.json
@@ -298,6 +298,11 @@
           "title": "Class Name",
           "type": "string"
         },
+	"has_explicit_dark_theme": {
+		"default": true,
+		"title": "Has Explicit Dark Theme",
+		"type": "boolean"
+	},
         "label_no_window": {
           "anyOf": [
             {
@@ -723,6 +728,11 @@
           "title": "Class Name",
           "type": "string"
         },
+	"has_explicit_dark_theme": {
+		"default": true,
+		"title": "Has Explicit Dark Theme",
+		"type": "boolean"
+	},
         "context_menu": {
           "default": true,
           "title": "Context Menu",

--- a/src/core/bar.py
+++ b/src/core/bar.py
@@ -103,7 +103,7 @@ class Bar(QWidget):
 
         try:
             self._os_theme_manager = OsThemeManager(self._bar_frame, self)
-            self._os_theme_manager.update_theme_class()
+            self._os_theme_manager.update_theme_class(self.config.has_explicit_dark_theme)
         except Exception as e:
             logging.error("Failed to initialize theme manager: %s", e)
             self._os_theme_manager = None
@@ -327,7 +327,7 @@ class Bar(QWidget):
     def changeEvent(self, event: QEvent) -> None:
         if event.type() == QEvent.Type.PaletteChange:
             if self._os_theme_manager:
-                self._os_theme_manager.update_theme_class()
+                self._os_theme_manager.update_theme_class(self.config.has_explicit_dark_theme)
         super().changeEvent(event)
 
     def eventFilter(self, obj, event):

--- a/src/core/bar_helper.py
+++ b/src/core/bar_helper.py
@@ -757,22 +757,22 @@ class OsThemeManager(QObject):
             logging.error("Failed to determine Windows theme: %s", e)
             return False
 
-    def update_theme_class(self):
+    def update_theme_class(self, has_explicit_dark_theme=True):
         """Update the theme class on the target widget"""
         if not self.target_widget:
             return
-
-        is_dark_theme = self.detect_os_theme()
-        if is_dark_theme != self._is_dark_theme:
-            class_property = self.target_widget.property("class")
-            if is_dark_theme:
-                class_property += " dark"
-            else:
-                class_property = class_property.replace(" dark", "")
-            self.target_widget.setProperty("class", class_property)
-            self._update_styles(self.target_widget)
-            self._is_dark_theme = is_dark_theme
-            GlobalState.set_dark(is_dark_theme)
+        if has_explicit_dark_theme:
+            is_dark_theme = self.detect_os_theme()
+            if is_dark_theme != self._is_dark_theme:
+                class_property = self.target_widget.property("class")
+                if is_dark_theme:
+                    class_property += " dark"
+                else:
+                    class_property = class_property.replace(" dark", "")
+                self.target_widget.setProperty("class", class_property)
+                self._is_dark_theme = is_dark_theme
+                GlobalState.set_dark(is_dark_theme)
+        self._update_styles(self.target_widget)
 
     def _update_styles(self, widget):
         """Update styles for widget and its children by unpolishing and re-polishing"""

--- a/src/core/setup/bar_config.py
+++ b/src/core/setup/bar_config.py
@@ -20,6 +20,7 @@ ROOT_BAR: dict = {
     "enabled": True,
     "screens": ["*"],
     "class_name": "yasb-bar",
+    "has_explicit_dark_theme": True,
     "alignment": {
         "position": "top",
         "align": "center",

--- a/src/core/validation/bar.py
+++ b/src/core/validation/bar.py
@@ -78,6 +78,7 @@ class BarConfig(CustomBaseModel):
     enabled: bool = True
     screens: list[str] = ["*"]
     class_name: str = "yasb-bar"
+    has_explicit_dark_theme: bool = True
     style: Literal["bar", "adaptive"] = "bar"
     style_adaptive_exclude: list[str] = []
     context_menu: bool = True


### PR DESCRIPTION
This PR allows YASB to use the in-built color roles from QPalette, letting users dynamically style their bar based on Dark/Light mode and Accent Color from Windows Settings > Personalization > Colors without any custom scripting or CSS importing.

Resolves #1096.